### PR TITLE
Enforce non-root container runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Routine formatting and test-only maintenance are omitted.
   formatting contracts.
 - Configured Zeabur to use the existing multi-stage standalone Dockerfile
   instead of packaging the full Node.js build environment into the Web image.
+- Enforced an unprivileged Web process even when the hosting platform overrides
+  the Docker image user.
 - Updated English and Chinese project documentation and added Zeabur release
   guidance.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,11 +51,13 @@ LABEL "framework"="next.js"
 ENV NODE_ENV=production
 
 # Create non-root user
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
+RUN apk add --no-cache su-exec \
+  && addgroup --system --gid 1001 nodejs \
+  && adduser --system --uid 1001 nextjs
 
 # Copy the self-contained application prepared by the build script
 COPY --from=builder /app/.next/standalone ./
+COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint
 
 # Set correct permissions
 RUN chown -R nextjs:nodejs /app
@@ -69,4 +71,5 @@ ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
 # Start the application
+ENTRYPOINT ["docker-entrypoint"]
 CMD ["node", "server.js"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,6 +5,8 @@ This directory contains Docker configuration for running the UllrAI Starter appl
 ## Files
 
 - `Dockerfile` - Multi-stage build configuration for the Next.js application
+- `entrypoint.sh` - Drops root privileges when the hosting platform overrides
+  the image user
 - `docker-compose.yml` - Development environment with PostgreSQL
 - Root `.dockerignore` - Excludes secrets and build artifacts
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$(id -u)" = "0" ]; then
+  exec su-exec nextjs:nodejs "$@"
+fi
+
+exec "$@"

--- a/docs/deployment-zeabur.md
+++ b/docs/deployment-zeabur.md
@@ -8,6 +8,10 @@ that file in place: the multi-stage image serves only the prepared Next.js
 standalone output instead of shipping the build toolchain and development
 dependencies in the Web runtime.
 
+The runtime entrypoint also drops to the unprivileged `nextjs` user when a
+hosting security context starts the container as root. Verify PID 1 after
+deployment instead of assuming the Dockerfile `USER` directive was preserved.
+
 Both `NEXT_PUBLIC_APP_URL` and `R2_PUBLIC_URL` are required build arguments.
 Zeabur injects their service-variable values into the multi-stage Docker build;
 the build fails closed when either value is missing.


### PR DESCRIPTION
## Summary
- add a minimal container entrypoint that drops privileges when a hosting platform starts the image as root
- preserve normal startup when the Docker image user is respected
- document the runtime security verification

## Why
Zeabur deployment inspection showed PID 1 running as root even though the image declares `USER nextjs`.

## Verification
- `sh -n docker/entrypoint.sh`
- Docker Compose config validation
- `pnpm prettier:check`
- `pnpm lint`
- `pnpm type-check`
- `git diff --check`

Zeabur deployment after merge will verify PID 1 is actually unprivileged.