### PR TITLE
Harden E2E test session route

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Run the suite with:
 pnpm test:e2e
 ```
 
-The Playwright runner starts the production server through `pnpm start` and enables a test-only session route with `E2E_TEST_MODE=true`. That route is guarded by `E2E_TEST_SECRET` and should only be enabled from the Playwright runner or CI.
+The Playwright runner starts the production server through `pnpm start` and enables a test-only session route with `E2E_TEST_MODE=true`. That route requires an explicit `E2E_TEST_SECRET` of at least 32 characters, signs the test cookie with that secret, and is disabled for non-local production deployments. Playwright generates a per-run secret when one is not provided by CI.
 
 #### Bundle Analysis Scripts
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -266,7 +266,7 @@ pnpm set:admin --email=your-email@example.com
 pnpm test:e2e
 ```
 
-Playwright 会通过 `pnpm start` 启动生产服务，并在测试期间启用仅供测试使用的会话入口：`E2E_TEST_MODE=true`。该入口受 `E2E_TEST_SECRET` 保护，只应在 Playwright 或 CI 环境下启用。
+Playwright 会通过 `pnpm start` 启动生产服务，并在测试期间启用仅供测试使用的会话入口：`E2E_TEST_MODE=true`。该入口要求显式配置至少 32 个字符的 `E2E_TEST_SECRET`，测试 cookie 会用该密钥签名，且非本机生产部署会禁用该入口。CI 未提供密钥时，Playwright 会为每次运行生成临时密钥。
 
 #### 包体积分析脚本
 

--- a/content/blog/en/saas-starter-kit-developer-guide.md
+++ b/content/blog/en/saas-starter-kit-developer-guide.md
@@ -499,7 +499,7 @@ Provides a powerful, extensible data management system.
 - **Run Tests**:
   - `pnpm test`
   - `pnpm test:e2e`
-- **Test-only session route**: Playwright enables `/api/test/session` only when `E2E_TEST_MODE=true` and the correct `E2E_TEST_SECRET` is present.
+- **Test-only session route**: Playwright enables `/api/test/session` only when `E2E_TEST_MODE=true` and an explicit `E2E_TEST_SECRET` of at least 32 characters is present. The route is disabled for non-local production deployments and signs the test cookie with that secret.
 
 ### 6.2. Code Quality Assurance
 

--- a/content/blog/zh-Hans/saas-starter-kit-developer-guide.md
+++ b/content/blog/zh-Hans/saas-starter-kit-developer-guide.md
@@ -500,7 +500,7 @@ sequenceDiagram
 - **运行测试**:
   - `pnpm test`
   - `pnpm test:e2e`
-- **测试专用会话路由**: Playwright 仅在 `E2E_TEST_MODE=true` 且提供正确 `E2E_TEST_SECRET` 时启用 `/api/test/session`。
+- **测试专用会话路由**: Playwright 仅在 `E2E_TEST_MODE=true` 且提供至少 32 个字符的显式 `E2E_TEST_SECRET` 时启用 `/api/test/session`。非本机生产部署会禁用该入口，测试 cookie 会使用该密钥签名。
 
 ### 6.2. 代码质量保障
 

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -15,6 +15,11 @@ test("allows an E2E user session to access the dashboard", async ({ page }) => {
   await page.goto("/dashboard");
 
   await expect(page).toHaveURL(/\/dashboard$/);
-  await expect(page.getByText("Account overview", { exact: true })).toBeVisible();
+  await expect(
+    page
+      .locator('[data-slot="card-title"]')
+      .filter({ hasText: "Account overview" })
+      .first(),
+  ).toBeVisible();
   await expect(page.getByText(user.email)).toBeVisible();
 });

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -9,7 +9,14 @@ interface TestUser {
   role: TestRole;
 }
 
-const E2E_TEST_SECRET = process.env.E2E_TEST_SECRET || "local-e2e-secret";
+function getE2ETestSecret(): string {
+  const secret = process.env.E2E_TEST_SECRET;
+  if (!secret) {
+    throw new Error("E2E_TEST_SECRET must be configured for Playwright auth.");
+  }
+
+  return secret;
+}
 
 function getTestUser(role: TestRole): TestUser {
   return {
@@ -45,7 +52,7 @@ export async function loginAs(page: Page, role: TestRole): Promise<TestUser> {
       };
     },
     {
-      secret: E2E_TEST_SECRET,
+      secret: getE2ETestSecret(),
       userPayload: user,
     },
   );

--- a/e2e/machine-auth.spec.ts
+++ b/e2e/machine-auth.spec.ts
@@ -7,7 +7,12 @@ test("creates an API key from developer access and uses it against the v1 auth e
   await loginAs(page, "user");
   await page.goto("/dashboard/developer");
 
-  await expect(page.getByText("API Keys", { exact: true })).toBeVisible();
+  await expect(
+    page
+      .locator('section#api-keys [data-slot="card-title"]')
+      .filter({ hasText: "API Keys" })
+      .first(),
+  ).toBeVisible();
   await page.getByRole("button", { name: "Create Key" }).click();
   await page.getByLabel("Name").fill("Playwright Key");
   await page.getByRole("button", { name: "Create" }).click();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig, devices } from "@playwright/test";
+import { randomBytes } from "node:crypto";
 
 const port = 3100;
 const baseURL = `http://127.0.0.1:${port}`;
+const e2eTestSecret =
+  process.env.E2E_TEST_SECRET ?? randomBytes(32).toString("hex");
+
+process.env.E2E_TEST_SECRET = e2eTestSecret;
 
 export default defineConfig({
   testDir: "./e2e",
@@ -17,7 +22,7 @@ export default defineConfig({
     video: "retain-on-failure",
   },
   webServer: {
-    command: `PORT=${port} NEXT_PUBLIC_APP_URL=${baseURL} E2E_TEST_MODE=true E2E_TEST_SECRET=local-e2e-secret pnpm start`,
+    command: `PORT=${port} NEXT_PUBLIC_APP_URL=${baseURL} E2E_TEST_MODE=true E2E_TEST_SECRET=${e2eTestSecret} pnpm start`,
     url: baseURL,
     reuseExistingServer: false,
     timeout: 120 * 1000,

--- a/src/app/api/test/session/route.test.ts
+++ b/src/app/api/test/session/route.test.ts
@@ -1,0 +1,205 @@
+import { webcrypto } from "node:crypto";
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import type { NextRequest } from "next/server";
+import {
+  E2E_AUTH_COOKIE_NAME,
+  getE2ETestUserFromHeaders,
+} from "@/lib/auth/session";
+
+const VALID_SECRET =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const TEST_USER = {
+  id: "e2e-user",
+  email: "user@e2e.local",
+  name: "E2E User",
+  role: "user",
+};
+
+const mockCookieSet = jest.fn();
+const mockJson = jest.fn((data: unknown, init: { status?: number } = {}) => ({
+  status: init.status ?? 200,
+  ok: (init.status ?? 200) >= 200 && (init.status ?? 200) < 300,
+  json: () => Promise.resolve(data),
+  cookies: {
+    set: mockCookieSet,
+  },
+}));
+
+jest.mock("next/server", () => ({
+  NextRequest: jest.fn(),
+  NextResponse: {
+    json: mockJson,
+  },
+}));
+
+const mockLimit = jest.fn();
+const mockWhere = jest.fn(() => ({
+  limit: mockLimit,
+}));
+const mockFrom = jest.fn(() => ({
+  where: mockWhere,
+}));
+const mockSelect = jest.fn(() => ({
+  from: mockFrom,
+}));
+const mockOnConflictDoUpdate = jest.fn();
+const mockValues = jest.fn(() => ({
+  onConflictDoUpdate: mockOnConflictDoUpdate,
+}));
+const mockInsert = jest.fn(() => ({
+  values: mockValues,
+}));
+const mockDeleteWhere = jest.fn();
+const mockDelete = jest.fn(() => ({
+  where: mockDeleteWhere,
+}));
+
+jest.mock("@/database", () => ({
+  db: {
+    select: mockSelect,
+    insert: mockInsert,
+    delete: mockDelete,
+  },
+}));
+
+jest.mock("@/database/schema", () => ({
+  users: {
+    id: "users.id",
+    email: "users.email",
+  },
+}));
+
+const mockEq = jest.fn();
+jest.mock("drizzle-orm", () => ({
+  eq: mockEq,
+}));
+
+const originalEnv = {
+  E2E_TEST_MODE: process.env.E2E_TEST_MODE,
+  E2E_TEST_SECRET: process.env.E2E_TEST_SECRET,
+  NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+  NODE_ENV: process.env.NODE_ENV,
+  VERCEL_ENV: process.env.VERCEL_ENV,
+};
+
+function setNodeEnv(value: string): void {
+  Object.defineProperty(process.env, "NODE_ENV", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function restoreEnvValue(key: keyof typeof originalEnv): void {
+  const value = originalEnv[key];
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+
+  process.env[key] = value;
+}
+
+function createPostRequest(secret: string | null): NextRequest {
+  const headers = new Headers();
+  if (secret !== null) {
+    headers.set("x-e2e-test-secret", secret);
+  }
+
+  return {
+    headers,
+    json: jest.fn().mockResolvedValue(TEST_USER),
+  } as unknown as NextRequest;
+}
+
+describe("POST /api/test/session", () => {
+  beforeAll(() => {
+    Object.defineProperty(globalThis, "crypto", {
+      value: webcrypto,
+      configurable: true,
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.E2E_TEST_MODE = "true";
+    process.env.E2E_TEST_SECRET = VALID_SECRET;
+    process.env.NEXT_PUBLIC_APP_URL = "http://127.0.0.1:3100";
+    delete process.env.VERCEL_ENV;
+    setNodeEnv("test");
+    mockLimit.mockResolvedValue([]);
+    mockOnConflictDoUpdate.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    restoreEnvValue("E2E_TEST_MODE");
+    restoreEnvValue("E2E_TEST_SECRET");
+    restoreEnvValue("NEXT_PUBLIC_APP_URL");
+    restoreEnvValue("VERCEL_ENV");
+    if (originalEnv.NODE_ENV === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      setNodeEnv(originalEnv.NODE_ENV);
+    }
+  });
+
+  it("returns 404 when the configured E2E secret is missing", async () => {
+    delete process.env.E2E_TEST_SECRET;
+
+    const { POST } = await import("./route");
+    const response = await POST(createPostRequest(VALID_SECRET));
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Not found" });
+    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockCookieSet).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for non-local production deployments", async () => {
+    setNodeEnv("production");
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+
+    const { POST } = await import("./route");
+    const response = await POST(createPostRequest(VALID_SECRET));
+
+    expect(response.status).toBe(404);
+    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockCookieSet).not.toHaveBeenCalled();
+  });
+
+  it("creates a signed E2E session cookie with a valid explicit secret", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(createPostRequest(VALID_SECRET));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ ok: true, userId: TEST_USER.id });
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(mockCookieSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: E2E_AUTH_COOKIE_NAME,
+        httpOnly: true,
+        sameSite: "lax",
+        value: expect.stringContaining("."),
+      }),
+    );
+
+    const cookieOptions = mockCookieSet.mock.calls[0]?.[0] as
+      | { value?: string }
+      | undefined;
+    await expect(
+      getE2ETestUserFromHeaders(
+        new Headers({
+          cookie: `${E2E_AUTH_COOKIE_NAME}=${cookieOptions?.value}`,
+        }),
+      ),
+    ).resolves.toMatchObject(TEST_USER);
+  });
+});

--- a/src/app/api/test/session/route.ts
+++ b/src/app/api/test/session/route.ts
@@ -86,6 +86,10 @@ export async function POST(request: NextRequest) {
   }
 
   const persistedUser = await upsertUser(parsedUser.data);
+  const cookieValue = await createE2ESessionCookieValue(persistedUser);
+  if (!cookieValue) {
+    return notFoundResponse();
+  }
 
   const response = NextResponse.json({
     ok: true,
@@ -93,7 +97,7 @@ export async function POST(request: NextRequest) {
   });
   response.cookies.set({
     name: E2E_AUTH_COOKIE_NAME,
-    value: createE2ESessionCookieValue(persistedUser),
+    value: cookieValue,
     httpOnly: true,
     sameSite: "lax",
     path: "/",

--- a/src/lib/auth/session.test.ts
+++ b/src/lib/auth/session.test.ts
@@ -1,0 +1,126 @@
+import { webcrypto } from "node:crypto";
+import { beforeAll, beforeEach, describe, expect, it } from "@jest/globals";
+import {
+  createE2ESessionCookieValue,
+  E2E_AUTH_COOKIE_NAME,
+  getE2ETestSecret,
+  getE2ETestUserFromHeaders,
+  shouldAllowE2ETestAccess,
+  type E2ETestUser,
+} from "./session";
+
+const VALID_SECRET =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const originalEnv = {
+  E2E_TEST_MODE: process.env.E2E_TEST_MODE,
+  E2E_TEST_SECRET: process.env.E2E_TEST_SECRET,
+  NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+  NODE_ENV: process.env.NODE_ENV,
+  VERCEL_ENV: process.env.VERCEL_ENV,
+};
+
+function setNodeEnv(value: string): void {
+  Object.defineProperty(process.env, "NODE_ENV", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function restoreEnvValue(key: keyof typeof originalEnv): void {
+  const value = originalEnv[key];
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+
+  process.env[key] = value;
+}
+
+describe("E2E auth session helpers", () => {
+  const user: E2ETestUser = {
+    id: "e2e-user",
+    email: "user@e2e.local",
+    name: "E2E User",
+    role: "user",
+  };
+
+  beforeAll(() => {
+    Object.defineProperty(globalThis, "crypto", {
+      value: webcrypto,
+      configurable: true,
+    });
+  });
+
+  beforeEach(() => {
+    process.env.E2E_TEST_MODE = "true";
+    process.env.E2E_TEST_SECRET = VALID_SECRET;
+    process.env.NEXT_PUBLIC_APP_URL = "http://127.0.0.1:3100";
+    delete process.env.VERCEL_ENV;
+    setNodeEnv("test");
+  });
+
+  afterEach(() => {
+    restoreEnvValue("E2E_TEST_MODE");
+    restoreEnvValue("E2E_TEST_SECRET");
+    restoreEnvValue("NEXT_PUBLIC_APP_URL");
+    restoreEnvValue("VERCEL_ENV");
+    if (originalEnv.NODE_ENV === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      setNodeEnv(originalEnv.NODE_ENV);
+    }
+  });
+
+  it("rejects E2E access when the secret is missing", () => {
+    delete process.env.E2E_TEST_SECRET;
+
+    expect(getE2ETestSecret()).toBeNull();
+    expect(shouldAllowE2ETestAccess(VALID_SECRET)).toBe(false);
+  });
+
+  it("rejects the previous shared default secret", () => {
+    process.env.E2E_TEST_SECRET = "local-e2e-secret";
+
+    expect(getE2ETestSecret()).toBeNull();
+    expect(shouldAllowE2ETestAccess("local-e2e-secret")).toBe(false);
+  });
+
+  it("rejects E2E access for non-local production deployments", () => {
+    setNodeEnv("production");
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+
+    expect(shouldAllowE2ETestAccess(VALID_SECRET)).toBe(false);
+  });
+
+  it("allows E2E access with a valid explicit secret in local test mode", () => {
+    expect(getE2ETestSecret()).toBe(VALID_SECRET);
+    expect(shouldAllowE2ETestAccess(VALID_SECRET)).toBe(true);
+  });
+
+  it("signs and verifies the E2E session cookie", async () => {
+    const cookieValue = await createE2ESessionCookieValue(user);
+
+    expect(cookieValue).toEqual(expect.stringContaining("."));
+    await expect(
+      getE2ETestUserFromHeaders(
+        new Headers({
+          cookie: `${E2E_AUTH_COOKIE_NAME}=${cookieValue}`,
+        }),
+      ),
+    ).resolves.toEqual(user);
+  });
+
+  it("rejects tampered E2E session cookies", async () => {
+    const cookieValue = await createE2ESessionCookieValue(user);
+    const tamperedCookieValue = cookieValue?.replace(/.$/, "x");
+
+    await expect(
+      getE2ETestUserFromHeaders(
+        new Headers({
+          cookie: `${E2E_AUTH_COOKIE_NAME}=${tamperedCookieValue}`,
+        }),
+      ),
+    ).resolves.toBeNull();
+  });
+});

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -3,6 +3,11 @@ import type { UserRole } from "@/lib/config/roles";
 
 export const E2E_AUTH_COOKIE_NAME = "__e2e_auth_session";
 const E2E_SESSION_MAX_AGE_SECONDS = 60 * 60;
+const E2E_TEST_SECRET_MIN_LENGTH = 32;
+const BLOCKED_E2E_TEST_SECRETS = new Set(["local-e2e-secret"]);
+const E2E_TEST_ROLES = new Set<UserRole>(["user", "admin", "super_admin"]);
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
 
 export interface E2ETestUser {
   id: string;
@@ -35,16 +40,157 @@ interface AppSession {
   };
 }
 
+function isLocalAppUrl(): boolean {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  if (!appUrl) {
+    return false;
+  }
+
+  try {
+    const { hostname } = new URL(appUrl);
+    return (
+      hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isProductionDeployment(): boolean {
+  if (process.env.VERCEL_ENV === "production") {
+    return true;
+  }
+
+  return process.env.NODE_ENV === "production" && !isLocalAppUrl();
+}
+
+export function getE2ETestSecret(): string | null {
+  const secret = process.env.E2E_TEST_SECRET?.trim();
+  if (!secret) {
+    return null;
+  }
+
+  if (
+    secret.length < E2E_TEST_SECRET_MIN_LENGTH ||
+    BLOCKED_E2E_TEST_SECRETS.has(secret)
+  ) {
+    return null;
+  }
+
+  return secret;
+}
+
 function isE2ETestModeEnabled(): boolean {
-  return process.env.E2E_TEST_MODE === "true";
+  return (
+    process.env.E2E_TEST_MODE === "true" &&
+    !isProductionDeployment() &&
+    getE2ETestSecret() !== null
+  );
 }
 
-export function getE2ETestSecret(): string {
-  return process.env.E2E_TEST_SECRET || "local-e2e-secret";
+function base64UrlEncode(bytes: Uint8Array): string {
+  const binary = String.fromCharCode(...bytes);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
 }
 
-export function createE2ESessionCookieValue(user: E2ETestUser): string {
-  return Buffer.from(JSON.stringify(user), "utf8").toString("base64url");
+function base64UrlEncodeText(value: string): string {
+  return base64UrlEncode(textEncoder.encode(value));
+}
+
+function base64UrlDecodeText(value: string): string | null {
+  try {
+    const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(
+      normalized.length + ((4 - (normalized.length % 4)) % 4),
+      "=",
+    );
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (character) =>
+      character.charCodeAt(0),
+    );
+    return textDecoder.decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+async function signE2EPayload(
+  payload: string,
+  secret: string,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    textEncoder.encode(payload),
+  );
+
+  return base64UrlEncode(new Uint8Array(signature));
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  let difference = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    difference |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+
+  return difference === 0;
+}
+
+async function hasValidE2ESignature(
+  payload: string,
+  signature: string,
+  secret: string,
+): Promise<boolean> {
+  const expectedSignature = await signE2EPayload(payload, secret);
+  return constantTimeEqual(signature, expectedSignature);
+}
+
+function isE2ETestUser(value: unknown): value is E2ETestUser {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const user = value as Partial<Record<keyof E2ETestUser, unknown>>;
+  const image = user.image;
+
+  return (
+    typeof user.id === "string" &&
+    user.id.length > 0 &&
+    typeof user.email === "string" &&
+    user.email.length > 0 &&
+    typeof user.name === "string" &&
+    user.name.length > 0 &&
+    typeof user.role === "string" &&
+    E2E_TEST_ROLES.has(user.role as UserRole) &&
+    (image === undefined || image === null || typeof image === "string")
+  );
+}
+
+export async function createE2ESessionCookieValue(
+  user: E2ETestUser,
+): Promise<string | null> {
+  const secret = getE2ETestSecret();
+  if (!secret) {
+    return null;
+  }
+
+  const payload = base64UrlEncodeText(JSON.stringify(user));
+  const signature = await signE2EPayload(payload, secret);
+  return `${payload}.${signature}`;
 }
 
 function parseCookieHeader(cookieHeader: string | null): Map<string, string> {
@@ -68,8 +214,15 @@ function parseCookieHeader(cookieHeader: string | null): Map<string, string> {
   return cookies;
 }
 
-export function getE2ETestUserFromHeaders(headers: Headers): E2ETestUser | null {
+export async function getE2ETestUserFromHeaders(
+  headers: Headers,
+): Promise<E2ETestUser | null> {
   if (!isE2ETestModeEnabled()) {
+    return null;
+  }
+
+  const secret = getE2ETestSecret();
+  if (!secret) {
     return null;
   }
 
@@ -80,10 +233,23 @@ export function getE2ETestUserFromHeaders(headers: Headers): E2ETestUser | null 
     return null;
   }
 
+  const [payload, signature, extra] = cookieValue.split(".");
+  if (!payload || !signature || extra !== undefined) {
+    return null;
+  }
+
+  if (!(await hasValidE2ESignature(payload, signature, secret))) {
+    return null;
+  }
+
+  const decodedPayload = base64UrlDecodeText(payload);
+  if (!decodedPayload) {
+    return null;
+  }
+
   try {
-    return JSON.parse(
-      Buffer.from(cookieValue, "base64url").toString("utf8"),
-    ) as E2ETestUser;
+    const parsedPayload = JSON.parse(decodedPayload);
+    return isE2ETestUser(parsedPayload) ? parsedPayload : null;
   } catch {
     return null;
   }
@@ -91,7 +257,9 @@ export function getE2ETestUserFromHeaders(headers: Headers): E2ETestUser | null 
 
 function createE2ESession(user: E2ETestUser): AppSession {
   const now = new Date();
-  const expiresAt = new Date(now.getTime() + E2E_SESSION_MAX_AGE_SECONDS * 1000);
+  const expiresAt = new Date(
+    now.getTime() + E2E_SESSION_MAX_AGE_SECONDS * 1000,
+  );
 
   return {
     session: {
@@ -120,7 +288,7 @@ function createE2ESession(user: E2ETestUser): AppSession {
 export async function getAuthSessionFromHeaders(
   headers: Headers,
 ): Promise<AppSession | null> {
-  const e2eUser = getE2ETestUserFromHeaders(headers);
+  const e2eUser = await getE2ETestUserFromHeaders(headers);
   if (e2eUser) {
     return createE2ESession(e2eUser);
   }
@@ -147,9 +315,15 @@ export async function hasAuthenticatedSession(
     return false;
   }
 
-  return request.cookies.has(E2E_AUTH_COOKIE_NAME);
+  return (await getE2ETestUserFromHeaders(request.headers)) !== null;
 }
 
 export function shouldAllowE2ETestAccess(secret: string | null): boolean {
-  return isE2ETestModeEnabled() && secret === getE2ETestSecret();
+  const expectedSecret = getE2ETestSecret();
+  return (
+    isE2ETestModeEnabled() &&
+    secret !== null &&
+    expectedSecret !== null &&
+    constantTimeEqual(secret, expectedSecret)
+  );
 }


### PR DESCRIPTION
## Summary
- require an explicit non-default E2E test secret and disable the test session path for non-local production deployments
- sign E2E auth cookies and verify signatures before accepting test sessions
- update Playwright to use a per-run secret and add Jest coverage for missing secret, production rejection, and valid signed sessions

## Verification
- pnpm lint
- pnpm type-check
- pnpm test -- src/lib/auth/session.test.ts src/app/api/test/session/route.test.ts