### PR TITLE
Fix Creem webhook failure status

### DIFF
--- a/src/app/api/billing/webhooks/creem/route.test.ts
+++ b/src/app/api/billing/webhooks/creem/route.test.ts
@@ -113,11 +113,11 @@ describe("Billing Webhooks Creem API", () => {
     it("should handle signature verification errors with 400 status", async () => {
       const mockSignature = "invalid-signature";
       const mockPayload = '{"event": "test"}';
+      const signatureError = new Error("Invalid signature.");
+      signatureError.name = "CreemWebhookSignatureError";
 
       mockHeadersList.get.mockReturnValue(mockSignature);
-      mockHandleWebhook.mockRejectedValue(
-        new Error("Invalid signature provided"),
-      );
+      mockHandleWebhook.mockRejectedValue(signatureError);
 
       const { POST } = await import("./route");
       const request = createMockRequest(mockPayload);
@@ -126,7 +126,7 @@ describe("Billing Webhooks Creem API", () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.error).toBe("Invalid signature provided");
+      expect(data.error).toBe("Invalid signature.");
     });
 
     it("should handle other webhook errors with 500 status", async () => {
@@ -273,15 +273,14 @@ describe("Billing Webhooks Creem API", () => {
       );
     });
 
-    it("should detect signature errors case-insensitively", async () => {
-      const mockSignature = "invalid-signature";
+    it("should return 500 when a non-signature error mentions signature", async () => {
+      const mockSignature = "valid-signature";
       const mockPayload = '{"event": "test"}';
 
       mockHeadersList.get.mockReturnValue(mockSignature);
 
-      // Test uppercase SIGNATURE in error message
       mockHandleWebhook.mockRejectedValue(
-        new Error("Invalid SIGNATURE provided"),
+        new Error("Database failed while saving signature metadata"),
       );
 
       const { POST } = await import("./route");
@@ -289,7 +288,7 @@ describe("Billing Webhooks Creem API", () => {
 
       const response = await POST(request);
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(500);
     });
 
     it("should return 500 for non-signature related errors", async () => {

--- a/src/app/api/billing/webhooks/creem/route.ts
+++ b/src/app/api/billing/webhooks/creem/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { billing } from "@/lib/billing";
 
+function isCreemSignatureError(error: unknown) {
+  return error instanceof Error && error.name === "CreemWebhookSignatureError";
+}
+
 export async function POST(request: NextRequest) {
   try {
     const payload = await request.text();
@@ -26,11 +30,7 @@ export async function POST(request: NextRequest) {
       error instanceof Error ? error.message : "Webhook processing failed";
     console.error(`[Creem Webhook Error]: ${message}`);
 
-    const status =
-      error instanceof Error &&
-      error.message.toLowerCase().includes("signature")
-        ? 400
-        : 500;
+    const status = isCreemSignatureError(error) ? 400 : 500;
 
     return NextResponse.json({ error: message }, { status });
   }

--- a/src/lib/billing/creem/provider.test.ts
+++ b/src/lib/billing/creem/provider.test.ts
@@ -542,12 +542,9 @@ describe("Creem Provider Implementation", () => {
         new Error("Webhook processing failed"),
       );
 
-      const result = await creemProvider.handleWebhook("payload", "signature");
-
-      expect(result).toEqual({
-        received: false,
-        message: "Webhook processing failed",
-      });
+      await expect(
+        creemProvider.handleWebhook("payload", "signature"),
+      ).rejects.toThrow("Webhook processing failed");
     });
 
     it("should handle webhook with no secret configured", async () => {
@@ -563,15 +560,9 @@ describe("Creem Provider Implementation", () => {
       jest.resetModules();
       const { default: providerWithoutSecret } = await import("./provider");
 
-      const result = await providerWithoutSecret.handleWebhook(
-        "payload",
-        "signature",
-      );
-
-      expect(result).toEqual({
-        received: false,
-        message: "Webhook secret not configured.",
-      });
+      await expect(
+        providerWithoutSecret.handleWebhook("payload", "signature"),
+      ).rejects.toThrow("Webhook secret not configured.");
     });
 
     it("should handle unknown webhook errors", async () => {
@@ -588,15 +579,9 @@ describe("Creem Provider Implementation", () => {
 
       mockHandleCreemWebhook.mockRejectedValue("String error");
 
-      const result = await providerWithSecret.handleWebhook(
-        "payload",
-        "signature",
-      );
-
-      expect(result).toEqual({
-        received: false,
-        message: "Webhook handling failed",
-      });
+      await expect(
+        providerWithSecret.handleWebhook("payload", "signature"),
+      ).rejects.toThrow("Webhook handling failed");
     });
   });
 });

--- a/src/lib/billing/creem/provider.ts
+++ b/src/lib/billing/creem/provider.ts
@@ -111,7 +111,7 @@ const creemProvider: PaymentProvider = {
   ): Promise<{ received: boolean; message?: string }> {
     if (!creemWebhookSecret) {
       console.error("Creem webhook secret is not configured.");
-      return { received: false, message: "Webhook secret not configured." };
+      throw new Error("Webhook secret not configured.");
     }
 
     try {
@@ -120,7 +120,10 @@ const creemProvider: PaymentProvider = {
       const message =
         error instanceof Error ? error.message : "Webhook handling failed";
       console.error(`[Creem Webhook Provider Error]: ${message}`);
-      return { received: false, message };
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error(message);
     }
   },
 };

--- a/src/lib/billing/creem/webhook.test.ts
+++ b/src/lib/billing/creem/webhook.test.ts
@@ -207,11 +207,12 @@ describe("Creem Webhook Handler", () => {
         object: { id: "checkout_123" },
       });
 
-      const { handleCreemWebhook } = await import("./webhook");
+      const { handleCreemWebhook, CreemWebhookSignatureError } =
+        await import("./webhook");
 
       await expect(
         handleCreemWebhook(payload, "invalid-signature"),
-      ).rejects.toThrow("Invalid signature.");
+      ).rejects.toThrow(CreemWebhookSignatureError);
     });
 
     it("should handle duplicate webhook events", async () => {
@@ -401,11 +402,12 @@ describe("Creem Webhook Handler", () => {
         object: { id: "checkout_123" },
       });
 
-      const { handleCreemWebhook } = await import("./webhook");
+      const { handleCreemWebhook, CreemWebhookSignatureError } =
+        await import("./webhook");
 
       await expect(
         handleCreemWebhook(payload, "invalid-signature"),
-      ).rejects.toThrow("Invalid signature.");
+      ).rejects.toThrow(CreemWebhookSignatureError);
     });
 
     // Note: Testing webhook secret configuration is complex due to module mocking
@@ -421,10 +423,11 @@ describe("Creem Webhook Handler", () => {
         object: { id: "checkout_123" },
       });
 
-      const { handleCreemWebhook } = await import("./webhook");
+      const { handleCreemWebhook, CreemWebhookSignatureError } =
+        await import("./webhook");
 
       await expect(handleCreemWebhook(payload, "signature")).rejects.toThrow(
-        "Invalid signature.",
+        CreemWebhookSignatureError,
       );
     });
 

--- a/src/lib/billing/creem/webhook.ts
+++ b/src/lib/billing/creem/webhook.ts
@@ -21,6 +21,13 @@ import { getProductTierByProductId } from "@/lib/config/products";
 
 // --- Helper functions and type guards (no changes here) ---
 
+export class CreemWebhookSignatureError extends Error {
+  constructor(message = "Invalid signature.") {
+    super(message);
+    this.name = "CreemWebhookSignatureError";
+  }
+}
+
 function getCustomerId(
   customerField: string | { id: string } | undefined,
 ): string {
@@ -78,7 +85,7 @@ export async function handleCreemWebhook(payload: string, signature: string) {
   const isValid = verifyCreemSignature(payload, signature, creemWebhookSecret);
   if (!isValid) {
     console.warn("Invalid webhook signature received.");
-    throw new Error("Invalid signature.");
+    throw new CreemWebhookSignatureError();
   }
 
   const event: CreemWebhookPayload = JSON.parse(payload);


### PR DESCRIPTION
## Summary
- add an explicit Creem webhook signature error and map only that error to HTTP 400
- rethrow Creem webhook provider failures so business/database errors return HTTP 500 and Creem can retry
- update route/provider/webhook tests for invalid signature, handler failures, and success paths

## Tests
- pnpm jest src/app/api/billing/webhooks/creem/route.test.ts src/lib/billing/creem/provider.test.ts src/lib/billing/creem/webhook.test.ts --runInBand
- pnpm lint
- pnpm type-check *(local workspace failed in unrelated unstaged e2e/helpers/auth.ts env typing change; not part of this branch commit)*