### PR TITLE
Harden upload validation flow

### DIFF
--- a/src/app/api/upload/complete/route.test.ts
+++ b/src/app/api/upload/complete/route.test.ts
@@ -30,9 +30,14 @@ jest.mock("@/lib/auth/server", () => ({
   },
 }));
 
-const mockFileExists = jest.fn() as any;
+const mockGetObjectMetadata = jest.fn() as any;
 jest.mock("@/lib/r2", () => ({
-  fileExists: mockFileExists,
+  getObjectMetadata: mockGetObjectMetadata,
+}));
+
+const mockCheckUploadRateLimit = jest.fn() as any;
+jest.mock("@/lib/upload-rate-limit", () => ({
+  checkUploadRateLimit: mockCheckUploadRateLimit,
 }));
 
 const mockSelectLimit = jest.fn().mockResolvedValue([]) as any;
@@ -82,6 +87,7 @@ jest.mock("@/lib/config/upload", () => ({
     MAX_FILE_SIZE: 10485760,
   },
   formatFileSize: mockFormatFileSize,
+  normalizeContentType: jest.fn((contentType: string) => contentType),
   uploadCompleteRequestSchema: mockUploadCompleteRequestSchema,
 }));
 
@@ -100,6 +106,13 @@ describe("Upload Complete API", () => {
     });
     mockDb.insert.mockReturnValue({
       values: mockInsertValues,
+    });
+    mockCheckUploadRateLimit.mockReturnValue({
+      allowed: true,
+      limit: 30,
+      remaining: 29,
+      resetAt: Date.now() + 60_000,
+      retryAfter: 0,
     });
   });
 
@@ -189,7 +202,7 @@ describe("Upload Complete API", () => {
     });
     mockIsFileTypeAllowed.mockReturnValue(true);
     mockIsFileSizeAllowed.mockReturnValue(true);
-    mockFileExists.mockResolvedValue(false);
+    mockGetObjectMetadata.mockResolvedValue(null);
 
     const { POST } = await import("./route");
     const response = await POST(createMockRequest(validRequestBody));
@@ -262,7 +275,10 @@ describe("Upload Complete API", () => {
     });
     mockIsFileTypeAllowed.mockReturnValue(true);
     mockIsFileSizeAllowed.mockReturnValue(true);
-    mockFileExists.mockResolvedValue(true);
+    mockGetObjectMetadata.mockResolvedValue({
+      contentLength: validRequestBody.size,
+      contentType: validRequestBody.contentType,
+    });
     const existingUpload = {
       fileKey: validRequestBody.key,
       url: validRequestBody.url,
@@ -306,7 +322,10 @@ describe("Upload Complete API", () => {
     });
     mockIsFileTypeAllowed.mockReturnValue(true);
     mockIsFileSizeAllowed.mockReturnValue(true);
-    mockFileExists.mockResolvedValue(true);
+    mockGetObjectMetadata.mockResolvedValue({
+      contentLength: validRequestBody.size,
+      contentType: validRequestBody.contentType,
+    });
 
     const { POST } = await import("./route");
     const response = await POST(createMockRequest(validRequestBody));
@@ -331,5 +350,53 @@ describe("Upload Complete API", () => {
       size: validRequestBody.size,
       contentType: validRequestBody.contentType,
     });
+  });
+
+  it("should reject when actual object size differs from the declared size", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockUploadCompleteRequestSchema.safeParse.mockReturnValue({
+      success: true,
+      data: validRequestBody,
+    });
+    mockIsFileTypeAllowed.mockReturnValue(true);
+    mockIsFileSizeAllowed.mockReturnValue(true);
+    mockGetObjectMetadata.mockResolvedValue({
+      contentLength: validRequestBody.size + 1,
+      contentType: validRequestBody.contentType,
+    });
+
+    const { POST } = await import("./route");
+    const response = await POST(createMockRequest(validRequestBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe(
+      "Uploaded object size does not match the declared size.",
+    );
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it("should reject when actual object content type differs from the declared type", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockUploadCompleteRequestSchema.safeParse.mockReturnValue({
+      success: true,
+      data: validRequestBody,
+    });
+    mockIsFileTypeAllowed.mockReturnValue(true);
+    mockIsFileSizeAllowed.mockReturnValue(true);
+    mockGetObjectMetadata.mockResolvedValue({
+      contentLength: validRequestBody.size,
+      contentType: "image/png",
+    });
+
+    const { POST } = await import("./route");
+    const response = await POST(createMockRequest(validRequestBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe(
+      "Uploaded object content type does not match the declared content type.",
+    );
+    expect(mockDb.insert).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/upload/complete/route.ts
+++ b/src/app/api/upload/complete/route.ts
@@ -7,17 +7,35 @@ import {
   formatFileSize,
   isFileSizeAllowed,
   isFileTypeAllowed,
+  normalizeContentType,
   UPLOAD_CONFIG,
   uploadCompleteRequestSchema,
 } from "@/lib/config/upload";
-import { fileExists } from "@/lib/r2";
+import { getObjectMetadata } from "@/lib/r2";
 import { getAuthSessionFromHeaders } from "@/lib/auth/session";
+import { checkUploadRateLimit } from "@/lib/upload-rate-limit";
 
 export async function POST(request: NextRequest) {
   try {
     const session = await getAuthSessionFromHeaders(request.headers);
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const rateLimit = checkUploadRateLimit(session.user.id);
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: "Too many upload requests. Please try again later." },
+        {
+          status: 429,
+          headers: {
+            "Retry-After": String(rateLimit.retryAfter),
+            "X-RateLimit-Limit": String(rateLimit.limit),
+            "X-RateLimit-Remaining": String(rateLimit.remaining),
+            "X-RateLimit-Reset": String(Math.ceil(rateLimit.resetAt / 1000)),
+          },
+        },
+      );
     }
 
     const body = await request.json();
@@ -33,9 +51,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { contentType, fileName, key, size, url } = validation.data;
+    const { fileName, key, size, url } = validation.data;
+    const contentType = normalizeContentType(validation.data.contentType);
     const keyPrefix = `uploads/${session.user.id}/`;
-    const expectedUrlPrefix = `${env.R2_PUBLIC_URL}/`;
+    const expectedUrl = `${env.R2_PUBLIC_URL}/${key}`;
 
     if (!key.startsWith(keyPrefix)) {
       return NextResponse.json(
@@ -44,7 +63,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!url.startsWith(expectedUrlPrefix) || !url.endsWith(key)) {
+    if (url !== expectedUrl) {
       return NextResponse.json(
         { error: "Upload URL does not match the stored object key." },
         { status: 400 },
@@ -67,11 +86,44 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const exists = await fileExists(key);
-    if (!exists) {
+    const metadata = await getObjectMetadata(key);
+    if (!metadata) {
       return NextResponse.json(
         { error: "Uploaded object could not be verified." },
         { status: 409 },
+      );
+    }
+
+    if (metadata.contentLength !== size) {
+      return NextResponse.json(
+        { error: "Uploaded object size does not match the declared size." },
+        { status: 400 },
+      );
+    }
+
+    if (metadata.contentType !== contentType) {
+      return NextResponse.json(
+        {
+          error:
+            "Uploaded object content type does not match the declared content type.",
+        },
+        { status: 400 },
+      );
+    }
+
+    if (!isFileTypeAllowed(metadata.contentType)) {
+      return NextResponse.json(
+        { error: `File type '${metadata.contentType}' is not allowed.` },
+        { status: 400 },
+      );
+    }
+
+    if (!isFileSizeAllowed(metadata.contentLength)) {
+      return NextResponse.json(
+        {
+          error: `File size of ${formatFileSize(metadata.contentLength)} exceeds the limit of ${formatFileSize(UPLOAD_CONFIG.MAX_FILE_SIZE)}.`,
+        },
+        { status: 400 },
       );
     }
 
@@ -96,19 +148,19 @@ export async function POST(request: NextRequest) {
     await db.insert(uploads).values({
       userId: session.user.id,
       fileKey: key,
-      url,
+      url: expectedUrl,
       fileName,
-      fileSize: size,
-      contentType,
+      fileSize: metadata.contentLength,
+      contentType: metadata.contentType,
     });
 
     return NextResponse.json({
       file: {
         key,
-        url,
+        url: expectedUrl,
         fileName,
-        size,
-        contentType,
+        size: metadata.contentLength,
+        contentType: metadata.contentType,
       },
     });
   } catch (error) {

--- a/src/app/api/upload/presigned-url/route.test.ts
+++ b/src/app/api/upload/presigned-url/route.test.ts
@@ -26,6 +26,11 @@ jest.mock("@/lib/r2", () => ({
   createPresignedUrl: mockCreatePresignedUrl,
 }));
 
+const mockCheckUploadRateLimit = jest.fn() as any;
+jest.mock("@/lib/upload-rate-limit", () => ({
+  checkUploadRateLimit: mockCheckUploadRateLimit,
+}));
+
 const mockIsFileTypeAllowed = jest.fn() as any;
 const mockIsFileSizeAllowed = jest.fn() as any;
 const mockFormatFileSize = jest.fn() as any;
@@ -40,12 +45,20 @@ jest.mock("@/lib/config/upload", () => ({
     MAX_FILE_SIZE: 10485760,
   },
   formatFileSize: mockFormatFileSize,
+  normalizeContentType: jest.fn((contentType: string) => contentType),
   presignedUrlRequestSchema: mockPresignedUrlRequestSchema,
 }));
 
 describe("Upload Presigned URL API", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCheckUploadRateLimit.mockReturnValue({
+      allowed: true,
+      limit: 30,
+      remaining: 29,
+      resetAt: Date.now() + 60_000,
+      retryAfter: 0,
+    });
   });
 
   const createMockRequest = (body: unknown): NextRequest =>

--- a/src/app/api/upload/presigned-url/route.ts
+++ b/src/app/api/upload/presigned-url/route.ts
@@ -5,19 +5,35 @@ import {
   isFileSizeAllowed,
   UPLOAD_CONFIG,
   formatFileSize,
-  presignedUrlRequestSchema, // 导入 Zod schema
+  presignedUrlRequestSchema,
+  normalizeContentType,
 } from "@/lib/config/upload";
 import { getAuthSessionFromHeaders } from "@/lib/auth/session";
+import { checkUploadRateLimit } from "@/lib/upload-rate-limit";
 
 export async function POST(request: NextRequest) {
   try {
-    // 1. 认证检查
     const session = await getAuthSessionFromHeaders(request.headers);
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // 2. 解析和验证请求体
+    const rateLimit = checkUploadRateLimit(session.user.id);
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: "Too many upload requests. Please try again later." },
+        {
+          status: 429,
+          headers: {
+            "Retry-After": String(rateLimit.retryAfter),
+            "X-RateLimit-Limit": String(rateLimit.limit),
+            "X-RateLimit-Remaining": String(rateLimit.remaining),
+            "X-RateLimit-Reset": String(Math.ceil(rateLimit.resetAt / 1000)),
+          },
+        },
+      );
+    }
+
     const body = await request.json();
     const validation = presignedUrlRequestSchema.safeParse(body);
 
@@ -31,9 +47,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { fileName, contentType, size } = validation.data;
+    const { fileName, size } = validation.data;
+    const contentType = normalizeContentType(validation.data.contentType);
 
-    // 3. 服务器端文件规则验证 (关键安全修复)
     if (!isFileTypeAllowed(contentType)) {
       return NextResponse.json(
         { error: `File type '${contentType}' is not allowed.` },
@@ -50,7 +66,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // 4. 创建预签名 URL
     const result = await createPresignedUrl({
       userId: session.user.id,
       fileName,
@@ -59,11 +74,9 @@ export async function POST(request: NextRequest) {
     });
 
     if (!result.success) {
-      // createPresignedUrl 内部已经包含了验证，但我们在这里再次捕获以防万一
       return NextResponse.json({ error: result.error }, { status: 400 });
     }
 
-    // 5. 返回预签名 URL 给客户端。上传完成后由单独的 complete 接口入库。
     return NextResponse.json({
       presignedUrl: result.presignedUrl,
       publicUrl: result.publicUrl,

--- a/src/app/api/upload/server-upload/route.test.ts
+++ b/src/app/api/upload/server-upload/route.test.ts
@@ -45,6 +45,11 @@ jest.mock("@/lib/auth/server", () => ({
   },
 }));
 
+const mockCheckUploadRateLimit = jest.fn() as any;
+jest.mock("@/lib/upload-rate-limit", () => ({
+  checkUploadRateLimit: mockCheckUploadRateLimit,
+}));
+
 // Mock AWS SDK
 const mockUpload = {
   done: jest.fn() as any,
@@ -77,26 +82,35 @@ jest.mock("crypto", () => ({
 
 // Mock env
 jest.mock("@/env", () => ({
-  R2_ENDPOINT: "https://r2.example.com",
-  R2_ACCESS_KEY_ID: "test-key",
-  R2_SECRET_ACCESS_KEY: "test-secret",
-  R2_BUCKET_NAME: "test-bucket",
-  R2_PUBLIC_URL: "https://cdn.example.com",
-  NEXT_PUBLIC_APP_URL: "https://app.example.com",
+  __esModule: true,
+  default: {
+    R2_ENDPOINT: "https://r2.example.com",
+    R2_ACCESS_KEY_ID: "test-key",
+    R2_SECRET_ACCESS_KEY: "test-secret",
+    R2_BUCKET_NAME: "test-bucket",
+    R2_PUBLIC_URL: "https://cdn.example.com",
+    NEXT_PUBLIC_APP_URL: "https://app.example.com",
+  },
 }));
 
 // Mock upload config
 const mockIsFileTypeAllowed = jest.fn() as any;
 const mockIsFileSizeAllowed = jest.fn() as any;
 const mockGetFileExtension = jest.fn() as any;
+const mockFormatFileSize = jest.fn() as any;
 
 jest.mock("@/lib/config/upload", () => ({
   UPLOAD_CONFIG: {
     MAX_FILE_SIZE: 10485760, // 10MB
+    MAX_SERVER_UPLOAD_FILES: 5,
+    MAX_SERVER_UPLOAD_TOTAL_SIZE: 20 * 1024 * 1024,
+    SERVER_UPLOAD_CONCURRENCY: 2,
   },
   isFileTypeAllowed: mockIsFileTypeAllowed,
   isFileSizeAllowed: mockIsFileSizeAllowed,
   getFileExtension: mockGetFileExtension,
+  formatFileSize: mockFormatFileSize,
+  normalizeContentType: jest.fn((contentType: string) => contentType),
 }));
 
 describe("Upload Server Upload API", () => {
@@ -104,6 +118,14 @@ describe("Upload Server Upload API", () => {
     jest.clearAllMocks();
     // Set default Date.now for consistent timestamps
     jest.spyOn(Date, "now").mockReturnValue(1640995200000); // 2022-01-01
+    mockCheckUploadRateLimit.mockReturnValue({
+      allowed: true,
+      limit: 30,
+      remaining: 29,
+      resetAt: Date.now() + 60_000,
+      retryAfter: 0,
+    });
+    mockFormatFileSize.mockImplementation((size: number) => `${size} bytes`);
   });
 
   afterEach(() => {
@@ -200,6 +222,59 @@ describe("Upload Server Upload API", () => {
 
       expect(response.status).toBe(400);
       expect(data.error).toBe("No files provided");
+    });
+
+    it("should reject requests with too many files", async () => {
+      mockGetSession.mockResolvedValue(mockSession);
+
+      const files = Array.from({ length: 6 }, (_, index) =>
+        createMockFile(`test-${index}.jpg`, "image/jpeg", 1024),
+      );
+      const mockFormData = {
+        getAll: jest.fn(() => files),
+      };
+
+      const { POST } = await import("./route");
+      const request = createMockRequest(
+        "multipart/form-data",
+        mockFormData as unknown as FormData,
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe(
+        "Too many files. Maximum 5 files are allowed per request.",
+      );
+      expect(mockUpload.done).not.toHaveBeenCalled();
+    });
+
+    it("should reject requests that exceed total upload size", async () => {
+      mockGetSession.mockResolvedValue(mockSession);
+
+      const files = [
+        createMockFile("large-1.jpg", "image/jpeg", 15 * 1024 * 1024),
+        createMockFile("large-2.jpg", "image/jpeg", 10 * 1024 * 1024),
+      ];
+      const mockFormData = {
+        getAll: jest.fn(() => files),
+      };
+
+      const { POST } = await import("./route");
+      const request = createMockRequest(
+        "multipart/form-data",
+        mockFormData as unknown as FormData,
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe(
+        "Total upload size of 26214400 bytes exceeds the per-request limit of 20971520 bytes.",
+      );
+      expect(mockUpload.done).not.toHaveBeenCalled();
     });
 
     it("should successfully upload single file", async () => {

--- a/src/app/api/upload/server-upload/route.ts
+++ b/src/app/api/upload/server-upload/route.ts
@@ -10,8 +10,11 @@ import {
   isFileTypeAllowed,
   isFileSizeAllowed,
   getFileExtension,
+  formatFileSize,
+  normalizeContentType,
 } from "@/lib/config/upload";
 import { getAuthSessionFromHeaders } from "@/lib/auth/session";
+import { checkUploadRateLimit } from "@/lib/upload-rate-limit";
 
 // Initialize S3 client for Cloudflare R2
 const r2Client = new S3Client({
@@ -23,12 +26,69 @@ const r2Client = new S3Client({
   },
 });
 
+type ServerUploadResult =
+  | {
+      fileName: string;
+      url: string;
+      key: string;
+      size: number;
+      contentType: string;
+      success: true;
+    }
+  | {
+      fileName: string;
+      success: false;
+      error: string;
+    };
+
+function isUploadFile(entry: FormDataEntryValue): entry is File {
+  return (
+    typeof entry === "object" &&
+    entry !== null &&
+    "name" in entry &&
+    "type" in entry &&
+    "size" in entry &&
+    "stream" in entry
+  );
+}
+
+async function processInBatches<T, R>(
+  items: T[],
+  batchSize: number,
+  task: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+
+  for (let index = 0; index < items.length; index += batchSize) {
+    const batch = items.slice(index, index + batchSize);
+    results.push(...(await Promise.all(batch.map(task))));
+  }
+
+  return results;
+}
+
 export async function POST(request: NextRequest) {
   try {
     // Check authentication
     const session = await getAuthSessionFromHeaders(request.headers);
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const rateLimit = checkUploadRateLimit(session.user.id);
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: "Too many upload requests. Please try again later." },
+        {
+          status: 429,
+          headers: {
+            "Retry-After": String(rateLimit.retryAfter),
+            "X-RateLimit-Limit": String(rateLimit.limit),
+            "X-RateLimit-Remaining": String(rateLimit.remaining),
+            "X-RateLimit-Reset": String(Math.ceil(rateLimit.resetAt / 1000)),
+          },
+        },
+      );
     }
 
     // Check if request is multipart/form-data
@@ -45,18 +105,50 @@ export async function POST(request: NextRequest) {
 
     // Parse multipart/form-data
     const formData = await request.formData();
-    const files = formData.getAll("files") as File[];
+    const fileEntries = formData.getAll("files");
+    const files = fileEntries.filter(isUploadFile);
 
-    if (!files || files.length === 0) {
+    if (fileEntries.length !== files.length) {
+      return NextResponse.json(
+        { error: "Invalid file entry in upload payload" },
+        { status: 400 },
+      );
+    }
+
+    if (files.length === 0) {
       return NextResponse.json({ error: "No files provided" }, { status: 400 });
     }
 
+    if (files.length > UPLOAD_CONFIG.MAX_SERVER_UPLOAD_FILES) {
+      return NextResponse.json(
+        {
+          error: `Too many files. Maximum ${UPLOAD_CONFIG.MAX_SERVER_UPLOAD_FILES} files are allowed per request.`,
+        },
+        { status: 400 },
+      );
+    }
+
+    const totalSize = files.reduce((sum, file) => sum + file.size, 0);
+    if (
+      !Number.isFinite(totalSize) ||
+      totalSize > UPLOAD_CONFIG.MAX_SERVER_UPLOAD_TOTAL_SIZE
+    ) {
+      return NextResponse.json(
+        {
+          error: `Total upload size of ${formatFileSize(totalSize)} exceeds the per-request limit of ${formatFileSize(UPLOAD_CONFIG.MAX_SERVER_UPLOAD_TOTAL_SIZE)}.`,
+        },
+        { status: 400 },
+      );
+    }
+
     // Function to process a single file
-    const processFile = async (file: File) => {
+    const processFile = async (file: File): Promise<ServerUploadResult> => {
       try {
+        const normalizedContentType = normalizeContentType(file.type);
+
         // Validate file type
-        if (!isFileTypeAllowed(file.type)) {
-          throw new Error(`File type ${file.type} is not allowed`);
+        if (!isFileTypeAllowed(normalizedContentType)) {
+          throw new Error(`File type ${normalizedContentType} is not allowed`);
         }
 
         // Validate file size
@@ -67,7 +159,7 @@ export async function POST(request: NextRequest) {
         }
 
         // Generate unique key for the file
-        const fileExtension = getFileExtension(file.type);
+        const fileExtension = getFileExtension(normalizedContentType);
         const timestamp = Date.now();
         const uuid = randomUUID();
         const key = `uploads/${session.user!.id}/${timestamp}-${uuid}.${fileExtension}`;
@@ -82,9 +174,10 @@ export async function POST(request: NextRequest) {
             Bucket: env.R2_BUCKET_NAME,
             Key: key,
             Body: fileStream,
-            ContentType: file.type,
+            ContentType: normalizedContentType,
             ContentLength: file.size,
           },
+          queueSize: 1,
         });
 
         // Execute the upload
@@ -100,7 +193,7 @@ export async function POST(request: NextRequest) {
           url: publicUrl,
           fileName: file.name,
           fileSize: file.size,
-          contentType: file.type,
+          contentType: normalizedContentType,
         });
 
         return {
@@ -108,7 +201,7 @@ export async function POST(request: NextRequest) {
           url: publicUrl,
           key: key,
           size: file.size,
-          contentType: file.type,
+          contentType: normalizedContentType,
           success: true,
         };
       } catch (error) {
@@ -121,9 +214,11 @@ export async function POST(request: NextRequest) {
       }
     };
 
-    // Process all files in parallel
-    const uploadPromises = files.map(processFile);
-    const uploadResults = await Promise.all(uploadPromises);
+    const uploadResults = await processInBatches(
+      files,
+      UPLOAD_CONFIG.SERVER_UPLOAD_CONCURRENCY,
+      processFile,
+    );
 
     const successCount = uploadResults.filter((r) => r.success).length;
     const failureCount = uploadResults.length - successCount;

--- a/src/lib/config/upload.test.ts
+++ b/src/lib/config/upload.test.ts
@@ -63,9 +63,19 @@ describe("Upload Configuration", () => {
       expect(isFileTypeAllowed("")).toBe(false);
     });
 
-    it("should be case sensitive", () => {
-      expect(isFileTypeAllowed("image/JPEG")).toBe(false);
-      expect(isFileTypeAllowed("IMAGE/JPEG")).toBe(false);
+    it("should reject active content types by default", () => {
+      expect(isFileTypeAllowed("image/svg+xml")).toBe(false);
+      expect(isFileTypeAllowed("text/html")).toBe(false);
+      expect(isFileTypeAllowed("text/javascript")).toBe(false);
+      expect(isFileTypeAllowed("application/javascript")).toBe(false);
+      expect(isFileTypeAllowed("application/xml")).toBe(false);
+      expect(isFileTypeAllowed("text/css")).toBe(false);
+    });
+
+    it("should normalize MIME type casing and parameters", () => {
+      expect(isFileTypeAllowed("image/JPEG")).toBe(true);
+      expect(isFileTypeAllowed("IMAGE/JPEG")).toBe(true);
+      expect(isFileTypeAllowed("image/jpeg; charset=binary")).toBe(true);
     });
   });
 
@@ -83,9 +93,10 @@ describe("Upload Configuration", () => {
       expect(isFileSizeAllowed(1024 * 1024 * 1024)).toBe(false); // 1GB
     });
 
-    it("should handle edge cases", () => {
-      expect(isFileSizeAllowed(0)).toBe(true);
-      expect(isFileSizeAllowed(-1)).toBe(true); // Function doesn't validate negative, just checks <= MAX
+    it("should reject non-positive and invalid sizes", () => {
+      expect(isFileSizeAllowed(0)).toBe(false);
+      expect(isFileSizeAllowed(-1)).toBe(false);
+      expect(isFileSizeAllowed(Number.NaN)).toBe(false);
     });
   });
 
@@ -392,8 +403,8 @@ describe("Upload Configuration", () => {
     it("should handle null and undefined inputs gracefully", () => {
       expect(isFileTypeAllowed(null as unknown as string)).toBe(false);
       expect(isFileTypeAllowed(undefined as unknown as string)).toBe(false);
-      expect(isFileSizeAllowed(null as unknown as number)).toBe(true); // null <= MAX_FILE_SIZE is true
-      expect(isFileSizeAllowed(undefined as unknown as number)).toBe(false); // undefined <= MAX_FILE_SIZE is false
+      expect(isFileSizeAllowed(null as unknown as number)).toBe(false);
+      expect(isFileSizeAllowed(undefined as unknown as number)).toBe(false);
     });
 
     it("should handle very small files", () => {

--- a/src/lib/config/upload.ts
+++ b/src/lib/config/upload.ts
@@ -3,8 +3,8 @@
 import { z } from "zod";
 
 /**
- * 将 MIME 类型映射到文件扩展名。
- * 这是文件扩展名的主要来源。
+ * Maps MIME types to file extensions.
+ * This is the primary source for upload file extensions.
  */
 const MIME_TYPE_TO_EXTENSION = {
   // Images
@@ -54,89 +54,137 @@ const MIME_TYPE_TO_EXTENSION = {
   "text/html": "html",
   "text/css": "css",
   "text/javascript": "js",
+  "application/javascript": "js",
+  "application/ecmascript": "js",
+  "text/ecmascript": "js",
   "application/json": "json", // Note: text/json is obsolete
   "application/xml": "xml", // Note: text/xml is also used
   "text/xml": "xml",
+  "application/xhtml+xml": "xhtml",
   "text/calendar": "ics",
 
   // Archives
   "application/zip": "zip",
   "application/x-rar-compressed": "rar",
   "application/x-7z-compressed": "7z",
-} as const; // 使用 as const 确保类型安全
+} as const;
+
+export const BLOCKED_ACTIVE_CONTENT_TYPES = [
+  "image/svg+xml",
+  "text/html",
+  "text/css",
+  "text/javascript",
+  "application/javascript",
+  "application/ecmascript",
+  "text/ecmascript",
+  "application/xhtml+xml",
+  "application/xml",
+  "text/xml",
+] as const;
+
+const BLOCKED_ACTIVE_CONTENT_TYPE_SET = new Set<string>(
+  BLOCKED_ACTIVE_CONTENT_TYPES,
+);
 
 /**
- * 全局文件上传配置。
- * 这是整个应用中文件上传规则的单一事实来源。
+ * Global upload policy for the application.
  */
 export const UPLOAD_CONFIG = {
   /**
-   * 允许的最大文件大小（字节）。
+   * Maximum allowed single-file size in bytes.
    * @default 50MB
    */
   MAX_FILE_SIZE: 50 * 1024 * 1024,
 
   /**
-   * 允许的最大文件大小（MB），用于在UI中显示。
+   * Maximum allowed single-file size in MB for UI display.
    */
   MAX_FILE_SIZE_MB: 50,
 
   /**
-   * 预签名 URL 的过期时间（秒）。
+   * Maximum files accepted by server-upload in one request.
+   */
+  MAX_SERVER_UPLOAD_FILES: 5,
+
+  /**
+   * Maximum aggregate size accepted by server-upload in one request.
+   */
+  MAX_SERVER_UPLOAD_TOTAL_SIZE: 100 * 1024 * 1024,
+
+  /**
+   * Maximum concurrent R2 uploads performed by server-upload.
+   */
+  SERVER_UPLOAD_CONCURRENCY: 2,
+
+  /**
+   * Lightweight per-user rate limit window for upload endpoints.
+   */
+  USER_UPLOAD_RATE_LIMIT_WINDOW_MS: 60 * 1000,
+
+  /**
+   * Maximum upload endpoint requests allowed per user in one window.
+   */
+  USER_UPLOAD_RATE_LIMIT_MAX_REQUESTS: 30,
+
+  /**
+   * Presigned URL expiration in seconds.
    * @default 15 minutes
    */
   PRESIGNED_URL_EXPIRATION: 15 * 60,
 
   /**
-   * 允许上传的 MIME 类型数组。
-   * **自动从 MIME_TYPE_TO_EXTENSION 生成，确保一致性。**
+   * MIME types allowed for public uploads.
    */
-  ALLOWED_FILE_TYPES: Object.keys(
-    MIME_TYPE_TO_EXTENSION,
+  ALLOWED_FILE_TYPES: Object.keys(MIME_TYPE_TO_EXTENSION).filter(
+    (contentType) => !BLOCKED_ACTIVE_CONTENT_TYPE_SET.has(contentType),
   ) as (keyof typeof MIME_TYPE_TO_EXTENSION)[],
 
   /**
-   * 允许上传目标的协议列表。
-   * 默认仅允许 HTTPS。
+   * Allowed upload target protocols.
    */
   ALLOWED_UPLOAD_URL_PROTOCOLS: ["https:"] as string[],
 
   /**
-   * 允许上传目标的主机名（精确匹配）。
-   * 如使用自定义域名，请将其添加到此列表。
+   * Exact allowed upload target hostnames.
    */
   ALLOWED_UPLOAD_HOSTS: [] as string[],
 
   /**
-   * 允许上传目标的主机名后缀匹配（用于供应商域名）。
+   * Allowed upload target hostname suffixes for provider domains.
    */
   ALLOWED_UPLOAD_HOST_SUFFIXES: [".r2.cloudflarestorage.com"] as string[],
 } as const;
 
+export function normalizeContentType(contentType: string): string {
+  if (typeof contentType !== "string") {
+    return "";
+  }
+
+  return contentType.split(";")[0]?.trim().toLowerCase() || "";
+}
+
 /**
- * 检查文件类型是否在允许列表中。
- * @param contentType - 文件的 MIME 类型。
- * @returns 如果允许则为 `true`，否则为 `false`。
+ * Checks whether a MIME type is allowed for upload.
  */
 export function isFileTypeAllowed(contentType: string): boolean {
+  const normalizedContentType = normalizeContentType(contentType);
+
   return UPLOAD_CONFIG.ALLOWED_FILE_TYPES.includes(
-    contentType as (typeof UPLOAD_CONFIG.ALLOWED_FILE_TYPES)[number],
+    normalizedContentType as (typeof UPLOAD_CONFIG.ALLOWED_FILE_TYPES)[number],
   );
 }
 
 /**
- * 检查文件大小是否在限制范围内。
- * @param size - 文件的字节大小。
- * @returns 如果在限制内则为 `true`，否则为 `false`。
+ * Checks whether a file size is positive and within the limit.
  */
 export function isFileSizeAllowed(size: number): boolean {
-  return size <= UPLOAD_CONFIG.MAX_FILE_SIZE;
+  return (
+    Number.isFinite(size) && size > 0 && size <= UPLOAD_CONFIG.MAX_FILE_SIZE
+  );
 }
 
 /**
- * 格式化文件大小以便于阅读。
- * @param bytes - 文件的字节大小。
- * @returns 格式化后的字符串 (例如, "1.23 MB")。
+ * Formats a byte size for display.
  */
 export function formatFileSize(bytes: number): string {
   if (bytes === 0) return "0 Bytes";
@@ -149,19 +197,19 @@ export function formatFileSize(bytes: number): string {
 }
 
 /**
- * 从 MIME 类型获取文件扩展名。
- * @param contentType - 文件的 MIME 类型。
- * @returns 对应的文件扩展名，如果找不到则默认为 "bin"。
+ * Gets a file extension from a MIME type.
  */
 export function getFileExtension(contentType: string): string {
-  if (contentType in MIME_TYPE_TO_EXTENSION) {
+  const normalizedContentType = normalizeContentType(contentType);
+
+  if (normalizedContentType in MIME_TYPE_TO_EXTENSION) {
     return MIME_TYPE_TO_EXTENSION[
-      contentType as keyof typeof MIME_TYPE_TO_EXTENSION
+      normalizedContentType as keyof typeof MIME_TYPE_TO_EXTENSION
     ];
   }
 
   // Fallback for types like 'application/vnd.some-custom-format'
-  const parts = contentType.split("/");
+  const parts = normalizedContentType.split("/");
   const subtype = parts[1];
   if (subtype && !subtype.includes("*")) {
     const ext = subtype.split("+")[0];
@@ -171,7 +219,6 @@ export function getFileExtension(contentType: string): string {
   return "bin"; // Default fallback
 }
 
-// 用于验证预签名 URL 请求体的 Zod schema
 export const presignedUrlRequestSchema = z.object({
   fileName: z
     .string()

--- a/src/lib/r2.test.ts
+++ b/src/lib/r2.test.ts
@@ -63,6 +63,7 @@ jest.mock("./config/upload", () => ({
   isFileTypeAllowed: mockIsFileTypeAllowed,
   isFileSizeAllowed: mockIsFileSizeAllowed,
   getFileExtension: mockGetFileExtension,
+  normalizeContentType: jest.fn((contentType: string) => contentType),
 }));
 
 // Mock crypto
@@ -247,7 +248,10 @@ describe("R2 Storage Functions", () => {
     it("should reject unsupported protocols", async () => {
       const { uploadFromUrl } = await import("./r2");
 
-      const result = await uploadFromUrl("ftp://example.com/file.jpg", "test-key");
+      const result = await uploadFromUrl(
+        "ftp://example.com/file.jpg",
+        "test-key",
+      );
 
       expect(result.success).toBe(false);
       expect(result.error).toBe("Unsupported URL protocol");
@@ -423,7 +427,10 @@ describe("R2 Storage Functions", () => {
     it("should return true when the object exists", async () => {
       const { fileExists } = await import("./r2");
 
-      mockSend.mockResolvedValueOnce({});
+      mockSend.mockResolvedValueOnce({
+        ContentLength: 1024,
+        ContentType: "image/jpeg",
+      });
 
       await expect(fileExists("test-key")).resolves.toBe(true);
     });
@@ -449,11 +456,37 @@ describe("R2 Storage Functions", () => {
 
       await expect(fileExists("test-key")).resolves.toBe(false);
       expect(consoleSpy).toHaveBeenCalledWith(
-        "Error checking file existence:",
+        "Error reading object metadata:",
         expect.any(Error),
       );
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe("getObjectMetadata", () => {
+    it("should return object metadata from HeadObject", async () => {
+      const { getObjectMetadata } = await import("./r2");
+
+      mockSend.mockResolvedValueOnce({
+        ContentLength: 2048,
+        ContentType: "image/png",
+      });
+
+      await expect(getObjectMetadata("test-key")).resolves.toEqual({
+        contentLength: 2048,
+        contentType: "image/png",
+      });
+    });
+
+    it("should return null when object metadata is incomplete", async () => {
+      const { getObjectMetadata } = await import("./r2");
+
+      mockSend.mockResolvedValueOnce({
+        ContentType: "image/png",
+      });
+
+      await expect(getObjectMetadata("test-key")).resolves.toBeNull();
     });
   });
 

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -15,6 +15,7 @@ import {
   isFileTypeAllowed,
   isFileSizeAllowed,
   getFileExtension,
+  normalizeContentType,
 } from "./config/upload";
 import { randomUUID } from "crypto";
 
@@ -112,6 +113,11 @@ interface UploadResult {
   url?: string;
   key?: string;
   error?: string;
+}
+
+export interface R2ObjectMetadata {
+  contentLength: number;
+  contentType: string;
 }
 
 const BLOCKED_URL_ERROR = "Blocked URL host";
@@ -305,15 +311,27 @@ export async function uploadBuffer(
   }
 }
 
-export async function fileExists(key: string): Promise<boolean> {
+export async function getObjectMetadata(
+  key: string,
+): Promise<R2ObjectMetadata | null> {
   try {
     const command = new HeadObjectCommand({
       Bucket: env.R2_BUCKET_NAME,
       Key: key,
     });
 
-    await r2Client.send(command);
-    return true;
+    const result = await r2Client.send(command);
+    const contentLength = result.ContentLength;
+    const contentType = normalizeContentType(result.ContentType || "");
+
+    if (typeof contentLength !== "number" || !contentType) {
+      return null;
+    }
+
+    return {
+      contentLength,
+      contentType,
+    };
   } catch (error) {
     if (
       error &&
@@ -325,13 +343,18 @@ export async function fileExists(key: string): Promise<boolean> {
       const maybeName = (error as { name?: string }).name;
 
       if (maybeStatus === 404 || maybeName === "NotFound") {
-        return false;
+        return null;
       }
     }
 
-    console.error("Error checking file existence:", error);
-    return false;
+    console.error("Error reading object metadata:", error);
+    return null;
   }
+}
+
+export async function fileExists(key: string): Promise<boolean> {
+  const metadata = await getObjectMetadata(key);
+  return metadata !== null;
 }
 
 /**
@@ -342,7 +365,6 @@ export async function deleteFile(
 ): Promise<{ success: boolean; error?: string }> {
   try {
     const command = new DeleteObjectCommand({
-      // 使用 DeleteObjectCommand
       Bucket: env.R2_BUCKET_NAME,
       Key: key,
     });
@@ -373,7 +395,7 @@ export async function deleteFiles(
       Bucket: env.R2_BUCKET_NAME,
       Delete: {
         Objects: keys.map((key) => ({ Key: key })),
-        Quiet: false, // 设置为 false 以在响应中获取已删除对象的信息
+        Quiet: false,
       },
     });
     await r2Client.send(command);

--- a/src/lib/upload-rate-limit.test.ts
+++ b/src/lib/upload-rate-limit.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { UPLOAD_CONFIG } from "@/lib/config/upload";
+import {
+  checkUploadRateLimit,
+  clearUploadRateLimitForTests,
+} from "./upload-rate-limit";
+
+describe("upload rate limit", () => {
+  beforeEach(() => {
+    clearUploadRateLimitForTests();
+    jest.spyOn(Date, "now").mockReturnValue(1_000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("allows requests until the per-user window is exhausted", () => {
+    const limit = UPLOAD_CONFIG.USER_UPLOAD_RATE_LIMIT_MAX_REQUESTS;
+
+    expect(checkUploadRateLimit("user-1")).toMatchObject({
+      allowed: true,
+      remaining: limit - 1,
+    });
+
+    for (let count = 1; count < limit; count += 1) {
+      expect(checkUploadRateLimit("user-1").allowed).toBe(true);
+    }
+
+    expect(checkUploadRateLimit("user-1")).toMatchObject({
+      allowed: false,
+      remaining: 0,
+      retryAfter: 60,
+    });
+  });
+
+  it("tracks users independently", () => {
+    for (
+      let count = 0;
+      count < UPLOAD_CONFIG.USER_UPLOAD_RATE_LIMIT_MAX_REQUESTS;
+      count += 1
+    ) {
+      checkUploadRateLimit("user-1");
+    }
+
+    expect(checkUploadRateLimit("user-2")).toMatchObject({
+      allowed: true,
+      remaining: UPLOAD_CONFIG.USER_UPLOAD_RATE_LIMIT_MAX_REQUESTS - 1,
+    });
+  });
+});

--- a/src/lib/upload-rate-limit.ts
+++ b/src/lib/upload-rate-limit.ts
@@ -1,0 +1,60 @@
+import { UPLOAD_CONFIG } from "@/lib/config/upload";
+
+interface UploadRateLimitBucket {
+  count: number;
+  resetAt: number;
+}
+
+interface UploadRateLimitResult {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetAt: number;
+  retryAfter: number;
+}
+
+const buckets = new Map<string, UploadRateLimitBucket>();
+
+export function checkUploadRateLimit(userId: string): UploadRateLimitResult {
+  const now = Date.now();
+  const windowMs = UPLOAD_CONFIG.USER_UPLOAD_RATE_LIMIT_WINDOW_MS;
+  const limit = UPLOAD_CONFIG.USER_UPLOAD_RATE_LIMIT_MAX_REQUESTS;
+  const existing = buckets.get(userId);
+
+  if (!existing || existing.resetAt <= now) {
+    const resetAt = now + windowMs;
+    buckets.set(userId, { count: 1, resetAt });
+
+    return {
+      allowed: true,
+      limit,
+      remaining: limit - 1,
+      resetAt,
+      retryAfter: 0,
+    };
+  }
+
+  if (existing.count >= limit) {
+    return {
+      allowed: false,
+      limit,
+      remaining: 0,
+      resetAt: existing.resetAt,
+      retryAfter: Math.ceil((existing.resetAt - now) / 1000),
+    };
+  }
+
+  existing.count += 1;
+
+  return {
+    allowed: true,
+    limit,
+    remaining: limit - existing.count,
+    resetAt: existing.resetAt,
+    retryAfter: 0,
+  };
+}
+
+export function clearUploadRateLimitForTests(): void {
+  buckets.clear();
+}


### PR DESCRIPTION
## Summary
- block active public upload MIME types such as SVG, HTML, CSS, JavaScript, and XML by default
- add server-upload file count, aggregate size, bounded batch concurrency, and lightweight per-user upload endpoint rate limiting
- verify presigned upload completion against R2 HeadObject metadata before persisting size/type

## Tests
- pnpm jest src/lib/config/upload.test.ts src/lib/r2.test.ts src/lib/upload-rate-limit.test.ts src/app/api/upload/presigned-url/route.test.ts src/app/api/upload/complete/route.test.ts src/app/api/upload/server-upload/route.test.ts --runInBand
- pnpm lint
- pnpm type-check

## Follow-up
- The included user-level rate limit is per-process and lightweight. A durable DB-backed quota/rate-limit should be added before relying on it for multi-instance enforcement.