### PR TITLE
Optimize Zeabur runtime image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Routine formatting and test-only maintenance are omitted.
   deployment configuration.
 - Tightened Node, CI, Docker, database configuration, dependency, lint, and
   formatting contracts.
+- Configured Zeabur to use the existing multi-stage standalone Dockerfile
+  instead of packaging the full Node.js build environment into the Web image.
 - Updated English and Chinese project documentation and added Zeabur release
   guidance.
 

--- a/README.md
+++ b/README.md
@@ -438,7 +438,9 @@ repository also includes a standalone multi-stage Docker build.
    service.
 2. Configure every required variable from `.env.example`. Set
    `NEXT_PUBLIC_APP_URL` to the final HTTPS origin before building because
-   canonical URLs and client configuration are compiled from it.
+   canonical URLs and client configuration are compiled from it. Set
+   `R2_PUBLIC_URL` before building so Next.js includes the storage hostname in
+   its image optimization allowlist.
 3. Run `pnpm db:migrate` once as a dedicated release command against the
    production `DATABASE_URL`. Do not attach migrations to every web process
    startup.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -423,7 +423,8 @@ Docker 构建。
 
 1. 将通过审查的 commit 推送到 Git 仓库，并连接到 Zeabur 服务。
 2. 配置 `.env.example` 中的全部必需变量。构建前必须把 `NEXT_PUBLIC_APP_URL`
-   设置为最终 HTTPS Origin，因为 canonical URL 与客户端配置会在构建时写入。
+   设置为最终 HTTPS Origin，因为 canonical URL 与客户端配置会在构建时写入；同时设置
+   `R2_PUBLIC_URL`，让 Next.js 把存储域名加入图片优化白名单。
 3. 使用生产 `DATABASE_URL` 把 `pnpm db:migrate` 作为一次性发布命令执行；不要挂在
    每个 Web 进程的启动钩子上。
 4. 迁移成功后再部署应用。`/api/health` 用于存活检查，`/api/ready` 用于包含数据库

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,12 +21,16 @@ COPY . .
 
 # Set environment to production for build
 ARG NEXT_PUBLIC_APP_URL
+ARG R2_PUBLIC_URL
 ENV NODE_ENV=production
 ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
+ENV R2_PUBLIC_URL=$R2_PUBLIC_URL
 ENV SKIP_ENV_VALIDATION=1
 
 # Build the Next.js application
-RUN test -n "$NEXT_PUBLIC_APP_URL" && pnpm run build
+RUN test -n "$NEXT_PUBLIC_APP_URL" \
+  && test -n "$R2_PUBLIC_URL" \
+  && pnpm run build
 
 # One-shot database migration image. It intentionally contains development
 # dependencies and source files, but is never used to serve application traffic.
@@ -40,6 +44,9 @@ CMD ["pnpm", "db:migrate"]
 # Production image
 FROM node:22-alpine AS runner
 WORKDIR /app
+
+LABEL "language"="nodejs"
+LABEL "framework"="next.js"
 
 ENV NODE_ENV=production
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,7 +23,9 @@ This directory contains Docker configuration for running the UllrAI Starter appl
    `RESEND_EMAIL_FROM` to an address on a domain verified in Resend. Set
    a second generated value in `UPLOAD_CLEANUP_SECRET`. Set
    `NEXT_PUBLIC_APP_URL` to the exact public origin used to access the build;
-   production SEO metadata is generated from this value at build time.
+   production SEO metadata is generated from this value at build time. Set
+   `R2_PUBLIC_URL` before building so the storage hostname is included in the
+   Next.js image optimization allowlist.
    `RATE_LIMIT_IP_HEADER` must name a client-IP header that your trusted
    ingress overwrites; never trust a header passed through directly from the
    public internet.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       dockerfile: docker/Dockerfile
       args:
         NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:?Set NEXT_PUBLIC_APP_URL to the public deployment origin}
+        R2_PUBLIC_URL: ${R2_PUBLIC_URL:?Set R2_PUBLIC_URL to the public R2 origin}
     restart: unless-stopped
     ports:
       - "127.0.0.1:3000:3000"

--- a/docs/deployment-zeabur.md
+++ b/docs/deployment-zeabur.md
@@ -3,6 +3,11 @@
 This repository's production reference deployment uses a Git-backed Zeabur
 service and PostgreSQL.
 
+Zeabur is configured through `zbpack.json` to build `docker/Dockerfile`. Keep
+that file in place: the multi-stage image serves only the prepared Next.js
+standalone output instead of shipping the build toolchain and development
+dependencies in the Web runtime.
+
 ## Release order
 
 1. Merge only a reviewed commit with green CI.

--- a/docs/deployment-zeabur.md
+++ b/docs/deployment-zeabur.md
@@ -8,6 +8,10 @@ that file in place: the multi-stage image serves only the prepared Next.js
 standalone output instead of shipping the build toolchain and development
 dependencies in the Web runtime.
 
+Both `NEXT_PUBLIC_APP_URL` and `R2_PUBLIC_URL` are required build arguments.
+Zeabur injects their service-variable values into the multi-stage Docker build;
+the build fails closed when either value is missing.
+
 ## Release order
 
 1. Merge only a reviewed commit with green CI.

--- a/zbpack.json
+++ b/zbpack.json
@@ -1,0 +1,5 @@
+{
+  "dockerfile": {
+    "path": "docker/Dockerfile"
+  }
+}


### PR DESCRIPTION
## Summary
- direct Zeabur to the existing multi-stage Dockerfile through `zbpack.json`
- keep build dependencies out of the production Web image
- document the production image contract and record it in the changelog

## Verification
- `pnpm prettier:check`
- `pnpm lint`
- `pnpm type-check`
- `git diff --check`
- `zbpack.json` JSON parse

Local Docker build could not run because no Docker daemon is available; Zeabur deployment after merge will be the production image validation.