### PR TITLE
Harden upload APIs and metadata consistency

### DIFF
--- a/src/app/api/upload/complete/route.test.ts
+++ b/src/app/api/upload/complete/route.test.ts
@@ -48,7 +48,13 @@ const mockSelectWhere = jest.fn().mockReturnValue({
 const mockSelectFrom = jest.fn().mockReturnValue({
   where: mockSelectWhere,
 }) as any;
-const mockInsertValues = jest.fn().mockResolvedValue(undefined) as any;
+const mockReturning = jest.fn() as any;
+const mockOnConflictDoNothing = jest.fn().mockReturnValue({
+  returning: mockReturning,
+}) as any;
+const mockInsertValues = jest.fn().mockReturnValue({
+  onConflictDoNothing: mockOnConflictDoNothing,
+}) as any;
 const mockDb = {
   select: jest.fn().mockReturnValue({
     from: mockSelectFrom,
@@ -108,6 +114,21 @@ describe("Upload Complete API", () => {
     mockDb.insert.mockReturnValue({
       values: mockInsertValues,
     });
+    mockInsertValues.mockReturnValue({
+      onConflictDoNothing: mockOnConflictDoNothing,
+    });
+    mockOnConflictDoNothing.mockReturnValue({
+      returning: mockReturning,
+    });
+    mockReturning.mockResolvedValue([
+      {
+        fileKey: validRequestBody.key,
+        url: validRequestBody.url,
+        fileName: validRequestBody.fileName,
+        fileSize: validRequestBody.size,
+        contentType: validRequestBody.contentType,
+      },
+    ]);
     mockCheckUploadRateLimit.mockReturnValue({
       allowed: true,
       limit: 30,
@@ -177,6 +198,25 @@ describe("Upload Complete API", () => {
     expect(data.error).toBe("Invalid request data");
   });
 
+  it("should return 400 for malformed JSON", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockUploadCompleteRequestSchema.safeParse.mockReturnValue({
+      success: false,
+      error: {
+        flatten: () => ({ fieldErrors: {} }),
+      },
+    });
+    const request = createMockRequest(validRequestBody);
+    (request.json as jest.Mock).mockRejectedValue(new Error("Invalid JSON"));
+
+    const { POST } = await import("./route");
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Invalid request data");
+  });
+
   it("should reject upload keys that do not belong to the current user", async () => {
     mockGetSession.mockResolvedValue(mockSession);
     mockUploadCompleteRequestSchema.safeParse.mockReturnValue({
@@ -211,6 +251,25 @@ describe("Upload Complete API", () => {
 
     expect(response.status).toBe(409);
     expect(data.error).toBe("Uploaded object could not be verified.");
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it("should return 500 when object storage metadata lookup fails", async () => {
+    mockGetSession.mockResolvedValue(mockSession);
+    mockUploadCompleteRequestSchema.safeParse.mockReturnValue({
+      success: true,
+      data: validRequestBody,
+    });
+    mockIsFileTypeAllowed.mockReturnValue(true);
+    mockIsFileSizeAllowed.mockReturnValue(true);
+    mockGetObjectMetadata.mockRejectedValue(new Error("R2 unavailable"));
+
+    const { POST } = await import("./route");
+    const response = await POST(createMockRequest(validRequestBody));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Internal Server Error. Please try again later.");
     expect(mockDb.insert).not.toHaveBeenCalled();
   });
 
@@ -287,6 +346,7 @@ describe("Upload Complete API", () => {
       fileSize: validRequestBody.size,
       contentType: validRequestBody.contentType,
     };
+    mockReturning.mockResolvedValue([]);
     mockSelectLimit.mockResolvedValue([existingUpload]);
 
     const { POST } = await import("./route");
@@ -294,7 +354,10 @@ describe("Upload Complete API", () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(mockOnConflictDoNothing).toHaveBeenCalledWith({
+      target: "fileKey",
+    });
     expect(data.file).toEqual({
       key: existingUpload.fileKey,
       url: existingUpload.url,

--- a/src/app/api/upload/complete/route.ts
+++ b/src/app/api/upload/complete/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
+    const body = await request.json().catch(() => null);
     const validation = uploadCompleteRequestSchema.safeParse(body);
 
     if (!validation.success) {
@@ -126,40 +126,42 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const existingUpload = await db
-      .select()
-      .from(uploads)
-      .where(and(eq(uploads.userId, session.user.id), eq(uploads.fileKey, key)))
-      .limit(1);
+    const inserted = await db
+      .insert(uploads)
+      .values({
+        userId: session.user.id,
+        fileKey: key,
+        url: expectedUrl,
+        fileName,
+        fileSize: metadata.contentLength,
+        contentType: metadata.contentType,
+      })
+      .onConflictDoNothing({ target: uploads.fileKey })
+      .returning();
 
-    if (existingUpload[0]) {
-      return NextResponse.json({
-        file: {
-          key: existingUpload[0].fileKey,
-          url: existingUpload[0].url,
-          fileName: existingUpload[0].fileName,
-          size: existingUpload[0].fileSize,
-          contentType: existingUpload[0].contentType,
-        },
-      });
+    const existing =
+      inserted[0] ??
+      (
+        await db
+          .select()
+          .from(uploads)
+          .where(
+            and(eq(uploads.userId, session.user.id), eq(uploads.fileKey, key)),
+          )
+          .limit(1)
+      )[0];
+
+    if (!existing) {
+      throw new Error("Upload record was not available after insert.");
     }
-
-    await db.insert(uploads).values({
-      userId: session.user.id,
-      fileKey: key,
-      url: expectedUrl,
-      fileName,
-      fileSize: metadata.contentLength,
-      contentType: metadata.contentType,
-    });
 
     return NextResponse.json({
       file: {
-        key,
-        url: expectedUrl,
-        fileName,
-        size: metadata.contentLength,
-        contentType: metadata.contentType,
+        key: existing.fileKey,
+        url: existing.url,
+        fileName: existing.fileName,
+        size: existing.fileSize,
+        contentType: existing.contentType,
       },
     });
   } catch (error) {

--- a/src/app/api/upload/presigned-url/route.test.ts
+++ b/src/app/api/upload/presigned-url/route.test.ts
@@ -211,6 +211,12 @@ describe("Upload Presigned URL API", () => {
 
     it("should handle request.json() failure", async () => {
       mockGetSession.mockResolvedValue(mockSession);
+      mockPresignedUrlRequestSchema.safeParse.mockReturnValue({
+        success: false,
+        error: {
+          flatten: () => ({ fieldErrors: {} }),
+        },
+      });
 
       const request = {
         headers: {
@@ -229,8 +235,8 @@ describe("Upload Presigned URL API", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      expect(response.status).toBe(500);
-      expect(data.error).toBe("Internal Server Error. Please try again later.");
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("Invalid request data");
     });
   });
 });

--- a/src/app/api/upload/presigned-url/route.ts
+++ b/src/app/api/upload/presigned-url/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
+    const body = await request.json().catch(() => null);
     const validation = presignedUrlRequestSchema.safeParse(body);
 
     if (!validation.success) {

--- a/src/app/api/upload/server-upload/route.test.ts
+++ b/src/app/api/upload/server-upload/route.test.ts
@@ -61,10 +61,17 @@ jest.mock("@aws-sdk/lib-storage", () => ({
   Upload: jest.fn(() => mockUpload),
 }));
 
+const mockDeleteFile = jest.fn() as any;
+jest.mock("@/lib/r2", () => ({
+  buildR2PublicUrl: (key: string) => `https://cdn.example.com/${key}`,
+  deleteFile: mockDeleteFile,
+}));
+
 // Mock database
+const mockInsertValues = jest.fn() as any;
 const mockDb = {
   insert: jest.fn().mockReturnValue({
-    values: jest.fn() as any,
+    values: mockInsertValues,
   }) as any,
 };
 jest.mock("@/database", () => ({
@@ -126,16 +133,29 @@ describe("Upload Server Upload API", () => {
       retryAfter: 0,
     });
     mockFormatFileSize.mockImplementation((size: number) => `${size} bytes`);
+    mockDeleteFile.mockResolvedValue({ success: true });
+    mockInsertValues.mockResolvedValue(undefined);
+    mockDb.insert.mockReturnValue({ values: mockInsertValues });
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  const createMockRequest = (contentType: string, formData?: FormData) => {
+  const createMockRequest = (
+    contentType: string,
+    formData?: FormData,
+    contentLength: number | string | null = 1024,
+  ) => {
     return {
       headers: {
-        get: jest.fn((key) => (key === "content-type" ? contentType : "")),
+        get: jest.fn((key) => {
+          if (key === "content-type") return contentType;
+          if (key === "content-length") {
+            return contentLength === null ? null : String(contentLength);
+          }
+          return "";
+        }),
         has: () => false,
         set: () => {},
         entries: () => [],
@@ -222,6 +242,56 @@ describe("Upload Server Upload API", () => {
 
       expect(response.status).toBe(400);
       expect(data.error).toBe("No files provided");
+    });
+
+    it("should reject oversized multipart requests before parsing", async () => {
+      mockGetSession.mockResolvedValue(mockSession);
+
+      const { POST } = await import("./route");
+      const request = createMockRequest(
+        "multipart/form-data",
+        undefined,
+        22 * 1024 * 1024,
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(413);
+      expect(data.error).toBe("Upload request is too large.");
+      expect(request.formData).not.toHaveBeenCalled();
+    });
+
+    it("should require Content-Length before parsing multipart data", async () => {
+      mockGetSession.mockResolvedValue(mockSession);
+
+      const { POST } = await import("./route");
+      const request = createMockRequest("multipart/form-data", undefined, null);
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(411);
+      expect(data.error).toBe("Content-Length header is required.");
+      expect(request.formData).not.toHaveBeenCalled();
+    });
+
+    it("should reject invalid Content-Length before parsing", async () => {
+      mockGetSession.mockResolvedValue(mockSession);
+
+      const { POST } = await import("./route");
+      const request = createMockRequest(
+        "multipart/form-data",
+        undefined,
+        "invalid",
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("Invalid Content-Length header.");
+      expect(request.formData).not.toHaveBeenCalled();
     });
 
     it("should reject requests with too many files", async () => {
@@ -399,8 +469,9 @@ describe("Upload Server Upload API", () => {
       expect(data.results[0]).toEqual({
         fileName: "test.jpg",
         success: false,
-        error: "S3 upload failed",
+        error: "Upload failed. Please try again.",
       });
+      expect(mockDeleteFile).not.toHaveBeenCalled();
     });
 
     it("should handle database insert failure", async () => {
@@ -409,7 +480,7 @@ describe("Upload Server Upload API", () => {
       mockIsFileSizeAllowed.mockReturnValue(true);
       mockGetFileExtension.mockReturnValue("jpg");
       mockUpload.done.mockResolvedValue({});
-      mockDb.insert().values.mockRejectedValue(new Error("Database error"));
+      mockInsertValues.mockRejectedValue(new Error("Database error"));
 
       const file = createMockFile("test.jpg", "image/jpeg", 1024);
       const mockFormData = {
@@ -429,8 +500,11 @@ describe("Upload Server Upload API", () => {
       expect(data.results[0]).toEqual({
         fileName: "test.jpg",
         success: false,
-        error: "Database error",
+        error: "Upload failed. Please try again.",
       });
+      expect(mockDeleteFile).toHaveBeenCalledWith(
+        "uploads/user-123/1640995200000-test-uuid-123.jpg",
+      );
     });
 
     it("should handle multiple files with mixed results", async () => {
@@ -482,7 +556,9 @@ describe("Upload Server Upload API", () => {
 
       const request = {
         headers: {
-          get: jest.fn(() => "multipart/form-data"),
+          get: jest.fn((key) =>
+            key === "content-type" ? "multipart/form-data" : "1024",
+          ),
           has: () => false,
           set: () => {},
           entries: () => [],
@@ -498,8 +574,8 @@ describe("Upload Server Upload API", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      expect(response.status).toBe(500);
-      expect(data.error).toBe("Internal server error");
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("Invalid multipart upload payload.");
     });
 
     it("should handle non-Error exceptions in processFile", async () => {
@@ -526,7 +602,7 @@ describe("Upload Server Upload API", () => {
       expect(data.results[0]).toEqual({
         fileName: "test.jpg",
         success: false,
-        error: "Unknown error",
+        error: "Upload failed. Please try again.",
       });
     });
   });

--- a/src/app/api/upload/server-upload/route.ts
+++ b/src/app/api/upload/server-upload/route.ts
@@ -15,7 +15,9 @@ import {
 } from "@/lib/config/upload";
 import { getAuthSessionFromHeaders } from "@/lib/auth/session";
 import { checkUploadRateLimit } from "@/lib/upload-rate-limit";
-import { buildR2PublicUrl } from "@/lib/r2";
+import { buildR2PublicUrl, deleteFile } from "@/lib/r2";
+
+const MULTIPART_OVERHEAD_BYTES = 1024 * 1024;
 
 // Initialize S3 client for Cloudflare R2
 const r2Client = new S3Client({
@@ -41,6 +43,13 @@ type ServerUploadResult =
       success: false;
       error: string;
     };
+
+class UploadValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UploadValidationError";
+  }
+}
 
 function isUploadFile(entry: FormDataEntryValue): entry is File {
   return (
@@ -104,8 +113,49 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const contentLengthHeader = request.headers.get("content-length");
+    if (contentLengthHeader === null) {
+      return NextResponse.json(
+        { error: "Content-Length header is required." },
+        { status: 411 },
+      );
+    }
+
+    if (!/^\d+$/.test(contentLengthHeader)) {
+      return NextResponse.json(
+        { error: "Invalid Content-Length header." },
+        { status: 400 },
+      );
+    }
+
+    const declaredLength = Number(contentLengthHeader);
+    const maxRequestSize =
+      UPLOAD_CONFIG.MAX_SERVER_UPLOAD_TOTAL_SIZE + MULTIPART_OVERHEAD_BYTES;
+    if (!Number.isSafeInteger(declaredLength) || declaredLength <= 0) {
+      return NextResponse.json(
+        { error: "Invalid Content-Length header." },
+        { status: 400 },
+      );
+    }
+
+    if (declaredLength > maxRequestSize) {
+      return NextResponse.json(
+        { error: "Upload request is too large." },
+        { status: 413 },
+      );
+    }
+
     // Parse multipart/form-data
-    const formData = await request.formData();
+    let formData: FormData;
+    try {
+      formData = await request.formData();
+    } catch (error) {
+      console.warn("Invalid multipart upload payload:", error);
+      return NextResponse.json(
+        { error: "Invalid multipart upload payload." },
+        { status: 400 },
+      );
+    }
     const fileEntries = formData.getAll("files");
     const files = fileEntries.filter(isUploadFile);
 
@@ -144,17 +194,21 @@ export async function POST(request: NextRequest) {
 
     // Function to process a single file
     const processFile = async (file: File): Promise<ServerUploadResult> => {
+      let uploadedKey: string | null = null;
+
       try {
         const normalizedContentType = normalizeContentType(file.type);
 
         // Validate file type
         if (!isFileTypeAllowed(normalizedContentType)) {
-          throw new Error(`File type ${normalizedContentType} is not allowed`);
+          throw new UploadValidationError(
+            `File type ${normalizedContentType} is not allowed`,
+          );
         }
 
         // Validate file size
         if (!isFileSizeAllowed(file.size)) {
-          throw new Error(
+          throw new UploadValidationError(
             `File size ${file.size} bytes exceeds maximum allowed size of ${UPLOAD_CONFIG.MAX_FILE_SIZE} bytes`,
           );
         }
@@ -183,6 +237,7 @@ export async function POST(request: NextRequest) {
 
         // Execute the upload
         await upload.done();
+        uploadedKey = key;
 
         // Generate public URL
         const publicUrl = buildR2PublicUrl(key);
@@ -207,10 +262,23 @@ export async function POST(request: NextRequest) {
         };
       } catch (error) {
         console.error(`Error uploading file ${file.name}:`, error);
+
+        if (uploadedKey) {
+          const cleanup = await deleteFile(uploadedKey);
+          if (!cleanup.success) {
+            console.error(
+              `Failed to clean up R2 object ${uploadedKey} after upload metadata error.`,
+            );
+          }
+        }
+
         return {
           fileName: file.name,
           success: false,
-          error: error instanceof Error ? error.message : "Unknown error",
+          error:
+            error instanceof UploadValidationError
+              ? error.message
+              : "Upload failed. Please try again.",
         };
       }
     };

--- a/src/database/migrations/0003_wandering_george_stacy.sql
+++ b/src/database/migrations/0003_wandering_george_stacy.sql
@@ -1,0 +1,17 @@
+LOCK TABLE "uploads" IN SHARE ROW EXCLUSIVE MODE;--> statement-breakpoint
+DROP INDEX "uploads_fileKey_idx";--> statement-breakpoint
+DELETE FROM "uploads"
+WHERE "id" IN (
+	SELECT "id"
+	FROM (
+		SELECT
+			"id",
+			row_number() OVER (
+				PARTITION BY "fileKey"
+				ORDER BY "createdAt" ASC, "id" ASC
+			) AS "duplicateRank"
+		FROM "uploads"
+	) AS "rankedUploads"
+	WHERE "duplicateRank" > 1
+);--> statement-breakpoint
+CREATE UNIQUE INDEX "uploads_fileKey_unique" ON "uploads" USING btree ("fileKey");

--- a/src/database/migrations/meta/0003_snapshot.json
+++ b/src/database/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1299 @@
+{
+  "id": "b08353f4-b4ab-43c9-97cc-c1206910861a",
+  "prevId": "40b777c1-0a31-42c0-97f3-a1b548c8f6b4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyPrefix": {
+          "name": "keyPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastFourChars": {
+          "name": "lastFourChars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rateLimit": {
+          "name": "rateLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestCountInWindow": {
+          "name": "requestCountInWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "windowStartedAt": {
+          "name": "windowStartedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_userId_idx": {
+          "name": "api_keys_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_keyHash_idx": {
+          "name": "api_keys_keyHash_idx",
+          "columns": [
+            {
+              "expression": "keyHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_userId_users_id_fk": {
+          "name": "api_keys_userId_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastFourChars": {
+          "name": "lastFourChars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshTokenHash": {
+          "name": "refreshTokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previousRefreshTokenHash": {
+          "name": "previousRefreshTokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshRotatedAt": {
+          "name": "refreshRotatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshExpiresAt": {
+          "name": "refreshExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceOs": {
+          "name": "deviceOs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceHostname": {
+          "name": "deviceHostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cliVersion": {
+          "name": "cliVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cli_tokens_userId_idx": {
+          "name": "cli_tokens_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_tokens_userId_users_id_fk": {
+          "name": "cli_tokens_userId_users_id_fk",
+          "tableFrom": "cli_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_tokenHash_unique": {
+          "name": "cli_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tokenHash"]
+        },
+        "cli_tokens_refreshTokenHash_unique": {
+          "name": "cli_tokens_refreshTokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refreshTokenHash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deviceCode": {
+          "name": "deviceCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCode": {
+          "name": "userCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "lastPolledAt": {
+          "name": "lastPolledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clientName": {
+          "name": "clientName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clientVersion": {
+          "name": "clientVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceOs": {
+          "name": "deviceOs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceHostname": {
+          "name": "deviceHostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_codes_expiresAt_idx": {
+          "name": "device_codes_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_userId_users_id_fk": {
+          "name": "device_codes_userId_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_deviceCode_unique": {
+          "name": "device_codes_deviceCode_unique",
+          "nullsNotDistinct": false,
+          "columns": ["deviceCode"]
+        },
+        "device_codes_userCode_unique": {
+          "name": "device_codes_userCode_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userCode"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paymentId": {
+          "name": "paymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paymentType": {
+          "name": "paymentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_userId_idx": {
+          "name": "payments_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_userId_users_id_fk": {
+          "name": "payments_userId_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payments_paymentId_unique": {
+          "name": "payments_paymentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["paymentId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonatedBy": {
+          "name": "impersonatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "productId": {
+          "name": "productId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastWebhookCreatedAt": {
+          "name": "lastWebhookCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_userId_idx": {
+          "name": "subscriptions_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_customerId_idx": {
+          "name": "subscriptions_customerId_idx",
+          "columns": [
+            {
+              "expression": "customerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_userId_users_id_fk": {
+          "name": "subscriptions_userId_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_subscriptionId_unique": {
+          "name": "subscriptions_subscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["subscriptionId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploads": {
+      "name": "uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileKey": {
+          "name": "fileKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uploads_userId_idx": {
+          "name": "uploads_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uploads_fileKey_unique": {
+          "name": "uploads_fileKey_unique",
+          "columns": [
+            {
+              "expression": "fileKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploads_userId_users_id_fk": {
+          "name": "uploads_userId_users_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentProviderCustomerId": {
+          "name": "paymentProviderCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_paymentProviderCustomerId_unique": {
+          "name": "users_paymentProviderCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["paymentProviderCustomerId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'creem'"
+        },
+        "processed": {
+          "name": "processed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_events_provider_eventId_unique": {
+          "name": "webhook_events_provider_eventId_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_events_provider_idx": {
+          "name": "webhook_events_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["user", "admin", "super_admin"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1784825234413,
       "tag": "0002_gorgeous_spot",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1784825895486,
+      "tag": "0003_wandering_george_stacy",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/schema.test.ts
+++ b/src/database/schema.test.ts
@@ -1514,8 +1514,14 @@ describe("Database Schema", () => {
       const configs = getIndexConfigs(uploads);
       const indexNames = configs.map((cfg) => cfg.name);
       expect(indexNames).toEqual(
-        expect.arrayContaining(["uploads_userId_idx", "uploads_fileKey_idx"]),
+        expect.arrayContaining([
+          "uploads_userId_idx",
+          "uploads_fileKey_unique",
+        ]),
       );
+      expect(
+        configs.find((cfg) => cfg.name === "uploads_fileKey_unique")?.unique,
+      ).toBe(true);
     });
   });
 });

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -262,7 +262,7 @@ export const uploads = pgTable(
   (table) => {
     return {
       userIdx: index("uploads_userId_idx").on(table.userId),
-      fileKeyIdx: index("uploads_fileKey_idx").on(table.fileKey),
+      fileKeyUnique: uniqueIndex("uploads_fileKey_unique").on(table.fileKey),
     };
   },
 );

--- a/src/lib/r2.test.ts
+++ b/src/lib/r2.test.ts
@@ -454,7 +454,7 @@ describe("R2 Storage Functions", () => {
       await expect(fileExists("missing-key")).resolves.toBe(false);
     });
 
-    it("should log unexpected errors and return false", async () => {
+    it("should surface unexpected metadata errors", async () => {
       const { fileExists } = await import("./r2");
 
       mockSend.mockRejectedValueOnce(new Error("Timeout"));
@@ -462,7 +462,7 @@ describe("R2 Storage Functions", () => {
         .spyOn(console, "error")
         .mockImplementation(() => {});
 
-      await expect(fileExists("test-key")).resolves.toBe(false);
+      await expect(fileExists("test-key")).rejects.toThrow("Timeout");
       expect(consoleSpy).toHaveBeenCalledWith(
         "Error reading object metadata:",
         expect.any(Error),

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -355,7 +355,7 @@ export async function getObjectMetadata(
     }
 
     console.error("Error reading object metadata:", error);
-    return null;
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary
- make upload completion idempotent under concurrency with a unique file-key index and atomic insert
- safely deduplicate historical upload metadata inside a locked transactional migration
- reject malformed JSON and multipart requests with controlled 4xx responses
- require a valid bounded Content-Length before parsing server-side multipart uploads
- delete an uploaded R2 object when its database metadata write fails
- stop exposing storage/database errors to clients and distinguish R2 not-found from service failures

## Review
Three independent sub-agent reviews covered migration/concurrency semantics, request parsing and error boundaries, and storage/build safety. Findings around unbounded chunked multipart requests and malformed multipart status mapping were fixed and re-reviewed to no blockers.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm type-check`
- `pnpm test --runInBand` (100 suites, 1093 tests)
- `LINGO_BUILD_MODE=cache-only pnpm build`
- `pnpm prettier:check`
- `pnpm audit` (0 known vulnerabilities)
- `git diff --check`
