### PR TITLE
Fix localized marketing static i18n

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,4 +43,4 @@ CREEM_WEBHOOK_SECRET=whsec_test_secret_here
 
 # OpenRouter API Key for i18n
 OPENROUTER_API_KEY="sk-or-xxx"
-LINGO_BUILD_MODE=translate
+LINGO_BUILD_MODE=cache-only

--- a/lingo.config.ts
+++ b/lingo.config.ts
@@ -48,9 +48,9 @@ Your goal is to perform state-of-the-art localization for software products and 
 `.trim();
 
 function resolveLingoBuildMode(): "cache-only" | "translate" {
-  return process.env.LINGO_BUILD_MODE === "cache-only"
-    ? "cache-only"
-    : "translate";
+  return process.env.LINGO_BUILD_MODE === "translate"
+    ? "translate"
+    : "cache-only";
 }
 
 function shouldUseLingoPseudotranslator(): boolean {

--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -85,7 +85,7 @@ describe("next.config.ts", () => {
     expect(nextConfig).not.toHaveProperty("analyzed");
   });
 
-  it("uses translate mode by default", async () => {
+  it("uses cache-only mode by default", async () => {
     delete process.env.LINGO_BUILD_MODE;
     jest.doMock("@/env", () => ({
       __esModule: true,
@@ -98,14 +98,14 @@ describe("next.config.ts", () => {
     await getConfig();
 
     expect(getLingoOptions()).toMatchObject({
-      buildMode: "translate",
+      buildMode: "cache-only",
       dev: {
         usePseudotranslator: true,
       },
     });
   });
 
-  it("uses cache-only mode when LINGO_BUILD_MODE requests it", async () => {
+  it("keeps cache-only mode when LINGO_BUILD_MODE requests it", async () => {
     process.env.LINGO_BUILD_MODE = "cache-only";
     jest.doMock("@/env", () => ({
       __esModule: true,

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -76,6 +76,22 @@ describe("proxy", () => {
     );
   });
 
+  it("does not let external locale headers bypass marketing canonicalization", async () => {
+    const request = new NextRequest("http://localhost/zh/contact", {
+      headers: {
+        "x-user-locale": "en",
+      },
+    });
+
+    const response = await proxy(request);
+
+    expect(response.status).toBeGreaterThanOrEqual(300);
+    expect(response.status).toBeLessThan(400);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost/zh-Hans/contact",
+    );
+  });
+
   it("redirects /en-prefixed marketing paths to English canonical bare paths", async () => {
     const request = new NextRequest("http://localhost/en/blog");
 

--- a/src/app/[locale]/layout.test.tsx
+++ b/src/app/[locale]/layout.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import LocalizedMarketingLayout from "./layout";
+import LocalizedMarketingLayout, { generateStaticParams } from "./layout";
 import { resolveStaticMarketingParams } from "@/lib/i18n/static-marketing-locale";
 
 jest.mock("@/app/(pages)/layout", () => ({
@@ -16,6 +16,16 @@ jest.mock("@/app/(pages)/layout", () => ({
 jest.mock("@/lib/i18n/static-marketing-locale", () => ({
   getStaticMarketingLocaleParams: jest.fn(() => [{ locale: "zh-Hans" }]),
   resolveStaticMarketingParams: jest.fn(() => Promise.resolve("zh-Hans")),
+}));
+
+jest.mock("@/lib/i18n/request-lingo-provider", () => ({
+  LocaleLingoProvider: ({
+    children,
+    locale,
+  }: {
+    children: React.ReactNode;
+    locale: string;
+  }) => <div data-locale={locale}>{children}</div>,
 }));
 
 const mockResolveStaticMarketingParams =
@@ -42,5 +52,13 @@ describe("LocalizedMarketingLayout", () => {
     expect(screen.getByTestId("homepage-header")).toBeInTheDocument();
     expect(screen.getByTestId("homepage-footer")).toBeInTheDocument();
     expect(screen.getByTestId("layout-child")).toBeInTheDocument();
+    expect(screen.getByTestId("pages-layout").parentElement).toHaveAttribute(
+      "data-locale",
+      "zh-Hans",
+    );
+  });
+
+  it("statically generates supported target locale params", () => {
+    expect(generateStaticParams()).toEqual([{ locale: "zh-Hans" }]);
   });
 });

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,7 +1,16 @@
-import { resolveStaticMarketingParams } from "@/lib/i18n/static-marketing-locale";
+import {
+  getStaticMarketingLocaleParams,
+  resolveStaticMarketingParams,
+} from "@/lib/i18n/static-marketing-locale";
+import { LocaleLingoProvider } from "@/lib/i18n/request-lingo-provider";
 import PagesLayout from "@/app/(pages)/layout";
 
-export const dynamic = "force-dynamic";
+export const dynamicParams = false;
+export const dynamic = "force-static";
+
+export function generateStaticParams() {
+  return getStaticMarketingLocaleParams();
+}
 
 export default async function LocalizedMarketingLayout({
   children,
@@ -10,7 +19,17 @@ export default async function LocalizedMarketingLayout({
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 }) {
-  await resolveStaticMarketingParams(params);
+  const locale = await resolveStaticMarketingParams(params);
 
-  return <PagesLayout>{children}</PagesLayout>;
+  return (
+    <LocaleLingoProvider locale={locale}>
+      <script
+        id="localized-document-lang"
+        dangerouslySetInnerHTML={{
+          __html: `document.documentElement.lang=${JSON.stringify(locale)};`,
+        }}
+      />
+      <PagesLayout>{children}</PagesLayout>
+    </LocaleLingoProvider>
+  );
 }

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -102,4 +102,5 @@ describe("RootLayout", () => {
     expect(lingoProvider?.props.initialLocale).toBe("zh-Hans");
     expect(lingoProvider?.props.initialTranslations).toEqual({ hello: "你好" });
   });
+
 });

--- a/src/lib/i18n/request-lingo-provider.tsx
+++ b/src/lib/i18n/request-lingo-provider.tsx
@@ -1,13 +1,15 @@
 import { AppLingoProvider } from "@/lib/i18n/lingo-provider";
 import { loadLingoTranslations } from "@/lib/i18n/lingo-translations";
 import { getRequestLocale } from "@/lib/i18n/server-locale";
+import type { SupportedLocale } from "@/lib/config/i18n";
 
-export async function RequestLingoProvider({
+export async function LocaleLingoProvider({
   children,
+  locale,
 }: {
   children: React.ReactNode;
+  locale: SupportedLocale;
 }) {
-  const locale = await getRequestLocale();
   const translations = await loadLingoTranslations(locale);
 
   return (
@@ -15,4 +17,14 @@ export async function RequestLingoProvider({
       {children}
     </AppLingoProvider>
   );
+}
+
+export async function RequestLingoProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const locale = await getRequestLocale();
+
+  return <LocaleLingoProvider locale={locale}>{children}</LocaleLingoProvider>;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,7 +7,6 @@ import {
   SOURCE_LOCALE,
   extractLocaleFromPath,
   isMarketingPath,
-  normalizeLocaleCandidate,
   resolvePreferredLocale,
   withLocalePrefix,
 } from "@/lib/config/i18n-routing";
@@ -34,23 +33,6 @@ function createLocalizedRequestHeaders(
 export default async function authMiddleware(request: NextRequest) {
   const requestUrl = new URL(request.url);
   const { pathname, search } = requestUrl;
-  const resolvedRequestLocale = normalizeLocaleCandidate(
-    request.headers.get(LOCALE_HEADER_NAME),
-  );
-
-  if (resolvedRequestLocale) {
-    const requestHeaders = createLocalizedRequestHeaders(
-      request,
-      resolvedRequestLocale,
-    );
-
-    return NextResponse.next({
-      request: {
-        headers: requestHeaders,
-      },
-    });
-  }
-
   const localeFromCookie = request.cookies.get(LOCALE_COOKIE_NAME)?.value;
   const preferredLocale = resolvePreferredLocale({
     cookieLocale: localeFromCookie,


### PR DESCRIPTION
## Summary
- statically generate supported localized marketing routes instead of forcing the locale segment dynamic
- make localized marketing layout load locale-specific Lingo translations explicitly
- prevent external x-user-locale request headers from bypassing proxy canonicalization
- default Lingo builds to cache-only unless translate is explicitly requested

## Verification
- pnpm content:build && pnpm exec jest --runTestsByPath src/app/layout.test.tsx src/app/[locale]/layout.test.tsx proxy.test.ts next.config.test.ts --runInBand
- pnpm type-check
- LINGO_BUILD_MODE=cache-only pnpm build
- pnpm lint
- pnpm test
- production start + curl/browser DOM check for /zh-Hans/pricing: SSG cache hit and documentElement.lang zh-Hans

## Notes
- The root layout cannot receive child [locale] params during static generation, so the localized segment explicitly overrides the Lingo provider and sets document lang early for browser DOM correctness.