### PR TITLE
Use English code comments

### DIFF
--- a/src/lib/admin/index.ts
+++ b/src/lib/admin/index.ts
@@ -1,4 +1,4 @@
-// 统一导出 admin 相关能力
+// Re-export admin capabilities from one module.
 export {
   getAdminStats,
   type AdminStatsWithCharts,

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -3,7 +3,7 @@ import { UserRole, hasRole as checkRole } from "@/lib/config/roles";
 import { buildLoginRedirectPath } from "./callback-url";
 import { getAuthSessionFromHeaders } from "./session";
 
-// 重新导出 UserRole 类型以保持向后兼容性
+// Re-export UserRole for backward compatibility.
 export type { UserRole };
 
 export interface AuthUser {

--- a/src/lib/billing/creem/client.ts
+++ b/src/lib/billing/creem/client.ts
@@ -8,7 +8,7 @@ if (!env.CREEM_API_KEY) {
 export const creemApiKey = env.CREEM_API_KEY;
 
 export const creemClient = new Creem({
-  // 根据环境选择服务器，0 是 live_mode, 1 是 test_mode
+  // Select the Creem server by environment: 0 is live_mode, 1 is test_mode.
   serverIdx: env.CREEM_ENVIRONMENT === "live_mode" ? 0 : 1,
   apiKey: creemApiKey,
 });

--- a/src/lib/billing/index.ts
+++ b/src/lib/billing/index.ts
@@ -1,7 +1,7 @@
 import { PAYMENT_PROVIDER } from "@/lib/config/constants";
 import type { PaymentProvider } from "./provider";
 import creemProvider from "./creem/provider";
-// import stripeProvider from "./stripe/provider"; // 示例：未来可以添加
+// import stripeProvider from "./stripe/provider"; // Example: add later.
 
 const BILLING_PROVIDERS: Record<string, PaymentProvider> = {
   creem: creemProvider,

--- a/src/lib/config/roles.ts
+++ b/src/lib/config/roles.ts
@@ -1,9 +1,9 @@
 import { userRoleEnum } from "@/database/schema";
 
-// 从数据库 schema 导出角色类型，确保单一事实来源
+// Derive role types from the database schema as the single source of truth.
 export type UserRole = (typeof userRoleEnum.enumValues)[number];
 
-// 角色层级配置 - 数字越大权限越高
+// Role hierarchy; higher numbers have broader permissions.
 export const ROLE_HIERARCHY: Record<UserRole, number> = {
   user: 1,
   admin: 2,
@@ -11,38 +11,38 @@ export const ROLE_HIERARCHY: Record<UserRole, number> = {
 } as const;
 
 /**
- * 检查用户是否具有所需角色权限
- * @param userRole 用户当前角色
- * @param requiredRole 所需的最低角色
- * @returns 是否具有权限
+ * Check whether the user has the required role.
+ * @param userRole Current user role
+ * @param requiredRole Minimum required role
+ * @returns Whether the role has permission
  */
 export function hasRole(userRole: UserRole, requiredRole: UserRole): boolean {
   return ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY[requiredRole];
 }
 
 /**
- * 获取所有可用角色
+ * Get all available roles.
  */
 export function getAllRoles(): UserRole[] {
   return userRoleEnum.enumValues as UserRole[];
 }
 
 /**
- * 获取角色的层级值
+ * Get the hierarchy level for a role.
  */
 export function getRoleLevel(role: UserRole): number {
   return ROLE_HIERARCHY[role];
 }
 
 /**
- * 检查角色是否为管理员级别（admin 或更高）
+ * Check whether a role has admin-level access.
  */
 export function isAdminRole(role: UserRole): boolean {
   return hasRole(role, "admin");
 }
 
 /**
- * 检查角色是否为超级管理员
+ * Check whether a role is a super admin.
  */
 export function isSuperAdminRole(role: UserRole): boolean {
   return role === "super_admin";

--- a/src/types/billing.ts
+++ b/src/types/billing.ts
@@ -47,7 +47,7 @@ export interface CreateCheckoutOptions {
   failureUrl?: string;
 }
 
-// --- Creem Webhook 事件对象详细类型定义 ---
+// --- Detailed Creem webhook object types ---
 
 export type CreemMetadata = {
   userId?: string;


### PR DESCRIPTION
## Summary
- Translate remaining Chinese code comments in billing, admin, auth, and role helpers to English.
- Keep runtime behavior unchanged.

## Verification
- pnpm prettier:check
- pnpm lint
- pnpm type-check
- pnpm jest src/lib/billing/creem/client.test.ts src/lib/config/roles.test.ts --runInBand
- git diff --check
- rg "[\p{Han}]" src/lib src/types -n (remaining hits are test/content data, not comments)