### PR TITLE
Harden billing APIs and make Creem webhooks correct

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "content:build": "node scripts/build-content-collections.mjs",
     "dev": "pnpm content:build && next dev",
-    "build": "pnpm content:build && next build",
+    "build": "pnpm content:build && next build --webpack",
     "start": "next start",
     "saas-cli": "node --import tsx packages/cli/src/index.ts",
     "lint": "eslint .",
@@ -21,8 +21,8 @@
     "db:rebaseline": "node --env-file-if-exists=.env --import tsx scripts/rebaseline-drizzle.ts",
     "prettier:check": "prettier --check --ignore-path .gitignore .",
     "prettier:format": "prettier --write --ignore-path .gitignore .",
-    "analyze": "pnpm content:build && ANALYZE=true next build",
-    "analyze:dev": "pnpm content:build && ANALYZE=true next dev",
+    "analyze": "pnpm content:build && ANALYZE=true next build --webpack",
+    "analyze:dev": "pnpm content:build && ANALYZE=true next dev --webpack",
     "set:admin": "node --env-file-if-exists=.env --import tsx scripts/set-admin.ts",
     "creem:sync-products": "node --env-file-if-exists=.env --import tsx scripts/sync-creem-products.ts"
   },

--- a/src/app/api/billing/checkout/route.test.ts
+++ b/src/app/api/billing/checkout/route.test.ts
@@ -325,7 +325,7 @@ describe("Billing Checkout API", () => {
       expect(data.error).toContain("Failed to create checkout session");
     });
 
-    it("should handle request.json() failure", async () => {
+    it("should return 400 when request JSON is malformed", async () => {
       mockGetSession.mockResolvedValue(mockSession);
 
       const request = {
@@ -346,8 +346,8 @@ describe("Billing Checkout API", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      expect(response.status).toBe(500);
-      expect(data.error).toContain("Failed to create checkout session");
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("Invalid request body");
     });
 
     it("should validate checkoutSchema with all valid enum values", async () => {

--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
+    const body = await request.json().catch(() => null);
     const parsedBody = checkoutSchema.safeParse(body);
 
     if (!parsedBody.success) {

--- a/src/app/api/billing/portal/route.test.ts
+++ b/src/app/api/billing/portal/route.test.ts
@@ -181,7 +181,9 @@ describe("Billing Portal API", () => {
       const data = await response.json();
 
       expect(response.status).toBe(500);
-      expect(data.error).toBe("Auth service unavailable");
+      expect(data.error).toBe(
+        "Unable to open the billing portal. Please try again later.",
+      );
     });
 
     it("should handle getUserSubscription failure", async () => {
@@ -195,7 +197,9 @@ describe("Billing Portal API", () => {
       const data = await response.json();
 
       expect(response.status).toBe(500);
-      expect(data.error).toBe("Database error");
+      expect(data.error).toBe(
+        "Unable to open the billing portal. Please try again later.",
+      );
     });
 
     it("should handle billing.createCustomerPortalUrl failure", async () => {
@@ -215,7 +219,9 @@ describe("Billing Portal API", () => {
       const data = await response.json();
 
       expect(response.status).toBe(500);
-      expect(data.error).toBe("Billing service error");
+      expect(data.error).toBe(
+        "Unable to open the billing portal. Please try again later.",
+      );
     });
 
     it("should handle non-Error exceptions", async () => {
@@ -233,7 +239,9 @@ describe("Billing Portal API", () => {
       const data = await response.json();
 
       expect(response.status).toBe(500);
-      expect(data.error).toBe("Internal Server Error");
+      expect(data.error).toBe(
+        "Unable to open the billing portal. Please try again later.",
+      );
     });
 
     it("should call getUserSubscription with correct user ID", async () => {

--- a/src/app/api/billing/portal/route.ts
+++ b/src/app/api/billing/portal/route.ts
@@ -28,8 +28,9 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     console.error("[Portal API Error]", error);
-    const message =
-      error instanceof Error ? error.message : "Internal Server Error";
-    return NextResponse.json({ error: message }, { status: 500 });
+    return NextResponse.json(
+      { error: "Unable to open the billing portal. Please try again later." },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/api/billing/webhooks/creem/route.test.ts
+++ b/src/app/api/billing/webhooks/creem/route.test.ts
@@ -45,8 +45,22 @@ describe("Billing Webhooks Creem API", () => {
   });
 
   const createMockRequest = (payload: string): NextRequest => {
+    const encodedPayload = new TextEncoder().encode(payload);
+    let delivered = false;
+
     return {
-      text: jest.fn().mockResolvedValue(payload) as any,
+      body: {
+        getReader: () => ({
+          read: jest.fn(async () => {
+            if (delivered) {
+              return { done: true, value: undefined };
+            }
+            delivered = true;
+            return { done: false, value: encodedPayload };
+          }),
+          cancel: jest.fn(async () => undefined),
+        }),
+      },
       headers: {
         get: () => "",
         has: () => false,
@@ -129,6 +143,21 @@ describe("Billing Webhooks Creem API", () => {
       expect(data.error).toBe("Invalid signature.");
     });
 
+    it("should return 400 for a signed invalid webhook payload", async () => {
+      const payloadError = new Error("Invalid webhook payload.");
+      payloadError.name = "InvalidWebhookPayloadError";
+
+      mockHeadersList.get.mockReturnValue("valid-signature");
+      mockHandleWebhook.mockRejectedValue(payloadError);
+
+      const { POST } = await import("./route");
+      const response = await POST(createMockRequest("{invalid-json"));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("Invalid webhook payload");
+    });
+
     it("should handle other webhook errors with 500 status", async () => {
       const mockSignature = "valid-signature";
       const mockPayload = '{"event": "test"}';
@@ -145,7 +174,7 @@ describe("Billing Webhooks Creem API", () => {
       const data = await response.json();
 
       expect(response.status).toBe(500);
-      expect(data.error).toBe("Database connection failed");
+      expect(data.error).toBe("Webhook processing failed");
     });
 
     it("should handle non-Error exceptions with 500 status", async () => {
@@ -165,13 +194,18 @@ describe("Billing Webhooks Creem API", () => {
       expect(data.error).toBe("Webhook processing failed");
     });
 
-    it("should handle request.text() failure", async () => {
+    it("should handle request body read failure", async () => {
       mockHeadersList.get.mockReturnValue("valid-signature");
 
       const request = {
-        text: jest
-          .fn()
-          .mockRejectedValue(new Error("Failed to read request body")) as any,
+        body: {
+          getReader: () => ({
+            read: jest
+              .fn()
+              .mockRejectedValue(new Error("Failed to read request body")),
+            cancel: jest.fn(),
+          }),
+        },
         headers: {
           get: () => "",
           has: () => false,
@@ -189,7 +223,7 @@ describe("Billing Webhooks Creem API", () => {
       const data = await response.json();
 
       expect(response.status).toBe(500);
-      expect(data.error).toBe("Failed to read request body");
+      expect(data.error).toBe("Webhook processing failed");
     });
 
     it("should handle headers() function failure", async () => {
@@ -203,7 +237,7 @@ describe("Billing Webhooks Creem API", () => {
       const data = await response.json();
 
       expect(response.status).toBe(500);
-      expect(data.error).toBe("Headers not available");
+      expect(data.error).toBe("Webhook processing failed");
 
       // Restore headers mock
       mockHeaders.mockResolvedValue(mockHeadersList);
@@ -271,6 +305,23 @@ describe("Billing Webhooks Creem API", () => {
         mockPayload,
         mockSignature,
       );
+    });
+
+    it("should reject a payload larger than one megabyte", async () => {
+      mockHeadersList.get.mockReturnValue("signature-123");
+
+      const request = createMockRequest("small");
+      request.headers.get = jest.fn((name: string) =>
+        name === "content-length" ? String(1024 * 1024 + 1) : "",
+      );
+
+      const { POST } = await import("./route");
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(413);
+      expect(data.error).toBe("Webhook payload is too large");
+      expect(mockHandleWebhook).not.toHaveBeenCalled();
     });
 
     it("should return 500 when a non-signature error mentions signature", async () => {

--- a/src/app/api/billing/webhooks/creem/route.ts
+++ b/src/app/api/billing/webhooks/creem/route.ts
@@ -1,14 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { billing } from "@/lib/billing";
+import {
+  readTextBodyWithLimit,
+  RequestBodyTooLargeError,
+} from "@/lib/http/request-body";
+
+const MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
 
 function isCreemSignatureError(error: unknown) {
   return error instanceof Error && error.name === "CreemWebhookSignatureError";
 }
 
+function isInvalidWebhookPayloadError(error: unknown) {
+  return error instanceof Error && error.name === "InvalidWebhookPayloadError";
+}
+
 export async function POST(request: NextRequest) {
   try {
-    const payload = await request.text();
+    const payload = await readTextBodyWithLimit(
+      request,
+      MAX_WEBHOOK_BODY_BYTES,
+    );
     const headersList = await headers();
 
     const signature = headersList.get("creem-signature");
@@ -30,8 +43,30 @@ export async function POST(request: NextRequest) {
       error instanceof Error ? error.message : "Webhook processing failed";
     console.error(`[Creem Webhook Error]: ${message}`);
 
-    const status = isCreemSignatureError(error) ? 400 : 500;
+    if (error instanceof RequestBodyTooLargeError) {
+      return NextResponse.json(
+        { error: "Webhook payload is too large" },
+        { status: 413 },
+      );
+    }
 
-    return NextResponse.json({ error: message }, { status });
+    if (isCreemSignatureError(error)) {
+      return NextResponse.json(
+        { error: "Invalid signature." },
+        { status: 400 },
+      );
+    }
+
+    if (isInvalidWebhookPayloadError(error)) {
+      return NextResponse.json(
+        { error: "Invalid webhook payload" },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json(
+      { error: "Webhook processing failed" },
+      { status: 500 },
+    );
   }
 }

--- a/src/database/migrations/0002_gorgeous_spot.sql
+++ b/src/database/migrations/0002_gorgeous_spot.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "webhook_events" DROP CONSTRAINT "webhook_events_eventId_unique";--> statement-breakpoint
+DROP INDEX "webhook_events_eventId_idx";--> statement-breakpoint
+ALTER TABLE "subscriptions" ADD COLUMN "lastWebhookCreatedAt" timestamp;--> statement-breakpoint
+UPDATE "subscriptions" SET "lastWebhookCreatedAt" = "updatedAt" WHERE "lastWebhookCreatedAt" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "webhook_events_provider_eventId_unique" ON "webhook_events" USING btree ("provider","eventId");

--- a/src/database/migrations/meta/0002_snapshot.json
+++ b/src/database/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1299 @@
+{
+  "id": "40b777c1-0a31-42c0-97f3-a1b548c8f6b4",
+  "prevId": "f4140284-df00-452e-a0ab-28d293c85b1d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyPrefix": {
+          "name": "keyPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastFourChars": {
+          "name": "lastFourChars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rateLimit": {
+          "name": "rateLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestCountInWindow": {
+          "name": "requestCountInWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "windowStartedAt": {
+          "name": "windowStartedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_userId_idx": {
+          "name": "api_keys_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_keyHash_idx": {
+          "name": "api_keys_keyHash_idx",
+          "columns": [
+            {
+              "expression": "keyHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_userId_users_id_fk": {
+          "name": "api_keys_userId_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastFourChars": {
+          "name": "lastFourChars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshTokenHash": {
+          "name": "refreshTokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previousRefreshTokenHash": {
+          "name": "previousRefreshTokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshRotatedAt": {
+          "name": "refreshRotatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshExpiresAt": {
+          "name": "refreshExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceOs": {
+          "name": "deviceOs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceHostname": {
+          "name": "deviceHostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cliVersion": {
+          "name": "cliVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cli_tokens_userId_idx": {
+          "name": "cli_tokens_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_tokens_userId_users_id_fk": {
+          "name": "cli_tokens_userId_users_id_fk",
+          "tableFrom": "cli_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_tokenHash_unique": {
+          "name": "cli_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tokenHash"]
+        },
+        "cli_tokens_refreshTokenHash_unique": {
+          "name": "cli_tokens_refreshTokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refreshTokenHash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deviceCode": {
+          "name": "deviceCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCode": {
+          "name": "userCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "lastPolledAt": {
+          "name": "lastPolledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clientName": {
+          "name": "clientName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clientVersion": {
+          "name": "clientVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceOs": {
+          "name": "deviceOs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceHostname": {
+          "name": "deviceHostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_codes_expiresAt_idx": {
+          "name": "device_codes_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_userId_users_id_fk": {
+          "name": "device_codes_userId_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_deviceCode_unique": {
+          "name": "device_codes_deviceCode_unique",
+          "nullsNotDistinct": false,
+          "columns": ["deviceCode"]
+        },
+        "device_codes_userCode_unique": {
+          "name": "device_codes_userCode_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userCode"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paymentId": {
+          "name": "paymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paymentType": {
+          "name": "paymentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_userId_idx": {
+          "name": "payments_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_userId_users_id_fk": {
+          "name": "payments_userId_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payments_paymentId_unique": {
+          "name": "payments_paymentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["paymentId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonatedBy": {
+          "name": "impersonatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "productId": {
+          "name": "productId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastWebhookCreatedAt": {
+          "name": "lastWebhookCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_userId_idx": {
+          "name": "subscriptions_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_customerId_idx": {
+          "name": "subscriptions_customerId_idx",
+          "columns": [
+            {
+              "expression": "customerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_userId_users_id_fk": {
+          "name": "subscriptions_userId_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_subscriptionId_unique": {
+          "name": "subscriptions_subscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["subscriptionId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploads": {
+      "name": "uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileKey": {
+          "name": "fileKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uploads_userId_idx": {
+          "name": "uploads_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uploads_fileKey_idx": {
+          "name": "uploads_fileKey_idx",
+          "columns": [
+            {
+              "expression": "fileKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploads_userId_users_id_fk": {
+          "name": "uploads_userId_users_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentProviderCustomerId": {
+          "name": "paymentProviderCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_paymentProviderCustomerId_unique": {
+          "name": "users_paymentProviderCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["paymentProviderCustomerId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'creem'"
+        },
+        "processed": {
+          "name": "processed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_events_provider_eventId_unique": {
+          "name": "webhook_events_provider_eventId_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_events_provider_idx": {
+          "name": "webhook_events_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["user", "admin", "super_admin"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1773132563613,
       "tag": "0001_tense_bloodstorm",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1784825234413,
+      "tag": "0002_gorgeous_spot",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/schema.test.ts
+++ b/src/database/schema.test.ts
@@ -354,7 +354,7 @@ describe("Database Schema", () => {
     it("should have proper column constraints", () => {
       expect(webhookEvents.id.primary).toBe(true);
       expect(webhookEvents.eventId.notNull).toBe(true);
-      expect(webhookEvents.eventId.isUnique).toBe(true);
+      expect(webhookEvents.eventId.isUnique).toBe(false);
       expect(webhookEvents.eventType.notNull).toBe(true);
       expect(webhookEvents.provider.notNull).toBe(true);
       expect(webhookEvents.provider.default).toBe("creem");
@@ -517,8 +517,8 @@ describe("Database Schema", () => {
       // Payments should have unique paymentId
       expect(payments.paymentId.isUnique).toBe(true);
 
-      // Webhook events should have unique eventId
-      expect(webhookEvents.eventId.isUnique).toBe(true);
+      // Webhook event IDs are unique within a provider via a composite index
+      expect(webhookEvents.eventId.isUnique).toBe(false);
 
       // Payment provider customer ID should be unique
       expect(users.paymentProviderCustomerId.isUnique).toBe(true);
@@ -1313,7 +1313,7 @@ describe("Database Schema", () => {
       expect(sessions.token.isUnique).toBe(true);
       expect(subscriptions.subscriptionId.isUnique).toBe(true);
       expect(payments.paymentId.isUnique).toBe(true);
-      expect(webhookEvents.eventId.isUnique).toBe(true);
+      expect(webhookEvents.eventId.isUnique).toBe(false);
 
       // Test default values
       expect(users.role.default).toBe("user");
@@ -1494,15 +1494,20 @@ describe("Database Schema", () => {
       expect(indexNames).toContain("payments_userId_idx");
     });
 
-    it("webhook events table keeps eventId/provider indexes for idempotency", () => {
+    it("webhook events table keeps provider-scoped idempotency indexes", () => {
       const configs = getIndexConfigs(webhookEvents);
       const indexNames = configs.map((cfg) => cfg.name);
       expect(indexNames).toEqual(
         expect.arrayContaining([
-          "webhook_events_eventId_idx",
+          "webhook_events_provider_eventId_unique",
           "webhook_events_provider_idx",
         ]),
       );
+      expect(
+        configs.find(
+          (cfg) => cfg.name === "webhook_events_provider_eventId_unique",
+        )?.unique,
+      ).toBe(true);
     });
 
     it("uploads table indexes file ownership and key", () => {

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -6,6 +6,7 @@ import {
   boolean,
   uuid,
   index,
+  uniqueIndex,
   pgEnum,
 } from "drizzle-orm/pg-core";
 
@@ -182,6 +183,7 @@ export const subscriptions = pgTable(
     currentPeriodStart: timestamp("currentPeriodStart"),
     currentPeriodEnd: timestamp("currentPeriodEnd"),
     canceledAt: timestamp("canceledAt"),
+    lastWebhookCreatedAt: timestamp("lastWebhookCreatedAt"),
     createdAt: timestamp("createdAt").notNull().defaultNow(),
     updatedAt: timestamp("updatedAt").notNull().defaultNow(),
   },
@@ -224,7 +226,7 @@ export const webhookEvents = pgTable(
   "webhook_events",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    eventId: text("eventId").notNull().unique(), // Unique identifier from webhook provider
+    eventId: text("eventId").notNull(), // Unique identifier from webhook provider
     eventType: text("eventType").notNull(),
     provider: text("provider").notNull().default("creem"), // Support multiple providers
     processed: boolean("processed").notNull().default(true),
@@ -234,7 +236,9 @@ export const webhookEvents = pgTable(
   },
   (table) => {
     return {
-      eventIdIdx: index("webhook_events_eventId_idx").on(table.eventId),
+      providerEventIdUnique: uniqueIndex(
+        "webhook_events_provider_eventId_unique",
+      ).on(table.provider, table.eventId),
       providerIdx: index("webhook_events_provider_idx").on(table.provider),
     };
   },

--- a/src/lib/billing/creem/webhook.test.ts
+++ b/src/lib/billing/creem/webhook.test.ts
@@ -7,6 +7,17 @@ import {
   afterEach,
 } from "@jest/globals";
 
+let webhookSequence = 0;
+
+function createWebhookPayload(event: Record<string, unknown>): string {
+  webhookSequence += 1;
+  return JSON.stringify({
+    id: `evt_test_${webhookSequence}`,
+    created_at: 1_700_000_000 + webhookSequence,
+    ...event,
+  });
+}
+
 // Mock all external dependencies
 const mockDb = {
   transaction: jest.fn(),
@@ -22,7 +33,6 @@ const mockCreemWebhookSecret = "test-webhook-secret";
 const mockFindUserByCustomerId = jest.fn();
 const mockUpsertSubscription = jest.fn();
 const mockUpsertPayment = jest.fn();
-const mockIsWebhookEventProcessed = jest.fn();
 const mockRecordWebhookEvent = jest.fn();
 
 const mockGetProductTierByProductId = jest.fn();
@@ -53,7 +63,6 @@ jest.mock("@/lib/database/subscription", () => ({
   findUserByCustomerId: mockFindUserByCustomerId,
   upsertSubscription: mockUpsertSubscription,
   upsertPayment: mockUpsertPayment,
-  isWebhookEventProcessed: mockIsWebhookEventProcessed,
   recordWebhookEvent: mockRecordWebhookEvent,
 }));
 
@@ -72,6 +81,7 @@ describe("Creem Webhook Handler", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    webhookSequence = 0;
 
     // Suppress console.log, console.warn, console.error in tests
     jest.spyOn(console, "log").mockImplementation(() => {});
@@ -98,8 +108,7 @@ describe("Creem Webhook Handler", () => {
       return callback(mockTx);
     });
 
-    mockIsWebhookEventProcessed.mockResolvedValue(false);
-    mockRecordWebhookEvent.mockResolvedValue(undefined);
+    mockRecordWebhookEvent.mockResolvedValue(true);
     mockFindUserByCustomerId.mockResolvedValue({
       id: "user1",
       email: "test@example.com",
@@ -118,7 +127,8 @@ describe("Creem Webhook Handler", () => {
 
   describe("handleCreemWebhook", () => {
     it("should handle valid webhook with checkout.completed event", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
+        id: "evt_checkout_123",
         eventType: "checkout.completed",
         object: {
           id: "checkout_123",
@@ -149,13 +159,8 @@ describe("Creem Webhook Handler", () => {
       const result = await handleCreemWebhook(payload, "test-signature");
 
       expect(result).toEqual({ received: true });
-      expect(mockIsWebhookEventProcessed).toHaveBeenCalledWith(
-        "checkout_123_checkout.completed",
-        "creem",
-        expect.any(Object),
-      );
       expect(mockRecordWebhookEvent).toHaveBeenCalledWith(
-        "checkout_123_checkout.completed",
+        "evt_checkout_123",
         "checkout.completed",
         "creem",
         payload,
@@ -166,7 +171,7 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should handle payment.succeeded event", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "payment.succeeded",
         object: {
           id: "payment_123",
@@ -202,7 +207,7 @@ describe("Creem Webhook Handler", () => {
     it("should reject invalid signature", async () => {
       mockTimingSafeEqual.mockReturnValue(false);
 
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "checkout.completed",
         object: { id: "checkout_123" },
       });
@@ -215,10 +220,50 @@ describe("Creem Webhook Handler", () => {
       ).rejects.toThrow(CreemWebhookSignatureError);
     });
 
-    it("should handle duplicate webhook events", async () => {
-      mockIsWebhookEventProcessed.mockResolvedValue(true);
+    it("should reject malformed JSON after signature verification", async () => {
+      const { handleCreemWebhook, InvalidWebhookPayloadError } =
+        await import("./webhook");
 
+      await expect(
+        handleCreemWebhook("{invalid-json", "test-signature"),
+      ).rejects.toThrow(InvalidWebhookPayloadError);
+      expect(mockRecordWebhookEvent).not.toHaveBeenCalled();
+    });
+
+    it("should reject payloads without a provider event ID", async () => {
       const payload = JSON.stringify({
+        created_at: 1_700_000_000,
+        eventType: "subscription.update",
+        object: { id: "sub_123" },
+      });
+      const { handleCreemWebhook, InvalidWebhookPayloadError } =
+        await import("./webhook");
+
+      await expect(
+        handleCreemWebhook(payload, "test-signature"),
+      ).rejects.toThrow(InvalidWebhookPayloadError);
+      expect(mockRecordWebhookEvent).not.toHaveBeenCalled();
+    });
+
+    it("should reject recognized events with invalid object data", async () => {
+      const payload = createWebhookPayload({
+        eventType: "subscription.update",
+        object: { id: "sub_123" },
+      });
+      const { handleCreemWebhook, InvalidWebhookPayloadError } =
+        await import("./webhook");
+
+      await expect(
+        handleCreemWebhook(payload, "test-signature"),
+      ).rejects.toThrow(InvalidWebhookPayloadError);
+      expect(mockRecordWebhookEvent).toHaveBeenCalledTimes(1);
+      expect(mockUpsertSubscription).not.toHaveBeenCalled();
+    });
+
+    it("should handle duplicate webhook events", async () => {
+      mockRecordWebhookEvent.mockResolvedValue(false);
+
+      const payload = createWebhookPayload({
         eventType: "checkout.completed",
         object: { id: "checkout_123" },
       });
@@ -232,12 +277,54 @@ describe("Creem Webhook Handler", () => {
       expect(mockUpsertPayment).not.toHaveBeenCalled();
     });
 
+    it("should process distinct updates for the same subscription object", async () => {
+      const createPayload = (eventId: string, status: string) =>
+        createWebhookPayload({
+          id: eventId,
+          eventType: "subscription.update",
+          object: {
+            id: "sub_123",
+            customer: "cus_123",
+            product: "prod_123",
+            status,
+            current_period_start_date: "2024-01-01T00:00:00Z",
+            current_period_end_date: "2024-02-01T00:00:00Z",
+            canceled_at: null,
+          },
+        });
+
+      const { handleCreemWebhook } = await import("./webhook");
+      await handleCreemWebhook(createPayload("evt_update_1", "active"), "sig");
+      await handleCreemWebhook(
+        createPayload("evt_update_2", "past_due"),
+        "sig",
+      );
+
+      expect(mockRecordWebhookEvent).toHaveBeenNthCalledWith(
+        1,
+        "evt_update_1",
+        "subscription.update",
+        "creem",
+        expect.any(String),
+        expect.any(Object),
+      );
+      expect(mockRecordWebhookEvent).toHaveBeenNthCalledWith(
+        2,
+        "evt_update_2",
+        "subscription.update",
+        "creem",
+        expect.any(String),
+        expect.any(Object),
+      );
+      expect(mockUpsertSubscription).toHaveBeenCalledTimes(2);
+    });
+
     it("should handle error during signature verification", async () => {
       mockTimingSafeEqual.mockImplementation(() => {
         throw new Error("Buffer length mismatch");
       });
 
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "checkout.completed",
         object: { id: "checkout_123" },
       });
@@ -249,8 +336,9 @@ describe("Creem Webhook Handler", () => {
       ).rejects.toThrow("Invalid signature.");
     });
 
-    it("should handle subscription.active event", async () => {
-      const payload = JSON.stringify({
+    it("should handle millisecond timestamps on subscription.active", async () => {
+      const payload = createWebhookPayload({
+        created_at: 1_700_000_000_123,
         eventType: "subscription.active",
         object: {
           id: "sub_123",
@@ -274,13 +362,14 @@ describe("Creem Webhook Handler", () => {
           customerId: "cus_123",
           subscriptionId: "sub_123",
           status: "active",
+          lastWebhookCreatedAt: new Date(1_700_000_000_123),
         }),
         expect.any(Object),
       );
     });
 
     it("should handle subscription renewal with payment object", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "payment.succeeded",
         object: {
           id: "payment_123",
@@ -321,8 +410,40 @@ describe("Creem Webhook Handler", () => {
       );
     });
 
+    it("should reject invalid renewal period timestamps", async () => {
+      const payload = createWebhookPayload({
+        eventType: "payment.succeeded",
+        object: {
+          id: "payment_123",
+          customer: "cus_123",
+          subscription_id: "sub_123",
+          product_id: "prod_123",
+          amount: 1000,
+          currency: "usd",
+          billing_reason: "subscription_cycle",
+          lines: {
+            data: [
+              {
+                period: {
+                  start: "invalid",
+                  end: "invalid",
+                },
+              },
+            ],
+          },
+        },
+      });
+      const { handleCreemWebhook, InvalidWebhookPayloadError } =
+        await import("./webhook");
+
+      await expect(
+        handleCreemWebhook(payload, "test-signature"),
+      ).rejects.toThrow(InvalidWebhookPayloadError);
+      expect(mockUpsertSubscription).not.toHaveBeenCalled();
+    });
+
     it("should handle one_time payment in checkout.completed", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "checkout.completed",
         object: {
           id: "checkout_123",
@@ -359,9 +480,9 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should skip already processed events", async () => {
-      mockIsWebhookEventProcessed.mockResolvedValue(true);
+      mockRecordWebhookEvent.mockResolvedValue(false);
 
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "checkout.completed",
         object: {
           id: "checkout_123",
@@ -378,7 +499,7 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should ignore unhandled event types", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "unhandled.event",
         object: {
           id: "obj_123",
@@ -397,7 +518,7 @@ describe("Creem Webhook Handler", () => {
     it("should throw error for invalid signature", async () => {
       mockTimingSafeEqual.mockReturnValue(false);
 
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "checkout.completed",
         object: { id: "checkout_123" },
       });
@@ -418,7 +539,7 @@ describe("Creem Webhook Handler", () => {
         throw new Error("Buffer length mismatch");
       });
 
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "checkout.completed",
         object: { id: "checkout_123" },
       });
@@ -432,7 +553,7 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should handle missing customer field in checkout", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "checkout.completed",
         object: {
           id: "checkout_123",
@@ -460,7 +581,7 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should handle missing userId in metadata", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "checkout.completed",
         object: {
           id: "checkout_123",
@@ -487,7 +608,7 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should handle customer as object instead of string", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "subscription.active",
         object: {
           id: "sub_123",
@@ -511,7 +632,7 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should handle product as object in subscription events", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "subscription.active",
         object: {
           id: "sub_123",
@@ -534,7 +655,7 @@ describe("Creem Webhook Handler", () => {
     it("should handle user not found error in subscription events", async () => {
       mockFindUserByCustomerId.mockResolvedValue(null);
 
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "subscription.active",
         object: {
           id: "sub_123",
@@ -558,7 +679,7 @@ describe("Creem Webhook Handler", () => {
     it("should handle missing subscription ID in renewal event", async () => {
       // This event should trigger subscription ID missing error
       // Create a payment object that will be identified as payment object but missing both subscription_id and id
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "subscription.paid",
         object: {
           id: "", // Empty ID so that renewalData.id is falsy
@@ -570,15 +691,16 @@ describe("Creem Webhook Handler", () => {
         },
       });
 
-      const { handleCreemWebhook } = await import("./webhook");
+      const { handleCreemWebhook, InvalidWebhookPayloadError } =
+        await import("./webhook");
 
       await expect(
         handleCreemWebhook(payload, "test-signature"),
-      ).rejects.toThrow("Subscription ID missing in renewal event");
+      ).rejects.toThrow(InvalidWebhookPayloadError);
     });
 
     it("should handle missing product ID in payment event", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "payment.succeeded",
         object: {
           id: "payment_123",
@@ -597,7 +719,7 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should handle unsupported payment mode in checkout", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "checkout.completed",
         object: {
           id: "checkout_123",
@@ -623,7 +745,7 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should handle subscription.paid event with subscription object", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "subscription.paid",
         object: {
           id: "sub_123",
@@ -649,41 +771,25 @@ describe("Creem Webhook Handler", () => {
       );
     });
 
-    it("should use fallback values for missing payment data", async () => {
-      // When undefined values are JSON.stringify'd, they get removed from the object
-      // So we need to use null or just have the key present to pass isPaymentObject check
-      const payload = JSON.stringify({
+    it("should reject payment events without a numeric amount", async () => {
+      const payload = createWebhookPayload({
         eventType: "payment.succeeded",
         object: {
           id: "payment_123",
           customer: "cus_123",
-          product_id: "prod_123", // Need product_id to avoid error
-          // Include amount field but set to null to trigger fallback
-          amount: null, // This makes it a payment object but triggers fallback to 0
-          // Missing currency field to trigger fallback to "usd"
+          product_id: "prod_123",
+          amount: null,
           subscription_id: "sub_123",
-          // Explicitly not setting billing_reason so it goes to processPaymentSucceededEvent
-          // If billing_reason was "subscription_cycle", it would go to processSubscriptionRenewal instead
         },
       });
 
-      // Reset the mock calls count for this specific test
-      mockUpsertPayment.mockClear();
-      mockUpsertSubscription.mockClear();
+      const { handleCreemWebhook, InvalidWebhookPayloadError } =
+        await import("./webhook");
 
-      const { handleCreemWebhook } = await import("./webhook");
-
-      const result = await handleCreemWebhook(payload, "test-signature");
-
-      expect(result).toEqual({ received: true });
-
-      expect(mockUpsertPayment).toHaveBeenCalledWith(
-        expect.objectContaining({
-          amount: 0, // fallback value for missing amount (paymentData.amount ?? paymentData.amount_paid ?? 0)
-          currency: "usd", // fallback value for missing currency (paymentData.currency ?? "usd")
-        }),
-        expect.any(Object),
-      );
+      await expect(
+        handleCreemWebhook(payload, "test-signature"),
+      ).rejects.toThrow(InvalidWebhookPayloadError);
+      expect(mockUpsertPayment).not.toHaveBeenCalled();
     });
   });
 
@@ -691,7 +797,7 @@ describe("Creem Webhook Handler", () => {
     it("should correctly identify checkout objects", async () => {
       // We need to test the internal type guards, but they're not exported
       // So we test indirectly through webhook handling
-      const checkoutPayload = JSON.stringify({
+      const checkoutPayload = createWebhookPayload({
         eventType: "checkout.completed",
         object: {
           id: "checkout_123",
@@ -716,7 +822,7 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should correctly identify subscription objects", async () => {
-      const subscriptionPayload = JSON.stringify({
+      const subscriptionPayload = createWebhookPayload({
         eventType: "subscription.active",
         object: {
           id: "sub_123",
@@ -738,7 +844,7 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should correctly identify payment objects", async () => {
-      const paymentPayload = JSON.stringify({
+      const paymentPayload = createWebhookPayload({
         eventType: "payment.succeeded",
         object: {
           id: "payment_123",
@@ -782,8 +888,7 @@ describe("Creem Webhook Handler", () => {
         id: "user-123",
         paymentProviderCustomerId: "cus_123",
       });
-      mockIsWebhookEventProcessed.mockResolvedValue(false);
-      mockRecordWebhookEvent.mockResolvedValue(undefined);
+      mockRecordWebhookEvent.mockResolvedValue(true);
       mockGetProductTierByProductId.mockResolvedValue("pro");
       mockTimingSafeEqual.mockReturnValue(true);
       mockCreateHmacFunction.mockReturnValue({
@@ -799,7 +904,7 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should handle missing customer field error", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "payment.succeeded",
         object: {
           id: "payment_123",
@@ -809,13 +914,12 @@ describe("Creem Webhook Handler", () => {
         },
       });
 
-      const { handleCreemWebhook } = await import("./webhook");
+      const { handleCreemWebhook, InvalidWebhookPayloadError } =
+        await import("./webhook");
 
       await expect(
         handleCreemWebhook(payload, "test-signature"),
-      ).rejects.toThrow(
-        "Customer field is missing in the webhook event object.",
-      );
+      ).rejects.toThrow(InvalidWebhookPayloadError);
     });
 
     it("should handle missing webhook secret configuration", async () => {
@@ -828,7 +932,7 @@ describe("Creem Webhook Handler", () => {
       // Test that specifically covers line 293 in webhook.ts
       mockFindUserByCustomerId.mockResolvedValue(null);
 
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "subscription.paid",
         object: {
           id: "payment_123",
@@ -863,7 +967,7 @@ describe("Creem Webhook Handler", () => {
     it("should handle user not found error in payment processing", async () => {
       mockFindUserByCustomerId.mockResolvedValue(null);
 
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "payment.succeeded",
         object: {
           id: "payment_123",
@@ -883,7 +987,7 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should handle period determination error in subscription renewal", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "subscription.paid",
         object: {
           id: "payment_123",
@@ -905,7 +1009,7 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should handle missing customer field with undefined value", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "payment.succeeded",
         object: {
           id: "payment_123",
@@ -915,17 +1019,16 @@ describe("Creem Webhook Handler", () => {
         },
       });
 
-      const { handleCreemWebhook } = await import("./webhook");
+      const { handleCreemWebhook, InvalidWebhookPayloadError } =
+        await import("./webhook");
 
       await expect(
         handleCreemWebhook(payload, "test-signature"),
-      ).rejects.toThrow(
-        "Customer field is missing in the webhook event object.",
-      );
+      ).rejects.toThrow(InvalidWebhookPayloadError);
     });
 
     it("should handle object customer field as object", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "payment.succeeded",
         object: {
           id: "payment_123",
@@ -946,7 +1049,7 @@ describe("Creem Webhook Handler", () => {
     });
 
     it("should handle missing customer field with empty object", async () => {
-      const payload = JSON.stringify({
+      const payload = createWebhookPayload({
         eventType: "payment.succeeded",
         object: {
           id: "payment_123",
@@ -956,16 +1059,13 @@ describe("Creem Webhook Handler", () => {
         },
       });
 
-      const { handleCreemWebhook } = await import("./webhook");
+      const { handleCreemWebhook, InvalidWebhookPayloadError } =
+        await import("./webhook");
 
-      // The code handles this case gracefully - empty object results in undefined customer ID
-      // which gets passed through. The findUserByCustomerId will be called with undefined
-      const result = await handleCreemWebhook(payload, "test-signature");
-      expect(result).toEqual({ received: true });
-      expect(mockFindUserByCustomerId).toHaveBeenCalledWith(
-        undefined,
-        expect.any(Object),
-      );
+      await expect(
+        handleCreemWebhook(payload, "test-signature"),
+      ).rejects.toThrow(InvalidWebhookPayloadError);
+      expect(mockFindUserByCustomerId).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/billing/creem/webhook.ts
+++ b/src/lib/billing/creem/webhook.ts
@@ -5,6 +5,7 @@ import type {
   CreemCheckoutObject,
   CreemSubscriptionObject,
   CreemPaymentObject,
+  SubscriptionStatus,
 } from "@/types/billing";
 import { db } from "@/database";
 import { users } from "@/database/schema";
@@ -13,7 +14,6 @@ import {
   findUserByCustomerId,
   upsertSubscription,
   upsertPayment,
-  isWebhookEventProcessed,
   recordWebhookEvent,
 } from "@/lib/database/subscription";
 import type { Tx } from "@/lib/database/subscription";
@@ -28,29 +28,187 @@ export class CreemWebhookSignatureError extends Error {
   }
 }
 
+export class InvalidWebhookPayloadError extends Error {
+  constructor(message = "Invalid webhook payload.") {
+    super(message);
+    this.name = "InvalidWebhookPayloadError";
+  }
+}
+
 function getCustomerId(
   customerField: string | { id: string } | undefined,
 ): string {
-  if (!customerField) {
-    throw new Error("Customer field is missing in the webhook event object.");
+  if (
+    !customerField ||
+    (typeof customerField === "string" && customerField.trim().length === 0) ||
+    (typeof customerField === "object" &&
+      (typeof customerField.id !== "string" ||
+        customerField.id.trim().length === 0))
+  ) {
+    throw new InvalidWebhookPayloadError(
+      "Customer field is missing in the webhook event object.",
+    );
   }
   return typeof customerField === "string" ? customerField : customerField.id;
 }
 
 function isCheckoutObject(obj: unknown): obj is CreemCheckoutObject {
-  return typeof obj === "object" && obj !== null && "order" in obj;
-}
-function isSubscriptionObject(obj: unknown): obj is CreemSubscriptionObject {
+  if (typeof obj !== "object" || obj === null || !("order" in obj)) {
+    return false;
+  }
+
+  const order = (obj as { order?: unknown }).order;
+  const subscription = (obj as { subscription?: unknown }).subscription;
   return (
-    typeof obj === "object" && obj !== null && "current_period_end_date" in obj
+    typeof order === "object" &&
+    order !== null &&
+    typeof (order as { id?: unknown }).id === "string" &&
+    typeof (order as { transaction?: unknown }).transaction === "string" &&
+    typeof (order as { amount_due?: unknown }).amount_due === "number" &&
+    typeof (order as { currency?: unknown }).currency === "string" &&
+    (subscription == null || isCheckoutSubscriptionObject(subscription))
   );
 }
+
+const subscriptionStatuses = new Set<SubscriptionStatus>([
+  "active",
+  "canceled",
+  "past_due",
+  "unpaid",
+  "paused",
+  "scheduled_cancel",
+  "trialing",
+  "incomplete",
+]);
+
+function isIdReference(value: unknown): value is string | { id: string } {
+  return (
+    (typeof value === "string" && value.trim().length > 0) ||
+    (typeof value === "object" &&
+      value !== null &&
+      typeof (value as { id?: unknown }).id === "string" &&
+      (value as { id: string }).id.trim().length > 0)
+  );
+}
+
+function isSubscriptionObject(obj: unknown): obj is CreemSubscriptionObject {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    isIdReference((obj as { customer?: unknown }).customer) &&
+    isIdReference((obj as { product?: unknown }).product) &&
+    typeof (obj as { status?: unknown }).status === "string" &&
+    subscriptionStatuses.has((obj as { status: SubscriptionStatus }).status)
+  );
+}
+
+function isCheckoutSubscriptionObject(
+  obj: unknown,
+): obj is CreemSubscriptionObject {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    typeof (obj as { id?: unknown }).id === "string" &&
+    isIdReference((obj as { product?: unknown }).product) &&
+    typeof (obj as { status?: unknown }).status === "string" &&
+    subscriptionStatuses.has((obj as { status: SubscriptionStatus }).status)
+  );
+}
+
 function isPaymentObject(obj: unknown): obj is CreemPaymentObject {
   return (
     typeof obj === "object" &&
     obj !== null &&
-    ("amount" in obj || "amount_paid" in obj)
+    isIdReference((obj as { customer?: unknown }).customer) &&
+    (typeof (obj as { amount?: unknown }).amount === "number" ||
+      typeof (obj as { amount_paid?: unknown }).amount_paid === "number")
   );
+}
+
+function parseCreemWebhookPayload(payload: string): CreemWebhookPayload {
+  let event: unknown;
+  try {
+    event = JSON.parse(payload);
+  } catch {
+    throw new InvalidWebhookPayloadError();
+  }
+
+  if (!event || typeof event !== "object") {
+    throw new InvalidWebhookPayloadError();
+  }
+
+  const candidate = event as Partial<CreemWebhookPayload>;
+  if (
+    typeof candidate.id !== "string" ||
+    candidate.id.trim().length === 0 ||
+    typeof candidate.eventType !== "string" ||
+    typeof candidate.created_at !== "number" ||
+    !Number.isFinite(candidate.created_at) ||
+    !candidate.object ||
+    typeof candidate.object !== "object" ||
+    typeof candidate.object.id !== "string" ||
+    candidate.object.id.trim().length === 0
+  ) {
+    throw new InvalidWebhookPayloadError();
+  }
+
+  return candidate as CreemWebhookPayload;
+}
+
+function toWebhookCreatedAt(timestamp: number): Date {
+  // Creem sends Unix milliseconds; accept seconds for older integrations.
+  const milliseconds =
+    timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp;
+  const createdAt = new Date(milliseconds);
+  if (Number.isNaN(createdAt.getTime())) {
+    throw new InvalidWebhookPayloadError();
+  }
+  return createdAt;
+}
+
+function invalidEventObject(eventType: string): never {
+  throw new InvalidWebhookPayloadError(
+    `Invalid object for Creem webhook event type ${eventType}.`,
+  );
+}
+
+function parseWebhookDate(value: unknown, fieldName: string): Date {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new InvalidWebhookPayloadError(
+      `Invalid ${fieldName} in Creem webhook payload.`,
+    );
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new InvalidWebhookPayloadError(
+      `Invalid ${fieldName} in Creem webhook payload.`,
+    );
+  }
+  return date;
+}
+
+function parseOptionalWebhookDate(
+  value: unknown,
+  fieldName: string,
+): Date | undefined {
+  return value === undefined ? undefined : parseWebhookDate(value, fieldName);
+}
+
+function parseUnixSecondsDate(value: unknown, fieldName: string): Date {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new InvalidWebhookPayloadError(
+      `Invalid ${fieldName} in Creem webhook payload.`,
+    );
+  }
+
+  const date = new Date(value * 1000);
+  if (Number.isNaN(date.getTime())) {
+    throw new InvalidWebhookPayloadError(
+      `Invalid ${fieldName} in Creem webhook payload.`,
+    );
+  }
+  return date;
 }
 
 function verifyCreemSignature(
@@ -88,58 +246,69 @@ export async function handleCreemWebhook(payload: string, signature: string) {
     throw new CreemWebhookSignatureError();
   }
 
-  const event: CreemWebhookPayload = JSON.parse(payload);
+  const event = parseCreemWebhookPayload(payload);
   console.log(`Received valid Creem webhook: ${event.eventType}`);
 
-  // Generate a unique event ID for idempotency
-  // Use event object ID + event type as the unique identifier
-  const eventId = `${event.object.id}_${event.eventType}`;
+  const eventId = event.id.trim();
+  const eventCreatedAt = toWebhookCreatedAt(event.created_at);
 
   await db.transaction(async (tx) => {
-    // Check if this event has already been processed
-    const alreadyProcessed = await isWebhookEventProcessed(
+    // Claim the event atomically. A conflicting insert means another request
+    // already owns or completed the same event.
+    const claimed = await recordWebhookEvent(
       eventId,
+      event.eventType,
       "creem",
+      payload,
       tx,
     );
-    if (alreadyProcessed) {
+    if (!claimed) {
       console.log(`Webhook event ${eventId} already processed, skipping.`);
       return;
     }
 
-    // Record the event as being processed (before actual processing to prevent race conditions)
-    await recordWebhookEvent(eventId, event.eventType, "creem", payload, tx);
-
     const eventObject = event.object;
     switch (event.eventType) {
       case "checkout.completed":
-        if (isCheckoutObject(eventObject))
-          await processCheckoutCompletedEvent(eventObject, tx);
+        if (!isCheckoutObject(eventObject)) {
+          invalidEventObject(event.eventType);
+        }
+        await processCheckoutCompletedEvent(eventObject, eventCreatedAt, tx);
         break;
       case "payment.succeeded":
-        if (
-          isPaymentObject(eventObject) &&
-          eventObject.billing_reason === "subscription_cycle"
-        ) {
-          await processSubscriptionRenewal(eventObject, tx);
-        } else if (isPaymentObject(eventObject)) {
+        if (!isPaymentObject(eventObject)) {
+          invalidEventObject(event.eventType);
+        }
+        if (eventObject.billing_reason === "subscription_cycle") {
+          await processSubscriptionRenewal(eventObject, eventCreatedAt, tx);
+        } else {
           await processPaymentSucceededEvent(eventObject, tx);
         }
         break;
 
       case "subscription.active":
-      case "subscription.updated":
+      case "subscription.trialing":
+      case "subscription.update":
       case "subscription.canceled":
+      case "subscription.scheduled_cancel":
       case "subscription.expired":
+      case "subscription.unpaid":
       case "subscription.past_due":
-        if (isSubscriptionObject(eventObject))
-          await processSubscriptionEvent(eventObject, tx);
+      case "subscription.paused":
+        if (!isSubscriptionObject(eventObject)) {
+          invalidEventObject(event.eventType);
+        }
+        await processSubscriptionEvent(eventObject, eventCreatedAt, tx);
         break;
 
       case "subscription.paid":
-        if (isSubscriptionObject(eventObject) || isPaymentObject(eventObject)) {
-          await processSubscriptionRenewal(eventObject, tx);
+        if (
+          !isSubscriptionObject(eventObject) &&
+          !isPaymentObject(eventObject)
+        ) {
+          invalidEventObject(event.eventType);
         }
+        await processSubscriptionRenewal(eventObject, eventCreatedAt, tx);
         break;
       default:
         console.log(
@@ -153,6 +322,7 @@ export async function handleCreemWebhook(payload: string, signature: string) {
 
 async function processCheckoutCompletedEvent(
   checkoutData: CreemCheckoutObject,
+  eventCreatedAt: Date,
   tx: Tx,
 ) {
   const {
@@ -162,13 +332,13 @@ async function processCheckoutCompletedEvent(
     order,
   } = checkoutData;
   if (!customerField || !order) {
-    throw new Error(
+    throw new InvalidWebhookPayloadError(
       "checkout.completed event is missing required data objects (customer or order).",
     );
   }
   const userId = metadata?.userId as string | undefined;
   if (!userId) {
-    throw new Error(
+    throw new InvalidWebhookPayloadError(
       `userId not found in metadata for checkout ${checkoutData.id}`,
     );
   }
@@ -196,11 +366,24 @@ async function processCheckoutCompletedEvent(
         subscriptionId: subscription.id,
         productId: tier?.id || productId,
         status: subscription.status,
-        currentPeriodStart: new Date(subscription.current_period_start_date),
-        currentPeriodEnd: new Date(subscription.current_period_end_date),
-        canceledAt: subscription.canceled_at
-          ? new Date(subscription.canceled_at)
-          : null,
+        currentPeriodStart: parseOptionalWebhookDate(
+          subscription.current_period_start_date,
+          "subscription.current_period_start_date",
+        ),
+        currentPeriodEnd: parseOptionalWebhookDate(
+          subscription.current_period_end_date,
+          "subscription.current_period_end_date",
+        ),
+        canceledAt:
+          subscription.canceled_at === undefined
+            ? undefined
+            : subscription.canceled_at
+              ? parseWebhookDate(
+                  subscription.canceled_at,
+                  "subscription.canceled_at",
+                )
+              : null,
+        lastWebhookCreatedAt: eventCreatedAt,
       },
       tx,
     );
@@ -242,7 +425,7 @@ async function processCheckoutCompletedEvent(
       tx,
     );
   } else {
-    throw new Error(
+    throw new InvalidWebhookPayloadError(
       `Unsupported payment mode: ${paymentMode} or missing subscription data for subscription mode`,
     );
   }
@@ -250,6 +433,7 @@ async function processCheckoutCompletedEvent(
 
 async function processSubscriptionEvent(
   subscriptionData: CreemSubscriptionObject,
+  eventCreatedAt: Date,
   tx: Tx,
 ) {
   const customerId = getCustomerId(subscriptionData.customer);
@@ -272,11 +456,24 @@ async function processSubscriptionEvent(
       subscriptionId: subscriptionData.id,
       productId: tier?.id || productId,
       status: subscriptionData.status,
-      currentPeriodStart: new Date(subscriptionData.current_period_start_date),
-      currentPeriodEnd: new Date(subscriptionData.current_period_end_date),
-      canceledAt: subscriptionData.canceled_at
-        ? new Date(subscriptionData.canceled_at)
-        : null,
+      currentPeriodStart: parseOptionalWebhookDate(
+        subscriptionData.current_period_start_date,
+        "subscription.current_period_start_date",
+      ),
+      currentPeriodEnd: parseOptionalWebhookDate(
+        subscriptionData.current_period_end_date,
+        "subscription.current_period_end_date",
+      ),
+      canceledAt:
+        subscriptionData.canceled_at === undefined
+          ? undefined
+          : subscriptionData.canceled_at
+            ? parseWebhookDate(
+                subscriptionData.canceled_at,
+                "subscription.canceled_at",
+              )
+            : null,
+      lastWebhookCreatedAt: eventCreatedAt,
     },
     tx,
   );
@@ -284,6 +481,7 @@ async function processSubscriptionEvent(
 
 async function processSubscriptionRenewal(
   renewalData: CreemPaymentObject | CreemSubscriptionObject,
+  eventCreatedAt: Date,
   tx: Tx,
 ) {
   const customerId = getCustomerId(renewalData.customer);
@@ -293,7 +491,9 @@ async function processSubscriptionRenewal(
       : renewalData.id;
 
   if (!subscriptionId)
-    throw new Error("Subscription ID missing in renewal event");
+    throw new InvalidWebhookPayloadError(
+      "Subscription ID missing in renewal event",
+    );
 
   const user = await findUserByCustomerId(customerId, tx);
   if (!user)
@@ -301,20 +501,37 @@ async function processSubscriptionRenewal(
       `User not found for customerId ${customerId} during subscription renewal.`,
     );
 
-  let periodStartDateStr: string, periodEndDateStr: string;
+  let currentPeriodStart: Date;
+  let currentPeriodEnd: Date;
 
   if (isPaymentObject(renewalData) && renewalData.lines?.data?.[0]?.period) {
-    periodStartDateStr = new Date(
-      renewalData.lines.data[0].period.start * 1000,
-    ).toISOString();
-    periodEndDateStr = new Date(
-      renewalData.lines.data[0].period.end * 1000,
-    ).toISOString();
+    currentPeriodStart = parseUnixSecondsDate(
+      renewalData.lines.data[0].period.start,
+      "payment.lines[0].period.start",
+    );
+    currentPeriodEnd = parseUnixSecondsDate(
+      renewalData.lines.data[0].period.end,
+      "payment.lines[0].period.end",
+    );
   } else if (isSubscriptionObject(renewalData)) {
-    periodStartDateStr = renewalData.current_period_start_date;
-    periodEndDateStr = renewalData.current_period_end_date;
+    if (
+      !renewalData.current_period_start_date ||
+      !renewalData.current_period_end_date
+    ) {
+      throw new InvalidWebhookPayloadError(
+        "Subscription renewal is missing its billing period.",
+      );
+    }
+    currentPeriodStart = parseWebhookDate(
+      renewalData.current_period_start_date,
+      "subscription.current_period_start_date",
+    );
+    currentPeriodEnd = parseWebhookDate(
+      renewalData.current_period_end_date,
+      "subscription.current_period_end_date",
+    );
   } else {
-    throw new Error(
+    throw new InvalidWebhookPayloadError(
       "Could not determine new period for subscription renewal from event object.",
     );
   }
@@ -331,7 +548,8 @@ async function processSubscriptionRenewal(
         ? renewalData.product
         : renewalData.product.id;
   }
-  if (!productId) throw new Error("Product ID missing in renewal event");
+  if (!productId)
+    throw new InvalidWebhookPayloadError("Product ID missing in renewal event");
 
   const tier = getProductTierByProductId(productId);
 
@@ -342,9 +560,10 @@ async function processSubscriptionRenewal(
       subscriptionId,
       productId: tier?.id || productId,
       status: "active",
-      currentPeriodStart: new Date(periodStartDateStr),
-      currentPeriodEnd: new Date(periodEndDateStr),
+      currentPeriodStart,
+      currentPeriodEnd,
       canceledAt: null,
+      lastWebhookCreatedAt: eventCreatedAt,
     },
     tx,
   );
@@ -367,7 +586,8 @@ async function processPaymentSucceededEvent(
 
   const productId =
     paymentData.product_id || paymentData.lines?.data?.[0]?.price?.product;
-  if (!productId) throw new Error("Product ID missing in payment event");
+  if (!productId)
+    throw new InvalidWebhookPayloadError("Product ID missing in payment event");
 
   const tier = getProductTierByProductId(productId);
 

--- a/src/lib/database/subscription.test.ts
+++ b/src/lib/database/subscription.test.ts
@@ -22,6 +22,7 @@ const mockSubscriptions = {
   currentPeriodStart: "subscriptions.currentPeriodStart",
   currentPeriodEnd: "subscriptions.currentPeriodEnd",
   canceledAt: "subscriptions.canceledAt",
+  lastWebhookCreatedAt: "subscriptions.lastWebhookCreatedAt",
   createdAt: "subscriptions.createdAt",
   updatedAt: "subscriptions.updatedAt",
 };
@@ -55,7 +56,12 @@ const mockWebhookEvents = {
 
 const mockEq = jest.fn();
 const mockDesc = jest.fn();
-const mockAnd = jest.fn();
+const mockSql = jest.fn(
+  (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+);
 
 const mockGetProductTierByProductId = jest.fn();
 const mockGetProductTierById = jest.fn();
@@ -75,7 +81,7 @@ jest.mock("@/database/tables", () => ({
 jest.mock("drizzle-orm", () => ({
   eq: mockEq,
   desc: mockDesc,
-  and: mockAnd,
+  sql: mockSql,
 }));
 
 jest.mock("@/lib/config/products", () => ({
@@ -86,6 +92,12 @@ jest.mock("@/lib/config/products", () => ({
 describe("Database Subscription Functions", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSql.mockImplementation(
+      (strings: TemplateStringsArray, ...values: unknown[]) => ({
+        strings,
+        values,
+      }),
+    );
 
     // Setup default mock implementations
     mockDb.select.mockReturnValue({
@@ -108,7 +120,9 @@ describe("Database Subscription Functions", () => {
         onConflictDoUpdate: jest.fn().mockReturnValue({
           returning: jest.fn().mockResolvedValue([]),
         }),
-        onConflictDoNothing: jest.fn().mockResolvedValue([]),
+        onConflictDoNothing: jest.fn().mockReturnValue({
+          returning: jest.fn().mockResolvedValue([{ id: "event-row-id" }]),
+        }),
         returning: jest.fn().mockResolvedValue([]),
       }),
     });
@@ -139,6 +153,7 @@ describe("Database Subscription Functions", () => {
         currentPeriodStart: new Date("2024-01-01"),
         currentPeriodEnd: new Date("2024-02-01"),
         canceledAt: null,
+        lastWebhookCreatedAt: new Date("2024-01-01T00:00:00Z"),
       };
 
       const mockResult = [{ id: "subscription-id", ...subscriptionData }];
@@ -169,6 +184,7 @@ describe("Database Subscription Functions", () => {
         currentPeriodStart: new Date("2024-01-01"),
         currentPeriodEnd: new Date("2024-02-01"),
         canceledAt: new Date("2024-01-15"),
+        lastWebhookCreatedAt: new Date("2024-01-15T00:00:00Z"),
       };
 
       const mockUpdateResult = [{ id: "subscription-id", ...subscriptionData }];
@@ -194,8 +210,10 @@ describe("Database Subscription Functions", () => {
           status: "canceled",
           productId: "product-123",
           canceledAt: subscriptionData.canceledAt,
+          lastWebhookCreatedAt: subscriptionData.lastWebhookCreatedAt,
           updatedAt: expect.any(Date),
         }),
+        setWhere: expect.any(Object),
       });
     });
 
@@ -206,6 +224,7 @@ describe("Database Subscription Functions", () => {
         subscriptionId: "sub-123",
         productId: "product-123",
         status: "active" as const,
+        lastWebhookCreatedAt: new Date("2024-01-01T00:00:00Z"),
       };
 
       const mockTx = {
@@ -803,102 +822,26 @@ describe("Database Subscription Functions", () => {
     });
   });
 
-  describe("isWebhookEventProcessed", () => {
-    it("should return true when event already processed", async () => {
-      const mockEvent = {
-        eventId: "event-123",
-        provider: "creem",
-        processed: true,
-      };
-
-      mockDb.select.mockReturnValue({
-        from: jest.fn().mockReturnValue({
-          where: jest.fn().mockReturnValue({
-            limit: jest.fn().mockResolvedValue([mockEvent]),
-          }),
-        }),
-      });
-
-      const { isWebhookEventProcessed } = await import("./subscription");
-
-      const result = await isWebhookEventProcessed("event-123");
-
-      expect(result).toBe(true);
-      expect(mockEq).toHaveBeenCalledWith(
-        mockWebhookEvents.eventId,
-        "event-123",
-      );
-      expect(mockEq).toHaveBeenCalledWith(mockWebhookEvents.provider, "creem");
-    });
-
-    it("should return false when event not processed", async () => {
-      mockDb.select.mockReturnValue({
-        from: jest.fn().mockReturnValue({
-          where: jest.fn().mockReturnValue({
-            limit: jest.fn().mockResolvedValue([]),
-          }),
-        }),
-      });
-
-      const { isWebhookEventProcessed } = await import("./subscription");
-
-      const result = await isWebhookEventProcessed("event-123");
-
-      expect(result).toBe(false);
-    });
-
-    it("should use custom provider", async () => {
-      mockDb.select.mockReturnValue({
-        from: jest.fn().mockReturnValue({
-          where: jest.fn().mockReturnValue({
-            limit: jest.fn().mockResolvedValue([]),
-          }),
-        }),
-      });
-
-      const { isWebhookEventProcessed } = await import("./subscription");
-
-      await isWebhookEventProcessed("event-123", "stripe");
-
-      expect(mockEq).toHaveBeenCalledWith(mockWebhookEvents.provider, "stripe");
-    });
-
-    it("should work with transaction", async () => {
-      const mockTx = {
-        select: jest.fn().mockReturnValue({
-          from: jest.fn().mockReturnValue({
-            where: jest.fn().mockReturnValue({
-              limit: jest.fn().mockResolvedValue([]),
-            }),
-          }),
-        }),
-      };
-
-      const { isWebhookEventProcessed } = await import("./subscription");
-
-      await isWebhookEventProcessed("event-123", "creem", mockTx as any);
-
-      expect(mockTx.select).toHaveBeenCalled();
-    });
-  });
-
   describe("recordWebhookEvent", () => {
     it("should record webhook event with all parameters", async () => {
       mockDb.insert.mockReturnValue({
         values: jest.fn().mockReturnValue({
-          onConflictDoNothing: jest.fn().mockResolvedValue([]),
+          onConflictDoNothing: jest.fn().mockReturnValue({
+            returning: jest.fn().mockResolvedValue([{ id: "event-row-id" }]),
+          }),
         }),
       });
 
       const { recordWebhookEvent } = await import("./subscription");
 
-      await recordWebhookEvent(
+      const result = await recordWebhookEvent(
         "event-123",
         "payment.succeeded",
         "creem",
         '{"eventType":"payment.succeeded"}',
       );
 
+      expect(result).toBe(true);
       expect(mockDb.insert).toHaveBeenCalledWith(mockWebhookEvents);
     });
 
@@ -922,7 +865,9 @@ describe("Database Subscription Functions", () => {
       const mockTx = {
         insert: jest.fn().mockReturnValue({
           values: jest.fn().mockReturnValue({
-            onConflictDoNothing: jest.fn().mockResolvedValue([]),
+            onConflictDoNothing: jest.fn().mockReturnValue({
+              returning: jest.fn().mockResolvedValue([{ id: "event-row-id" }]),
+            }),
           }),
         }),
       };
@@ -941,7 +886,10 @@ describe("Database Subscription Functions", () => {
     });
 
     it("should ignore conflicts gracefully", async () => {
-      const mockOnConflictDoNothing = jest.fn().mockResolvedValue([]);
+      const mockReturning = jest.fn().mockResolvedValue([]);
+      const mockOnConflictDoNothing = jest.fn().mockReturnValue({
+        returning: mockReturning,
+      });
 
       mockDb.insert.mockReturnValue({
         values: jest.fn().mockReturnValue({
@@ -951,9 +899,13 @@ describe("Database Subscription Functions", () => {
 
       const { recordWebhookEvent } = await import("./subscription");
 
-      await recordWebhookEvent("event-123", "payment.succeeded");
+      const result = await recordWebhookEvent("event-123", "payment.succeeded");
 
-      expect(mockOnConflictDoNothing).toHaveBeenCalled();
+      expect(result).toBe(false);
+      expect(mockOnConflictDoNothing).toHaveBeenCalledWith({
+        target: [mockWebhookEvents.provider, mockWebhookEvents.eventId],
+      });
+      expect(mockReturning).toHaveBeenCalled();
     });
   });
 

--- a/src/lib/database/subscription.ts
+++ b/src/lib/database/subscription.ts
@@ -6,7 +6,7 @@ import {
   users,
   webhookEvents,
 } from "@/database/tables";
-import { eq, desc, and } from "drizzle-orm"; // Added desc for descending order
+import { eq, desc, sql } from "drizzle-orm"; // Added desc for descending order
 import type { PgTransaction } from "drizzle-orm/pg-core";
 import type { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js";
 import type { Subscription, SubscriptionStatus } from "@/types/billing";
@@ -31,6 +31,7 @@ interface UpsertSubscriptionData {
   currentPeriodStart?: Date;
   currentPeriodEnd?: Date;
   canceledAt?: Date | null;
+  lastWebhookCreatedAt: Date;
 }
 
 interface UpsertPaymentData {
@@ -65,8 +66,10 @@ export async function upsertSubscription(
         currentPeriodStart: data.currentPeriodStart,
         currentPeriodEnd: data.currentPeriodEnd,
         canceledAt: data.canceledAt,
+        lastWebhookCreatedAt: data.lastWebhookCreatedAt,
         updatedAt: now,
       },
+      setWhere: sql`${subscriptions.lastWebhookCreatedAt} is null or ${subscriptions.lastWebhookCreatedAt} <= ${data.lastWebhookCreatedAt}`,
     })
     .returning();
 }
@@ -177,39 +180,13 @@ export async function getUserPayments(userId: string, limit: number = 10) {
 }
 
 /**
- * Check if a webhook event has already been processed
- * @param eventId - Unique identifier from the webhook provider
- * @param provider - Webhook provider name (default: 'creem')
- * @param tx - Optional transaction
- * @returns true if event was already processed, false otherwise
- */
-export async function isWebhookEventProcessed(
-  eventId: string,
-  provider: string = "creem",
-  tx?: Tx,
-): Promise<boolean> {
-  const dbase = getDb(tx);
-  const result = await dbase
-    .select()
-    .from(webhookEvents)
-    .where(
-      and(
-        eq(webhookEvents.eventId, eventId),
-        eq(webhookEvents.provider, provider),
-      ),
-    )
-    .limit(1);
-
-  return result.length > 0;
-}
-
-/**
  * Record a webhook event as processed to ensure idempotency
  * @param eventId - Unique identifier from the webhook provider
  * @param eventType - Type of the webhook event
  * @param provider - Webhook provider name (default: 'creem')
  * @param payload - Original webhook payload for debugging
  * @param tx - Optional transaction
+ * @returns true when this request claimed the event, false on conflict
  */
 export async function recordWebhookEvent(
   eventId: string,
@@ -217,9 +194,9 @@ export async function recordWebhookEvent(
   provider: string = "creem",
   payload?: string,
   tx?: Tx,
-): Promise<void> {
+): Promise<boolean> {
   const dbase = getDb(tx);
-  await dbase
+  const inserted = await dbase
     .insert(webhookEvents)
     .values({
       eventId,
@@ -229,5 +206,10 @@ export async function recordWebhookEvent(
       processed: true,
       processedAt: new Date(),
     })
-    .onConflictDoNothing(); // Ignore if already exists
+    .onConflictDoNothing({
+      target: [webhookEvents.provider, webhookEvents.eventId],
+    })
+    .returning({ id: webhookEvents.id });
+
+  return inserted.length > 0;
 }

--- a/src/lib/http/request-body.test.ts
+++ b/src/lib/http/request-body.test.ts
@@ -1,0 +1,60 @@
+import {
+  readTextBodyWithLimit,
+  RequestBodyTooLargeError,
+} from "./request-body";
+
+function createStreamingRequest(
+  chunks: string[],
+  headers: HeadersInit = {},
+): Request {
+  const encoder = new TextEncoder();
+  const encodedChunks = chunks.map((chunk) => encoder.encode(chunk));
+  let index = 0;
+  const body = {
+    getReader() {
+      return {
+        async read() {
+          const value = encodedChunks[index];
+          index += 1;
+          return value ? { done: false, value } : { done: true, value };
+        },
+        async cancel() {
+          index = encodedChunks.length;
+        },
+      };
+    },
+  } as ReadableStream<Uint8Array>;
+
+  return {
+    body,
+    headers: new Headers(headers),
+  } as Request;
+}
+
+describe("readTextBodyWithLimit", () => {
+  it("preserves text split across stream chunks", async () => {
+    const request = createStreamingRequest(["hello ", "世界"]);
+
+    await expect(readTextBodyWithLimit(request, 64)).resolves.toBe(
+      "hello 世界",
+    );
+  });
+
+  it("rejects a declared body that exceeds the limit", async () => {
+    const request = createStreamingRequest(["small"], {
+      "content-length": "128",
+    });
+
+    await expect(readTextBodyWithLimit(request, 64)).rejects.toBeInstanceOf(
+      RequestBodyTooLargeError,
+    );
+  });
+
+  it("rejects a streamed body that exceeds the limit", async () => {
+    const request = createStreamingRequest(["1234", "5678"]);
+
+    await expect(readTextBodyWithLimit(request, 7)).rejects.toBeInstanceOf(
+      RequestBodyTooLargeError,
+    );
+  });
+});

--- a/src/lib/http/request-body.ts
+++ b/src/lib/http/request-body.ts
@@ -1,0 +1,45 @@
+export class RequestBodyTooLargeError extends Error {
+  constructor() {
+    super("Request body exceeds the allowed size.");
+    this.name = "RequestBodyTooLargeError";
+  }
+}
+
+export async function readTextBodyWithLimit(
+  request: Request,
+  maxBytes: number,
+): Promise<string> {
+  const contentLength = request.headers.get("content-length");
+  if (contentLength) {
+    const declaredBytes = Number(contentLength);
+    if (Number.isFinite(declaredBytes) && declaredBytes > maxBytes) {
+      throw new RequestBodyTooLargeError();
+    }
+  }
+
+  if (!request.body) {
+    return "";
+  }
+
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  let bytesRead = 0;
+  let body = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    bytesRead += value.byteLength;
+    if (bytesRead > maxBytes) {
+      await reader.cancel().catch(() => undefined);
+      throw new RequestBodyTooLargeError();
+    }
+
+    body += decoder.decode(value, { stream: true });
+  }
+
+  return body + decoder.decode();
+}

--- a/src/types/billing.ts
+++ b/src/types/billing.ts
@@ -20,6 +20,8 @@ export type SubscriptionStatus =
   | "canceled"
   | "past_due"
   | "unpaid"
+  | "paused"
+  | "scheduled_cancel"
   | "trialing"
   | "incomplete";
 
@@ -66,9 +68,9 @@ interface CreemBaseObject {
 export interface CreemSubscriptionObject extends CreemBaseObject {
   product: string | { id: string };
   status: SubscriptionStatus;
-  current_period_start_date: string;
-  current_period_end_date: string;
-  canceled_at: string | null;
+  current_period_start_date?: string;
+  current_period_end_date?: string;
+  canceled_at?: string | null;
 }
 
 export interface CreemPaymentObject extends CreemBaseObject {


### PR DESCRIPTION
## Summary
- make Creem webhook claiming atomic and provider-scoped
- require real event IDs, validate signed payloads and official lifecycle event names
- prevent stale subscription events from overwriting newer state, including a safe history backfill migration
- cap webhook request bodies at 1 MiB and return controlled 400/413/500 responses
- harden checkout and portal error handling
- pin production builds and bundle analysis to Webpack because the Lingo loader bridge intermittently fails under Turbopack

## Review
Three independent sub-agent reviews covered webhook concurrency/migration semantics, request-body and error boundaries, and SDK/build compatibility. Reported findings were fixed and re-reviewed to no blockers.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm type-check`
- `pnpm test --runInBand` (100 suites, 1088 tests)
- `LINGO_BUILD_MODE=cache-only pnpm build`
- `pnpm prettier:check`
- `pnpm audit` (0 known vulnerabilities)
- `git diff --check`
