### PR TITLE
fix: make auth navigation session-aware

### DIFF
--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -38,6 +38,11 @@ jest.mock("@/lib/auth/providers", () => ({
   getAvailableSocialProviders: () => mockGetAvailableSocialProviders(),
 }));
 
+const mockRequireGuest = jest.fn(async () => undefined);
+jest.mock("@/lib/auth/permissions", () => ({
+  requireGuest: () => mockRequireGuest(),
+}));
+
 const mockCreateMetadataDefaults = jest.fn(() => ({}));
 jest.mock("@/lib/metadata", () => ({
   createMetadataDefaults: () => mockCreateMetadataDefaults(),
@@ -89,6 +94,7 @@ describe("LoginPage", () => {
       }),
     );
     expect(mockGetAvailableSocialProviders).toHaveBeenCalledTimes(1);
+    expect(mockRequireGuest).toHaveBeenCalledTimes(1);
   });
 
   it("passes callbackUrl from search params to AuthForm", async () => {

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -7,6 +7,8 @@ import {
 } from "@/lib/auth/callback-url";
 import { createMetadataDefaults } from "@/lib/metadata";
 import { resolveAuthFeedback } from "@/lib/auth/feedback";
+import { requireGuest } from "@/lib/auth/permissions";
+
 export async function generateMetadata() {
   const { locale, t } = await getServerTranslations();
   const metadata = createMetadataDefaults({ locale });
@@ -35,6 +37,8 @@ interface LoginPageProps {
   }>;
 }
 export default async function LoginPage({ searchParams }: LoginPageProps) {
+  await requireGuest();
+
   const availableProviders = getAvailableSocialProviders();
   const resolvedSearchParams: Awaited<
     NonNullable<LoginPageProps["searchParams"]>

--- a/src/app/(auth)/signup/page.test.tsx
+++ b/src/app/(auth)/signup/page.test.tsx
@@ -32,6 +32,11 @@ jest.mock("@/lib/auth/providers", () => ({
   getAvailableSocialProviders: () => mockGetAvailableSocialProviders(),
 }));
 
+const mockRequireGuest = jest.fn(async () => undefined);
+jest.mock("@/lib/auth/permissions", () => ({
+  requireGuest: () => mockRequireGuest(),
+}));
+
 const mockCreateMetadataDefaults = jest.fn(() => ({}));
 jest.mock("@/lib/metadata", () => ({
   createMetadataDefaults: () => mockCreateMetadataDefaults(),
@@ -76,6 +81,7 @@ describe("SignUpPage", () => {
       }),
     );
     expect(mockGetAvailableSocialProviders).toHaveBeenCalledTimes(1);
+    expect(mockRequireGuest).toHaveBeenCalledTimes(1);
   });
 
   it("passes callbackUrl from search params to signup AuthForm", async () => {

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -5,7 +5,9 @@ import {
   DEFAULT_CALLBACK_URL,
   normalizeCallbackUrl,
 } from "@/lib/auth/callback-url";
+import { requireGuest } from "@/lib/auth/permissions";
 import { createMetadataDefaults } from "@/lib/metadata";
+
 export async function generateMetadata() {
   const { locale, t } = await getServerTranslations();
   const metadata = createMetadataDefaults({ locale });
@@ -31,6 +33,8 @@ interface SignUpPageProps {
   }>;
 }
 export default async function SignUpPage({ searchParams }: SignUpPageProps) {
+  await requireGuest();
+
   const availableProviders = getAvailableSocialProviders();
   const resolvedSearchParams = searchParams ? await searchParams : {};
   const rawCallbackUrl = resolvedSearchParams.callbackUrl;

--- a/src/components/homepage/header-actions.test.tsx
+++ b/src/components/homepage/header-actions.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+
+import { HeaderActions } from "./header-actions";
+
+const mockUseSession = jest.fn();
+
+jest.mock("@/lib/auth/client", () => ({
+  useSession: () => mockUseSession(),
+}));
+
+jest.mock("@/components/locale-switcher", () => ({
+  LocaleSwitcher: () => <button type="button">Locale</button>,
+}));
+
+jest.mock("@/components/mode-toggle", () => ({
+  ModeToggle: () => <button type="button">Theme</button>,
+}));
+
+const labels = {
+  dashboard: "Dashboard",
+  getStarted: "Get Started",
+  navigationMenu: "Navigation Menu",
+  signIn: "Sign In",
+  toggleMenu: "Toggle menu",
+};
+
+const navigationItems = [
+  {
+    id: "features",
+    href: "/features",
+    title: "Features",
+  },
+];
+
+describe("HeaderActions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows guest actions when the user is signed out", () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      isPending: false,
+    });
+
+    render(<HeaderActions labels={labels} navigationItems={navigationItems} />);
+
+    expect(screen.getByRole("link", { name: "Sign In" })).toHaveAttribute(
+      "href",
+      "/login",
+    );
+    expect(screen.getByRole("link", { name: "Get Started" })).toHaveAttribute(
+      "href",
+      "/signup",
+    );
+    expect(
+      screen.queryByRole("link", { name: "Dashboard" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the dashboard action when the user is signed in", () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          id: "user-123",
+        },
+      },
+      isPending: false,
+    });
+
+    render(<HeaderActions labels={labels} navigationItems={navigationItems} />);
+
+    expect(screen.getByRole("link", { name: "Dashboard" })).toHaveAttribute(
+      "href",
+      "/dashboard",
+    );
+    expect(
+      screen.queryByRole("link", { name: "Sign In" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Get Started" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps guest actions hidden while the session is loading", () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      isPending: true,
+    });
+
+    render(<HeaderActions labels={labels} navigationItems={navigationItems} />);
+
+    expect(
+      screen.queryByRole("link", { name: "Sign In" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Get Started" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Dashboard" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/homepage/header-actions.tsx
+++ b/src/components/homepage/header-actions.tsx
@@ -10,18 +10,41 @@ import { Logo } from "@/components/logo";
 import { ModeToggle } from "@/components/mode-toggle";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
+import { useSession } from "@/lib/auth/client";
 import { APP_NAME } from "@/lib/config/constants";
 
 type HeaderLabels = {
+  dashboard: string;
   getStarted: string;
   navigationMenu: string;
   signIn: string;
   toggleMenu: string;
 };
 
-function AuthButtons({ labels }: { labels: HeaderLabels }) {
+function AuthButtons({
+  isAuthenticated,
+  isPending,
+  labels,
+}: {
+  isAuthenticated: boolean;
+  isPending: boolean;
+  labels: HeaderLabels;
+}) {
+  if (isAuthenticated) {
+    return (
+      <div className="hidden items-center md:flex">
+        <Button asChild size="sm">
+          <Link href="/dashboard">{labels.dashboard}</Link>
+        </Button>
+      </div>
+    );
+  }
+
   return (
-    <div className="hidden items-center gap-2 md:flex">
+    <div
+      aria-hidden={isPending}
+      className={`hidden items-center gap-2 md:flex ${isPending ? "invisible" : ""}`}
+    >
       <Button asChild variant="ghost" size="sm">
         <Link href="/login">{labels.signIn}</Link>
       </Button>
@@ -32,9 +55,30 @@ function AuthButtons({ labels }: { labels: HeaderLabels }) {
   );
 }
 
-function MobileAuthButtons({ labels }: { labels: HeaderLabels }) {
+function MobileAuthButtons({
+  isAuthenticated,
+  isPending,
+  labels,
+}: {
+  isAuthenticated: boolean;
+  isPending: boolean;
+  labels: HeaderLabels;
+}) {
+  if (isAuthenticated) {
+    return (
+      <div className="mt-8">
+        <Button asChild className="w-full">
+          <Link href="/dashboard">{labels.dashboard}</Link>
+        </Button>
+      </div>
+    );
+  }
+
   return (
-    <div className="mt-8 space-y-3">
+    <div
+      aria-hidden={isPending}
+      className={`mt-8 space-y-3 ${isPending ? "invisible" : ""}`}
+    >
       <Button asChild className="w-full">
         <Link href="/login">{labels.signIn}</Link>
       </Button>
@@ -53,12 +97,18 @@ export function HeaderActions({
   navigationItems: MarketingNavItem[];
 }) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const { data: session, isPending } = useSession();
+  const isAuthenticated = Boolean(session?.user);
 
   return (
     <div className="flex items-center gap-3">
       <LocaleSwitcher variant="ghost" size="icon" />
       <ModeToggle variant="ghost" size="icon" />
-      <AuthButtons labels={labels} />
+      <AuthButtons
+        isAuthenticated={isAuthenticated}
+        isPending={isPending}
+        labels={labels}
+      />
 
       <Button
         variant="ghost"
@@ -92,7 +142,11 @@ export function HeaderActions({
               ))}
             </nav>
 
-            <MobileAuthButtons labels={labels} />
+            <MobileAuthButtons
+              isAuthenticated={isAuthenticated}
+              isPending={isPending}
+              labels={labels}
+            />
           </div>
         </SheetContent>
       </Sheet>

--- a/src/components/homepage/header.tsx
+++ b/src/components/homepage/header.tsx
@@ -82,6 +82,7 @@ export function Header({
           <HeaderActions
             navigationItems={navigationItems}
             labels={{
+              dashboard: t("header_dashboard", "Dashboard"),
               getStarted: t("3dd52b8e342a", "Get Started"),
               navigationMenu: t("2924b40503f8", "Navigation Menu"),
               signIn: t("6639ec6351f1", "Sign In"),

--- a/src/lib/auth/permissions.test.ts
+++ b/src/lib/auth/permissions.test.ts
@@ -127,6 +127,35 @@ describe("Auth Permissions", () => {
     });
   });
 
+  describe("requireGuest", () => {
+    it("should redirect authenticated users to dashboard", async () => {
+      mockAuth.api.getSession.mockResolvedValue({
+        session: { userId: "user-123" },
+        user: {
+          id: "user-123",
+          email: "user@example.com",
+          role: "user",
+          name: "Test User",
+          image: null,
+        },
+      });
+
+      const { requireGuest } = await import("./permissions");
+
+      await expect(requireGuest()).rejects.toThrow("NEXT_REDIRECT: /dashboard");
+      expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
+    });
+
+    it("should allow unauthenticated users", async () => {
+      mockAuth.api.getSession.mockResolvedValue({ session: null, user: null });
+
+      const { requireGuest } = await import("./permissions");
+
+      await expect(requireGuest()).resolves.toBeUndefined();
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+  });
+
   describe("requireAdmin", () => {
     it("should return admin user when authenticated with admin role", async () => {
       const mockAdmin = {

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -66,6 +66,17 @@ export async function requireAuth(requiredRole?: UserRole): Promise<AuthUser> {
 }
 
 /**
+ * Redirect authenticated users away from guest-only pages.
+ */
+export async function requireGuest(): Promise<void> {
+  const user = await getCurrentUser();
+
+  if (user) {
+    redirect("/dashboard");
+  }
+}
+
+/**
  * Require admin role
  */
 export async function requireAdmin(): Promise<AuthUser> {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1141,5 +1141,6 @@
   "upload_batch_delete_error": "We couldn't delete the selected uploads. Please try again.",
   "upload_batch_delete_success": "The selected uploads were deleted.",
   "upload_delete_error": "We couldn't delete the upload. Please try again.",
-  "upload_delete_success": "The upload has been deleted."
+  "upload_delete_success": "The upload has been deleted.",
+  "header_dashboard": "Dashboard"
 }

--- a/src/messages/zh-Hans.json
+++ b/src/messages/zh-Hans.json
@@ -1141,5 +1141,6 @@
   "upload_batch_delete_error": "所选上传记录删除失败，请重试。",
   "upload_batch_delete_success": "所选上传记录已删除。",
   "upload_delete_error": "上传记录删除失败，请重试。",
-  "upload_delete_success": "上传记录已删除。"
+  "upload_delete_success": "上传记录已删除。",
+  "header_dashboard": "控制台"
 }


### PR DESCRIPTION
## What changed

- make the marketing header show Dashboard for authenticated users
- hide guest actions while the session is loading to prevent UI flicker
- redirect authenticated users away from login and signup pages
- add English and Simplified Chinese copy plus focused tests

## Why

The marketing header always rendered sign-in and signup actions, and authenticated users could still open guest-only auth pages. The UI now reflects the active session while preserving static generation for marketing content.

## Validation

- `pnpm lint`
- `pnpm type-check`
- `pnpm prettier:check`
- `pnpm test --runInBand` — 113 suites, 1058 tests
- `SKIP_ENV_VALIDATION=1 pnpm build`
