### PR TITLE
fix: restore client boundary and rate-limit defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,8 @@ DATABASE_URL="postgres://<user>:<password>@<url>:<port>/<db_name>"
 # DB_IDLE_TIMEOUT=300
 # DB_MAX_LIFETIME=14400
 # DB_CONNECT_TIMEOUT=4
-# Must be overwritten by your trusted reverse proxy.
-RATE_LIMIT_IP_HEADER=x-forwarded-for
+# Optional override for non-Zeabur ingress. Defaults to x-forwarded-for.
+# RATE_LIMIT_IP_HEADER=x-forwarded-for
 
 # Application settings
 NEXT_PUBLIC_APP_URL="http://localhost:3000"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -33,7 +33,6 @@ jobs:
           --health-retries 10
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/saas_ci
-      RATE_LIMIT_IP_HEADER: x-forwarded-for
       BETTER_AUTH_SECRET: ci-only-secret-at-least-32-characters
       RESEND_API_KEY: re_ci_placeholder
       RESEND_EMAIL_FROM: noreply@example.com

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Then edit the `.env` file and fill in all required values.
 | Variable Name                    | Description                                                     | Example                                             |
 | :------------------------------- | :-------------------------------------------------------------- | :-------------------------------------------------- |
 | `DATABASE_URL`                   | **Required.** PostgreSQL connection string.                     | `postgresql://user:password@localhost:5432/db_name` |
-| `RATE_LIMIT_IP_HEADER`           | Client-IP header overwritten by your trusted ingress.           | Platform-specific                                   |
+| `RATE_LIMIT_IP_HEADER`           | Optional trusted client-IP header; defaults to Zeabur.          | `x-forwarded-for`                                   |
 | `NEXT_PUBLIC_APP_URL`            | **Required.** Public URL of your deployed app.                  | `http://localhost:3000` or `https://yourdomain.com` |
 | `BETTER_AUTH_SECRET`             | **Required.** Random session secret, at least 32 characters.    | Generate with `openssl rand -base64 32`             |
 | `RESEND_API_KEY`                 | **Required.** Resend API Key for sending emails.                | `re_xxxxxxxxxxxxxxxx`                               |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -90,7 +90,7 @@ cp .env.example .env
 | 变量名                           | 描述                                                  | 示例                                                |
 | :------------------------------- | :---------------------------------------------------- | :-------------------------------------------------- |
 | `DATABASE_URL`                   | **必需。** PostgreSQL 连接字符串。                    | `postgresql://user:password@localhost:5432/db_name` |
-| `RATE_LIMIT_IP_HEADER`           | 由可信入口覆盖写入的客户端 IP 请求头。                | 以部署平台为准                                      |
+| `RATE_LIMIT_IP_HEADER`           | **选填。** 可信客户端 IP 请求头，默认适配 Zeabur。    | `x-forwarded-for`                                   |
 | `NEXT_PUBLIC_APP_URL`            | **必需。** 您应用部署后的公开 URL。                   | `http://localhost:3000` 或 `https://yourdomain.com` |
 | `BETTER_AUTH_SECRET`             | **必需。** 至少 32 个字符的随机会话密钥。             | 使用 `openssl rand -base64 32` 生成                 |
 | `RESEND_API_KEY`                 | **必需。** 用于发送邮件的 Resend API Key。            | `re_xxxxxxxxxxxxxxxx`                               |

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,9 +28,9 @@ This directory contains Docker configuration for running the UllrAI Starter appl
    production SEO metadata is generated from this value at build time. Set
    `R2_PUBLIC_URL` before building so the storage hostname is included in the
    Next.js image optimization allowlist.
-   `RATE_LIMIT_IP_HEADER` must name a client-IP header that your trusted
-   ingress overwrites; never trust a header passed through directly from the
-   public internet.
+   `RATE_LIMIT_IP_HEADER` defaults to Zeabur's `x-forwarded-for`. Override it
+   only when your trusted ingress uses a different supported header; never
+   trust a header passed through directly from the public internet.
 
 2. **Run the application**
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       DB_IDLE_TIMEOUT: 300
       DB_MAX_LIFETIME: 14400
       DB_CONNECT_TIMEOUT: 4
-      RATE_LIMIT_IP_HEADER: ${RATE_LIMIT_IP_HEADER:?Set the client IP header overwritten by your trusted reverse proxy}
+      RATE_LIMIT_IP_HEADER: ${RATE_LIMIT_IP_HEADER:-x-forwarded-for}
 
       # Application URL
       NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:?Set NEXT_PUBLIC_APP_URL}

--- a/docs/deployment-zeabur.md
+++ b/docs/deployment-zeabur.md
@@ -79,9 +79,9 @@ it manually. Publish production changes only through `release/*` tags.
 9. Exercise English and Simplified Chinese marketing URLs, authentication
    redirects, and an authenticated Dashboard session.
 
-`RATE_LIMIT_IP_HEADER` must be the single-value client-IP header overwritten by
-the active Zeabur ingress. Verify the header behavior for the selected region
-before release; do not assume a generic `X-Forwarded-For` value is trustworthy.
+`RATE_LIMIT_IP_HEADER` is optional and defaults to `x-forwarded-for`, the client
+IP header documented by Zeabur. Override it only when another trusted ingress
+uses a different supported header.
 
 Migrations are a release step, not an application startup hook. This prevents
 multiple replicas from racing on schema changes. The Web service must start

--- a/env.js
+++ b/env.js
@@ -64,12 +64,14 @@ const env = createEnv({
     DB_IDLE_TIMEOUT: z.coerce.number().int().nonnegative().default(300),
     DB_MAX_LIFETIME: z.coerce.number().int().nonnegative().default(14400),
     DB_CONNECT_TIMEOUT: z.coerce.number().int().positive().max(4).default(4),
-    RATE_LIMIT_IP_HEADER: z.enum([
-      "cf-connecting-ip",
-      "x-vercel-forwarded-for",
-      "x-real-ip",
-      "x-forwarded-for",
-    ]),
+    RATE_LIMIT_IP_HEADER: z
+      .enum([
+        "cf-connecting-ip",
+        "x-vercel-forwarded-for",
+        "x-real-ip",
+        "x-forwarded-for",
+      ])
+      .default("x-forwarded-for"),
 
     // Authentication credentials
     GOOGLE_CLIENT_ID: optionalCredentialSchema,

--- a/knip.json
+++ b/knip.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignoreBinaries": ["xdg-open"],
-  "ignoreDependencies": ["content-collections"],
   "ignoreFiles": ["content-collections.ts"],
   "ignoreIssues": {
     "src/database/tables.ts": ["exports"]

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "node .next/standalone/server.js",
     "saas-cli": "node --import tsx packages/cli/src/index.ts",
     "lint": "eslint .",
-    "dead-code:check": "SKIP_ENV_VALIDATION=1 knip",
+    "dead-code:check": "pnpm content:build && SKIP_ENV_VALIDATION=1 knip",
     "type-check": "pnpm content:build && node scripts/clean-next-types.mjs && tsc --noEmit",
     "test": "pnpm content:build && SKIP_ENV_VALIDATION=1 jest",
     "test:watch": "pnpm content:build && SKIP_ENV_VALIDATION=1 jest --watch",

--- a/src/components/ui/copy-button.tsx
+++ b/src/components/ui/copy-button.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useTranslation } from "@/lib/i18n/translation/client";
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";


### PR DESCRIPTION
## What changed

- Mark `CopyButton` as a Client Component.
- Make `RATE_LIMIT_IP_HEADER` optional with Zeabur's `x-forwarded-for` default.
- Apply the same default to Docker Compose and document the override behavior.
- Remove the stale Knip dependency ignore that produced a configuration warning.

## Why

`CopyButton` uses React state, effects, the Clipboard API, and a client-side translation hook, so it needs a client boundary. Zeabur already exposes the client IP through `X-Forwarded-For`, so deployments should not need to repeat that configuration.

## Validation

- `pnpm prettier:check`
- `pnpm lint`
- `pnpm dead-code:check`
- `pnpm type-check`
- `pnpm test --runInBand` (112 suites, 1053 tests)
- `pnpm build` without `RATE_LIMIT_IP_HEADER`
- `docker compose -f docker/docker-compose.yml config --no-interpolate`