### PR TITLE
Enforce semantic release tags

### DIFF
--- a/.github/workflows/promote-release-to-prod.yml
+++ b/.github/workflows/promote-release-to-prod.yml
@@ -3,7 +3,7 @@ name: Promote release tag to prod
 on:
   push:
     tags:
-      - "release/*"
+      - "release/v*.*.*"
 
 permissions:
   contents: write
@@ -22,6 +22,25 @@ jobs:
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
+
+      - name: Validate release version
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${RELEASE_TAG}" =~ ^release/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::Release tags must use the release/vX.Y.Z format"
+            exit 1
+          fi
+
+          release_version="${RELEASE_TAG#release/v}"
+          package_version="$(node -p "require('./package.json').version")"
+
+          if [ "${release_version}" != "${package_version}" ]; then
+            echo "::error::${RELEASE_TAG} does not match package.json version ${package_version}"
+            exit 1
+          fi
 
       - name: Promote tagged commit to prod
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,8 +174,8 @@ pnpm creem:sync-products
 
 - The production Zeabur service tracks `prod`, not the default development
   branch.
-- Publish production changes by pushing a `release/*` tag on a reviewed commit
-  from the repository's default branch.
+- Publish production changes by pushing a `release/vX.Y.Z` tag that matches
+  `package.json` on a reviewed commit from the repository's default branch.
 - `.github/workflows/promote-release-to-prod.yml` validates the tag ancestry and
   updates `prod`. Do not push or merge directly into `prod`.
 - Resolve the default branch dynamically in release automation. The current

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ repository also includes a standalone multi-stage Docker build.
 
 Configure the production Zeabur service to deploy the `prod` branch, not
 the default development branch (`main` in this repository). Pushing a
-`release/*` tag runs
+`release/vX.Y.Z` tag matching the version in `package.json` runs
 [`promote-release-to-prod.yml`](.github/workflows/promote-release-to-prod.yml),
 which verifies that the tagged commit belongs to the repository's default
 branch (`main` at present) before moving `prod` to that commit. Zeabur deploys
@@ -456,7 +456,8 @@ see [the Zeabur deployment guide](docs/deployment-zeabur.md#using-the-workflow-i
 3. Run `pnpm db:migrate` once as a dedicated release command against the
    production `DATABASE_URL`. Do not attach migrations to every web process
    startup.
-4. Tag that commit with an annotated `release/*` tag and push the tag:
+4. Update the version in `package.json`, then tag that commit with an annotated
+   `release/vX.Y.Z` tag using the same version and push it:
 
    ```bash
    git tag -a release/v1.2.3 -m "Release v1.2.3"

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -426,7 +426,7 @@ Docker 构建。
 > 结账时输入推荐码 `visoar`，即可享受 10% 折扣。
 
 将生产环境 Zeabur 服务的部署分支设为 `prod`，不要监听日常开发使用的默认分支（本仓库
-为 `main`）。推送 `release/*` tag 后，
+为 `main`）。推送与 `package.json` 版本一致的 `release/vX.Y.Z` tag 后，
 [`promote-release-to-prod.yml`](.github/workflows/promote-release-to-prod.yml)
 会先确认对应 commit 位于仓库默认分支的历史中，再将 `prod` 指向该 commit；只有分支
 更新成功后，Zeabur 才会开始部署。fork 后可沿用同一方案，详见
@@ -438,7 +438,8 @@ Docker 构建。
    `R2_PUBLIC_URL`，让 Next.js 把存储域名加入图片优化白名单。
 3. 使用生产 `DATABASE_URL` 把 `pnpm db:migrate` 作为一次性发布命令执行；不要挂在
    每个 Web 进程的启动钩子上。
-4. 在该 commit 上创建 `release/*` 附注标签（annotated tag）并推送：
+4. 更新 `package.json` 中的版本，然后在该 commit 上创建版本一致的
+   `release/vX.Y.Z` 附注标签（annotated tag）并推送：
 
    ```bash
    git tag -a release/v1.2.3 -m "Release v1.2.3"

--- a/docs/deployment-zeabur.md
+++ b/docs/deployment-zeabur.md
@@ -24,7 +24,7 @@ the build fails closed when either value is missing.
 Configure the production Zeabur service to deploy the `prod` branch. It must not
 deploy direct pushes to the default development branch.
 
-Pushing a `release/*` tag triggers
+Pushing a `release/vX.Y.Z` tag matching the version in `package.json` triggers
 [`promote-release-to-prod.yml`](../.github/workflows/promote-release-to-prod.yml).
 The workflow reads the repository's default branch from GitHub instead of
 hardcoding its name, verifies that the tagged commit is reachable from that
@@ -58,14 +58,15 @@ named `main` or `master`:
    allow this workflow to update it with a force-with-lease push.
 
 Treat `prod` as workflow-owned state: do not merge pull requests into it or push
-it manually. Publish production changes only through `release/*` tags.
+it manually. Publish production changes only through `release/vX.Y.Z` tags.
 
 ## Release order
 
 1. Merge only a reviewed commit into the default branch with green CI.
 2. Confirm the service variables match `.env.example`.
 3. Run `pnpm db:migrate` once against the production `DATABASE_URL`.
-4. Create an annotated `release/*` tag on that commit and push it:
+4. Update the version in `package.json`, then create an annotated
+   `release/vX.Y.Z` tag using the same version on that commit and push it:
 
    ```bash
    git tag -a release/v1.2.3 -m "Release v1.2.3"


### PR DESCRIPTION
## Summary
- accept only `release/vX.Y.Z` production tags
- require the tag version to match `package.json`
- document the semantic release convention consistently

## Verification
- `pnpm prettier:check`
- shell validation for accepted and rejected tag formats
- `git diff --check`