### PR TITLE
Fix review cleanup issues

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     video: "retain-on-failure",
   },
   webServer: {
-    command: `PORT=${port} NEXT_PUBLIC_APP_URL=${baseURL} E2E_TEST_MODE=true E2E_TEST_SECRET=${e2eTestSecret} pnpm start`,
+    command: `PORT=${port} NEXT_PUBLIC_APP_URL=${baseURL} E2E_TEST_MODE=true PLAYWRIGHT=true E2E_TEST_SECRET=${e2eTestSecret} pnpm start`,
     url: baseURL,
     reuseExistingServer: false,
     timeout: 120 * 1000,

--- a/src/app/api/test/session/route.test.ts
+++ b/src/app/api/test/session/route.test.ts
@@ -84,6 +84,7 @@ jest.mock("drizzle-orm", () => ({
 const originalEnv = {
   E2E_TEST_MODE: process.env.E2E_TEST_MODE,
   E2E_TEST_SECRET: process.env.E2E_TEST_SECRET,
+  PLAYWRIGHT: process.env.PLAYWRIGHT,
   NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
   NODE_ENV: process.env.NODE_ENV,
   VERCEL_ENV: process.env.VERCEL_ENV,
@@ -131,6 +132,7 @@ describe("POST /api/test/session", () => {
     jest.clearAllMocks();
     process.env.E2E_TEST_MODE = "true";
     process.env.E2E_TEST_SECRET = VALID_SECRET;
+    process.env.PLAYWRIGHT = "true";
     process.env.NEXT_PUBLIC_APP_URL = "http://127.0.0.1:3100";
     delete process.env.VERCEL_ENV;
     setNodeEnv("test");
@@ -141,6 +143,7 @@ describe("POST /api/test/session", () => {
   afterEach(() => {
     restoreEnvValue("E2E_TEST_MODE");
     restoreEnvValue("E2E_TEST_SECRET");
+    restoreEnvValue("PLAYWRIGHT");
     restoreEnvValue("NEXT_PUBLIC_APP_URL");
     restoreEnvValue("VERCEL_ENV");
     if (originalEnv.NODE_ENV === undefined) {
@@ -171,6 +174,34 @@ describe("POST /api/test/session", () => {
 
     expect(response.status).toBe(404);
     expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockCookieSet).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 outside Playwright", async () => {
+    delete process.env.PLAYWRIGHT;
+
+    const { POST } = await import("./route");
+    const response = await POST(createPostRequest(VALID_SECRET));
+
+    expect(response.status).toBe(404);
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockCookieSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-E2E identities", async () => {
+    const request = createPostRequest(VALID_SECRET);
+    request.json = jest.fn().mockResolvedValue({
+      ...TEST_USER,
+      id: "real-user",
+      email: "admin@example.com",
+      role: "super_admin",
+    });
+
+    const { POST } = await import("./route");
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
     expect(mockCookieSet).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/test/session/route.ts
+++ b/src/app/api/test/session/route.ts
@@ -11,8 +11,8 @@ import {
 } from "@/lib/auth/session";
 
 const e2eUserSchema = z.object({
-  id: z.string().min(1),
-  email: z.string().email(),
+  id: z.string().regex(/^e2e-[a-z0-9_-]+$/),
+  email: z.string().email().endsWith("@e2e.local"),
   name: z.string().min(1),
   role: z.enum(["user", "admin", "super_admin"]),
   image: z.string().nullable().optional(),
@@ -24,26 +24,15 @@ function notFoundResponse(): NextResponse {
 
 async function upsertUser(user: E2ETestUser) {
   const now = new Date();
-  const existingUser = await db
-    .select({
-      id: users.id,
-    })
-    .from(users)
-    .where(eq(users.email, user.email))
-    .limit(1);
-  const persistedUser = {
-    ...user,
-    id: existingUser[0]?.id ?? user.id,
-  };
 
   await db
     .insert(users)
     .values({
-      id: persistedUser.id,
-      email: persistedUser.email,
-      name: persistedUser.name,
-      image: persistedUser.image ?? null,
-      role: persistedUser.role,
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      image: user.image ?? null,
+      role: user.role,
       emailVerified: true,
       banned: false,
       banReason: null,
@@ -55,10 +44,10 @@ async function upsertUser(user: E2ETestUser) {
     .onConflictDoUpdate({
       target: users.id,
       set: {
-        email: persistedUser.email,
-        name: persistedUser.name,
-        image: persistedUser.image ?? null,
-        role: persistedUser.role,
+        email: user.email,
+        name: user.name,
+        image: user.image ?? null,
+        role: user.role,
         emailVerified: true,
         banned: false,
         banReason: null,
@@ -67,7 +56,7 @@ async function upsertUser(user: E2ETestUser) {
       },
     });
 
-  return persistedUser;
+  return user;
 }
 
 export async function POST(request: NextRequest) {
@@ -113,7 +102,7 @@ export async function DELETE(request: NextRequest) {
   }
 
   const userId = request.nextUrl.searchParams.get("userId");
-  if (userId) {
+  if (userId?.startsWith("e2e-")) {
     await db.delete(users).where(eq(users.id, userId));
   }
 

--- a/src/app/api/upload/complete/route.test.ts
+++ b/src/app/api/upload/complete/route.test.ts
@@ -32,6 +32,7 @@ jest.mock("@/lib/auth/server", () => ({
 
 const mockGetObjectMetadata = jest.fn() as any;
 jest.mock("@/lib/r2", () => ({
+  buildR2PublicUrl: (key: string) => `https://cdn.example.com/${key}`,
   getObjectMetadata: mockGetObjectMetadata,
 }));
 

--- a/src/app/api/upload/complete/route.ts
+++ b/src/app/api/upload/complete/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/database";
 import { uploads } from "@/database/schema";
-import env from "@/env";
 import { and, eq } from "drizzle-orm";
 import {
   formatFileSize,
@@ -11,7 +10,7 @@ import {
   UPLOAD_CONFIG,
   uploadCompleteRequestSchema,
 } from "@/lib/config/upload";
-import { getObjectMetadata } from "@/lib/r2";
+import { buildR2PublicUrl, getObjectMetadata } from "@/lib/r2";
 import { getAuthSessionFromHeaders } from "@/lib/auth/session";
 import { checkUploadRateLimit } from "@/lib/upload-rate-limit";
 
@@ -54,7 +53,7 @@ export async function POST(request: NextRequest) {
     const { fileName, key, size, url } = validation.data;
     const contentType = normalizeContentType(validation.data.contentType);
     const keyPrefix = `uploads/${session.user.id}/`;
-    const expectedUrl = `${env.R2_PUBLIC_URL}/${key}`;
+    const expectedUrl = buildR2PublicUrl(key);
 
     if (!key.startsWith(keyPrefix)) {
       return NextResponse.json(

--- a/src/app/api/upload/server-upload/route.ts
+++ b/src/app/api/upload/server-upload/route.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/config/upload";
 import { getAuthSessionFromHeaders } from "@/lib/auth/session";
 import { checkUploadRateLimit } from "@/lib/upload-rate-limit";
+import { buildR2PublicUrl } from "@/lib/r2";
 
 // Initialize S3 client for Cloudflare R2
 const r2Client = new S3Client({
@@ -184,7 +185,7 @@ export async function POST(request: NextRequest) {
         await upload.done();
 
         // Generate public URL
-        const publicUrl = `${env.R2_PUBLIC_URL}/${key}`;
+        const publicUrl = buildR2PublicUrl(key);
 
         // Store upload record in database
         await db.insert(uploads).values({

--- a/src/lib/admin/stats.test.ts
+++ b/src/lib/admin/stats.test.ts
@@ -22,6 +22,7 @@ const mockDesc = jest.fn();
 const mockEq = jest.fn();
 const mockInArray = jest.fn();
 const mockGte = jest.fn();
+const mockSql = jest.fn();
 
 // Mock database tables
 const mockUsers = {
@@ -73,6 +74,7 @@ jest.mock("drizzle-orm", () => ({
   eq: mockEq,
   inArray: mockInArray,
   gte: mockGte,
+  sql: mockSql,
 }));
 
 describe("Admin Stats", () => {
@@ -102,6 +104,7 @@ describe("Admin Stats", () => {
     mockEq.mockReturnValue("column = value");
     mockInArray.mockReturnValue("column IN (values)");
     mockGte.mockReturnValue("column >= value");
+    mockSql.mockReturnValue("formatted_date");
     mockFormatFileSize.mockImplementation((size) => `${size} B`);
 
     // Mock default database responses
@@ -462,26 +465,14 @@ describe("Admin Stats", () => {
 
   describe("getAdminStatsWithCharts", () => {
     it("should fetch stats with chart data successfully", async () => {
-      const now = new Date();
       const mockUsers = [
-        { createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 24) }, // 1 day ago
-        { createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 24 * 2) }, // 2 days ago
-        { createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 24) }, // 1 day ago (duplicate date)
+        { date: "2026-05-28", count: 2 },
+        { date: "2026-05-27", count: 1 },
       ];
 
       const mockPayments = [
-        {
-          createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 24 * 30),
-          amount: 1000,
-        }, // 1 month ago
-        {
-          createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 24 * 60),
-          amount: 2000,
-        }, // 2 months ago
-        {
-          createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 24 * 30),
-          amount: 1500,
-        }, // 1 month ago (same month)
+        { month: "2026-04", revenue: "2500", count: 2 },
+        { month: "2026-03", revenue: "2000", count: 1 },
       ];
 
       // Mock basic stats calls (first 11 calls)
@@ -521,14 +512,18 @@ describe("Admin Stats", () => {
         {
           from: jest.fn().mockReturnValue({
             where: jest.fn().mockReturnValue({
-              orderBy: jest.fn().mockResolvedValue(mockUsers),
+              groupBy: jest.fn().mockReturnValue({
+                orderBy: jest.fn().mockResolvedValue(mockUsers),
+              }),
             }),
           }),
         },
         {
           from: jest.fn().mockReturnValue({
             where: jest.fn().mockReturnValue({
-              orderBy: jest.fn().mockResolvedValue(mockPayments),
+              groupBy: jest.fn().mockReturnValue({
+                orderBy: jest.fn().mockResolvedValue(mockPayments),
+              }),
             }),
           }),
         },
@@ -548,9 +543,11 @@ describe("Admin Stats", () => {
       expect(result.charts).toHaveProperty("recentUsers");
       expect(result.charts).toHaveProperty("monthlyRevenue");
 
-      // Test that chart data is processed correctly
-      expect(Array.isArray(result.charts.recentUsers)).toBe(true);
-      expect(Array.isArray(result.charts.monthlyRevenue)).toBe(true);
+      expect(result.charts.recentUsers).toEqual(mockUsers);
+      expect(result.charts.monthlyRevenue).toEqual([
+        { month: "2026-04", revenue: 2500, count: 2 },
+        { month: "2026-03", revenue: 2000, count: 1 },
+      ]);
     });
 
     it("should surface chart data errors", async () => {
@@ -589,14 +586,18 @@ describe("Admin Stats", () => {
         {
           from: jest.fn().mockReturnValue({
             where: jest.fn().mockReturnValue({
-              orderBy: jest.fn().mockRejectedValue(new Error("Chart error")),
+              groupBy: jest.fn().mockReturnValue({
+                orderBy: jest.fn().mockRejectedValue(new Error("Chart error")),
+              }),
             }),
           }),
         },
         {
           from: jest.fn().mockReturnValue({
             where: jest.fn().mockReturnValue({
-              orderBy: jest.fn().mockResolvedValue([]),
+              groupBy: jest.fn().mockReturnValue({
+                orderBy: jest.fn().mockResolvedValue([]),
+              }),
             }),
           }),
         },

--- a/src/lib/admin/stats.ts
+++ b/src/lib/admin/stats.ts
@@ -2,7 +2,7 @@
 import type { AdminStats } from "@/app/dashboard/admin/_components/admin-stats-cards";
 import { db } from "@/database";
 import { users, subscriptions, payments, uploads } from "@/database/schema";
-import { count, sum, desc, eq, inArray, gte } from "drizzle-orm";
+import { count, sum, desc, eq, inArray, gte, sql } from "drizzle-orm";
 import { formatFileSize } from "@/lib/config/upload";
 
 // Extended interface for chart data
@@ -130,54 +130,37 @@ export async function getAdminStatsWithCharts(): Promise<AdminStatsWithCharts> {
 
   const twelveMonthsAgo = new Date();
   twelveMonthsAgo.setMonth(twelveMonthsAgo.getMonth() - 12);
+  const userCreatedDate = sql<string>`to_char(${users.createdAt}, 'YYYY-MM-DD')`;
+  const paymentCreatedMonth = sql<string>`to_char(${payments.createdAt}, 'YYYY-MM')`;
 
-  const [basicStats, recentUsersRaw, monthlyRevenueRaw] = await Promise.all([
+  const [basicStats, recentUsersData, monthlyRevenueRaw] = await Promise.all([
     getAdminStats(),
     db
-      .select({ createdAt: users.createdAt })
+      .select({
+        date: userCreatedDate,
+        count: count(),
+      })
       .from(users)
       .where(gte(users.createdAt, thirtyDaysAgo))
-      .orderBy(desc(users.createdAt)),
+      .groupBy(userCreatedDate)
+      .orderBy(desc(userCreatedDate)),
     db
-      .select({ createdAt: payments.createdAt, amount: payments.amount })
+      .select({
+        month: paymentCreatedMonth,
+        revenue: sum(payments.amount),
+        count: count(),
+      })
       .from(payments)
       .where(gte(payments.createdAt, twelveMonthsAgo))
-      .orderBy(desc(payments.createdAt)),
+      .groupBy(paymentCreatedMonth)
+      .orderBy(desc(paymentCreatedMonth)),
   ]);
 
-  const userCountsByDate = recentUsersRaw.reduce(
-    (acc, user) => {
-      const date = user.createdAt.toISOString().split("T")[0];
-      acc[date] = (acc[date] || 0) + 1;
-      return acc;
-    },
-    {} as Record<string, number>,
-  );
-
-  const recentUsersData = Object.entries(userCountsByDate)
-    .map(([date, count]) => ({ date, count }))
-    .toSorted((a, b) => b.date.localeCompare(a.date));
-
-  const revenueByMonth = monthlyRevenueRaw.reduce(
-    (acc, payment) => {
-      const month = payment.createdAt.toISOString().substring(0, 7);
-      if (!acc[month]) {
-        acc[month] = { revenue: 0, count: 0 };
-      }
-      acc[month].revenue += Number(payment.amount);
-      acc[month].count += 1;
-      return acc;
-    },
-    {} as Record<string, { revenue: number; count: number }>,
-  );
-
-  const monthlyRevenueData = Object.entries(revenueByMonth)
-    .map(([month, data]) => ({
-      month,
-      revenue: data.revenue,
-      count: data.count,
-    }))
-    .toSorted((a, b) => b.month.localeCompare(a.month));
+  const monthlyRevenueData = monthlyRevenueRaw.map((data) => ({
+    month: data.month,
+    revenue: Number(data.revenue) || 0,
+    count: data.count,
+  }));
 
   return {
     ...basicStats,

--- a/src/lib/auth/session.test.ts
+++ b/src/lib/auth/session.test.ts
@@ -14,6 +14,7 @@ const VALID_SECRET =
 const originalEnv = {
   E2E_TEST_MODE: process.env.E2E_TEST_MODE,
   E2E_TEST_SECRET: process.env.E2E_TEST_SECRET,
+  PLAYWRIGHT: process.env.PLAYWRIGHT,
   NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
   NODE_ENV: process.env.NODE_ENV,
   VERCEL_ENV: process.env.VERCEL_ENV,
@@ -55,6 +56,7 @@ describe("E2E auth session helpers", () => {
   beforeEach(() => {
     process.env.E2E_TEST_MODE = "true";
     process.env.E2E_TEST_SECRET = VALID_SECRET;
+    process.env.PLAYWRIGHT = "true";
     process.env.NEXT_PUBLIC_APP_URL = "http://127.0.0.1:3100";
     delete process.env.VERCEL_ENV;
     setNodeEnv("test");
@@ -63,6 +65,7 @@ describe("E2E auth session helpers", () => {
   afterEach(() => {
     restoreEnvValue("E2E_TEST_MODE");
     restoreEnvValue("E2E_TEST_SECRET");
+    restoreEnvValue("PLAYWRIGHT");
     restoreEnvValue("NEXT_PUBLIC_APP_URL");
     restoreEnvValue("VERCEL_ENV");
     if (originalEnv.NODE_ENV === undefined) {
@@ -89,6 +92,12 @@ describe("E2E auth session helpers", () => {
   it("rejects E2E access for non-local production deployments", () => {
     setNodeEnv("production");
     process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+
+    expect(shouldAllowE2ETestAccess(VALID_SECRET)).toBe(false);
+  });
+
+  it("rejects E2E access outside Playwright", () => {
+    delete process.env.PLAYWRIGHT;
 
     expect(shouldAllowE2ETestAccess(VALID_SECRET)).toBe(false);
   });

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -83,6 +83,7 @@ export function getE2ETestSecret(): string | null {
 function isE2ETestModeEnabled(): boolean {
   return (
     process.env.E2E_TEST_MODE === "true" &&
+    process.env.PLAYWRIGHT === "true" &&
     !isProductionDeployment() &&
     getE2ETestSecret() !== null
   );

--- a/src/lib/fixed-window-rate-limit.test.ts
+++ b/src/lib/fixed-window-rate-limit.test.ts
@@ -1,0 +1,49 @@
+import { FixedWindowRateLimiter } from "./fixed-window-rate-limit";
+
+describe("FixedWindowRateLimiter", () => {
+  it("allows requests until the fixed window limit is reached", () => {
+    const limiter = new FixedWindowRateLimiter();
+
+    expect(
+      limiter.check({ key: "client", limit: 2, now: 1_000, windowMs: 60_000 }),
+    ).toMatchObject({
+      allowed: true,
+      remaining: 1,
+      resetAt: 61_000,
+      retryAfter: 0,
+    });
+    expect(
+      limiter.check({ key: "client", limit: 2, now: 2_000, windowMs: 60_000 }),
+    ).toMatchObject({
+      allowed: true,
+      remaining: 0,
+      resetAt: 61_000,
+      retryAfter: 0,
+    });
+    expect(
+      limiter.check({ key: "client", limit: 2, now: 3_000, windowMs: 60_000 }),
+    ).toMatchObject({
+      allowed: false,
+      remaining: 0,
+      resetAt: 61_000,
+      retryAfter: 58,
+    });
+  });
+
+  it("resets and cleans up expired buckets", () => {
+    const limiter = new FixedWindowRateLimiter();
+
+    limiter.check({ key: "expired", limit: 1, now: 1_000, windowMs: 1_000 });
+    expect(limiter.size()).toBe(1);
+
+    const result = limiter.check({
+      key: "fresh",
+      limit: 1,
+      now: 62_000,
+      windowMs: 1_000,
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(limiter.size()).toBe(1);
+  });
+});

--- a/src/lib/fixed-window-rate-limit.ts
+++ b/src/lib/fixed-window-rate-limit.ts
@@ -1,0 +1,92 @@
+type CheckFixedWindowRateLimitParams = {
+  key: string;
+  limit: number;
+  windowMs: number;
+  now?: number;
+};
+
+type FixedWindowBucket = {
+  count: number;
+  resetAt: number;
+};
+
+export type FixedWindowRateLimitResult = {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetAt: number;
+  retryAfter: number;
+};
+
+const CLEANUP_INTERVAL_MS = 60 * 1000;
+
+export class FixedWindowRateLimiter {
+  private readonly buckets = new Map<string, FixedWindowBucket>();
+  private nextCleanupAt = 0;
+
+  check({
+    key,
+    limit,
+    now = Date.now(),
+    windowMs,
+  }: CheckFixedWindowRateLimitParams): FixedWindowRateLimitResult {
+    this.cleanupExpiredBuckets(now);
+
+    const existing = this.buckets.get(key);
+    if (!existing || existing.resetAt <= now) {
+      const resetAt = now + windowMs;
+      this.buckets.set(key, { count: 1, resetAt });
+
+      return {
+        allowed: true,
+        limit,
+        remaining: Math.max(limit - 1, 0),
+        resetAt,
+        retryAfter: 0,
+      };
+    }
+
+    if (existing.count >= limit) {
+      return {
+        allowed: false,
+        limit,
+        remaining: 0,
+        resetAt: existing.resetAt,
+        retryAfter: Math.max(Math.ceil((existing.resetAt - now) / 1000), 1),
+      };
+    }
+
+    existing.count += 1;
+
+    return {
+      allowed: true,
+      limit,
+      remaining: Math.max(limit - existing.count, 0),
+      resetAt: existing.resetAt,
+      retryAfter: 0,
+    };
+  }
+
+  clear(): void {
+    this.buckets.clear();
+    this.nextCleanupAt = 0;
+  }
+
+  size(): number {
+    return this.buckets.size;
+  }
+
+  private cleanupExpiredBuckets(now: number): void {
+    if (now < this.nextCleanupAt) {
+      return;
+    }
+
+    for (const [key, bucket] of this.buckets) {
+      if (bucket.resetAt <= now) {
+        this.buckets.delete(key);
+      }
+    }
+
+    this.nextCleanupAt = now + CLEANUP_INTERVAL_MS;
+  }
+}

--- a/src/lib/r2.test.ts
+++ b/src/lib/r2.test.ts
@@ -105,6 +105,14 @@ describe("R2 Storage Functions", () => {
   });
 
   describe("createPresignedUrl", () => {
+    it("should normalize public URLs", async () => {
+      const { buildR2PublicUrl } = await import("./r2");
+
+      expect(
+        buildR2PublicUrl("/uploads/user-123/file.jpg", "https://cdn.test/"),
+      ).toBe("https://cdn.test/uploads/user-123/file.jpg");
+    });
+
     it("should create presigned URL with valid parameters", async () => {
       const { createPresignedUrl } = await import("./r2");
 

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -91,7 +91,7 @@ export async function createPresignedUrl({
     });
 
     // Generate public URL
-    const publicUrl = `${env.R2_PUBLIC_URL}/${key}`;
+    const publicUrl = buildR2PublicUrl(key);
 
     return {
       success: true,
@@ -118,6 +118,13 @@ interface UploadResult {
 export interface R2ObjectMetadata {
   contentLength: number;
   contentType: string;
+}
+
+export function buildR2PublicUrl(
+  key: string,
+  baseUrl = env.R2_PUBLIC_URL,
+): string {
+  return `${baseUrl.replace(/\/+$/, "")}/${key.replace(/^\/+/, "")}`;
 }
 
 const BLOCKED_URL_ERROR = "Blocked URL host";
@@ -295,7 +302,7 @@ export async function uploadBuffer(
 
     await r2Client.send(command);
 
-    const publicUrl = `${env.R2_PUBLIC_URL}/${key}`;
+    const publicUrl = buildR2PublicUrl(key);
 
     return {
       success: true,

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from "next/server";
+import { FixedWindowRateLimiter } from "@/lib/fixed-window-rate-limit";
 import type { RateLimitInfo } from "@/lib/machine-auth/types";
 
 export type RateLimitResult =
@@ -18,12 +19,7 @@ type CheckRateLimitParams = {
   windowMs: number;
 };
 
-type RateLimitBucket = {
-  count: number;
-  resetAt: number;
-};
-
-const buckets = new Map<string, RateLimitBucket>();
+const rateLimiter = new FixedWindowRateLimiter();
 
 function getBucketKey(scope: string, key: string): string {
   return `${scope}:${key}`;
@@ -35,43 +31,18 @@ export function checkRateLimit({
   scope,
   windowMs,
 }: CheckRateLimitParams): Promise<RateLimitResult> {
-  const now = Date.now();
-  const bucketKey = getBucketKey(scope, key);
-  const existing = buckets.get(bucketKey);
-
-  if (!existing || existing.resetAt <= now) {
-    const resetAt = now + windowMs;
-    buckets.set(bucketKey, { count: 1, resetAt });
-
-    return Promise.resolve({
-      allowed: true,
-      info: {
-        limit,
-        remaining: Math.max(limit - 1, 0),
-        resetAt: Math.ceil(resetAt / 1000),
-      },
-    });
-  }
-
-  if (existing.count >= limit) {
-    return Promise.resolve({
-      allowed: false,
-      info: {
-        limit,
-        remaining: 0,
-        resetAt: Math.ceil(existing.resetAt / 1000),
-      },
-    });
-  }
-
-  existing.count += 1;
+  const result = rateLimiter.check({
+    key: getBucketKey(scope, key),
+    limit,
+    windowMs,
+  });
 
   return Promise.resolve({
-    allowed: true,
+    allowed: result.allowed,
     info: {
-      limit,
-      remaining: Math.max(limit - existing.count, 0),
-      resetAt: Math.ceil(existing.resetAt / 1000),
+      limit: result.limit,
+      remaining: result.remaining,
+      resetAt: Math.ceil(result.resetAt / 1000),
     },
   });
 }
@@ -89,5 +60,5 @@ export function getClientRateLimitKey(request: NextRequest): string {
 }
 
 export function clearRateLimitForTests(): void {
-  buckets.clear();
+  rateLimiter.clear();
 }

--- a/src/lib/upload-rate-limit.ts
+++ b/src/lib/upload-rate-limit.ts
@@ -1,9 +1,5 @@
 import { UPLOAD_CONFIG } from "@/lib/config/upload";
-
-interface UploadRateLimitBucket {
-  count: number;
-  resetAt: number;
-}
+import { FixedWindowRateLimiter } from "@/lib/fixed-window-rate-limit";
 
 interface UploadRateLimitResult {
   allowed: boolean;
@@ -13,48 +9,16 @@ interface UploadRateLimitResult {
   retryAfter: number;
 }
 
-const buckets = new Map<string, UploadRateLimitBucket>();
+const uploadRateLimiter = new FixedWindowRateLimiter();
 
 export function checkUploadRateLimit(userId: string): UploadRateLimitResult {
-  const now = Date.now();
-  const windowMs = UPLOAD_CONFIG.USER_UPLOAD_RATE_LIMIT_WINDOW_MS;
-  const limit = UPLOAD_CONFIG.USER_UPLOAD_RATE_LIMIT_MAX_REQUESTS;
-  const existing = buckets.get(userId);
-
-  if (!existing || existing.resetAt <= now) {
-    const resetAt = now + windowMs;
-    buckets.set(userId, { count: 1, resetAt });
-
-    return {
-      allowed: true,
-      limit,
-      remaining: limit - 1,
-      resetAt,
-      retryAfter: 0,
-    };
-  }
-
-  if (existing.count >= limit) {
-    return {
-      allowed: false,
-      limit,
-      remaining: 0,
-      resetAt: existing.resetAt,
-      retryAfter: Math.ceil((existing.resetAt - now) / 1000),
-    };
-  }
-
-  existing.count += 1;
-
-  return {
-    allowed: true,
-    limit,
-    remaining: limit - existing.count,
-    resetAt: existing.resetAt,
-    retryAfter: 0,
-  };
+  return uploadRateLimiter.check({
+    key: userId,
+    limit: UPLOAD_CONFIG.USER_UPLOAD_RATE_LIMIT_MAX_REQUESTS,
+    windowMs: UPLOAD_CONFIG.USER_UPLOAD_RATE_LIMIT_WINDOW_MS,
+  });
 }
 
 export function clearUploadRateLimitForTests(): void {
-  buckets.clear();
+  uploadRateLimiter.clear();
 }


### PR DESCRIPTION
## Summary
- add a shared in-process fixed-window rate limiter with periodic expired-bucket cleanup
- tighten the E2E session route so it only works under explicit Playwright mode and E2E identities
- normalize R2 public URL joins across upload flows
- aggregate admin chart data in SQL instead of pulling raw rows into JS

## Verification
- pnpm content:build && pnpm exec jest --runTestsByPath src/lib/fixed-window-rate-limit.test.ts src/lib/upload-rate-limit.test.ts src/app/api/v1/device/code/route.test.ts src/app/api/payment-status/route.test.ts src/app/api/test/session/route.test.ts src/lib/auth/session.test.ts src/app/api/upload/complete/route.test.ts src/app/api/upload/server-upload/route.test.ts src/lib/r2.test.ts src/lib/admin/stats.test.ts --runInBand
- pnpm type-check
- pnpm lint
- pnpm test
- pnpm build

## Notes
- Rate limiting remains intentionally process-local for now; this PR only reduces duplication and stale bucket growth without adding Redis or database state.