### PR TITLE
Harden dependencies and E2E isolation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,8 @@ UPLOAD_CLEANUP_SECRET="replace-with-at-least-32-random-characters"
 CREEM_ENVIRONMENT=test_mode
 CREEM_API_KEY=creem_test_api_key_here
 CREEM_WEBHOOK_SECRET=whsec_test_secret_here
+
+# E2E testing
+# Required only by pnpm test:e2e. Use a dedicated local database.
+# E2E_DATABASE_URL="postgresql://postgres:postgres@localhost:5432/saas_e2e"
+# E2E_BASE_URL="http://127.0.0.1:3100"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -21,18 +21,19 @@ jobs:
       postgres:
         image: postgres:16-alpine
         env:
-          POSTGRES_DB: saas_ci
+          POSTGRES_DB: saas_e2e
           POSTGRES_PASSWORD: postgres
           POSTGRES_USER: postgres
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U postgres -d saas_ci"
+          --health-cmd "pg_isready -U postgres -d saas_e2e"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
     env:
-      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/saas_ci
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/saas_e2e
+      E2E_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/saas_e2e
       BETTER_AUTH_SECRET: ci-only-secret-at-least-32-characters
       RESEND_API_KEY: re_ci_placeholder
       RESEND_EMAIL_FROM: noreply@example.com
@@ -73,8 +74,5 @@ jobs:
       - run: pnpm dead-code:check
       - run: pnpm type-check
       - run: pnpm test --runInBand
-      - run: pnpm build
-        env:
-          NEXT_PUBLIC_APP_URL: http://127.0.0.1:3100
       - run: pnpm exec playwright install --with-deps chromium
-      - run: pnpm exec playwright test
+      - run: pnpm test:e2e

--- a/README.md
+++ b/README.md
@@ -279,10 +279,14 @@ This repository includes a Playwright smoke test suite in `e2e/` for the most im
 Run the suite with:
 
 ```bash
+createdb saas_e2e
+# Add E2E_DATABASE_URL=postgresql://.../saas_e2e to .env
 pnpm test:e2e
 ```
 
-The Playwright runner starts the production server through `pnpm start` and enables a test-only session route with `E2E_TEST_MODE=true`. That route requires an explicit `E2E_TEST_SECRET` of at least 32 characters, signs the test cookie with that secret, and is disabled for non-local production deployments. Playwright generates a per-run secret when one is not provided by CI.
+`E2E_DATABASE_URL` is mandatory and must point to a dedicated local PostgreSQL database whose name contains a standalone `e2e` or `test` segment. Outside CI, the runner rejects the regular `DATABASE_URL` to prevent test users, API keys, CLI tokens, device codes, and rate-limit state from reaching a development or shared database. It applies migrations, builds the app, starts the production server, and cleans E2E fixtures before and after the suite.
+
+The test-only session route is enabled only while Playwright is running against the declared E2E database. It also requires an explicit `E2E_TEST_SECRET` of at least 32 characters and is disabled for non-local production deployments. Playwright generates a per-run secret when CI does not provide one.
 
 #### Bundle Analysis Scripts
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -277,10 +277,14 @@ pnpm set:admin --email=your-email@example.com
 运行方式：
 
 ```bash
+createdb saas_e2e
+# 在 .env 中添加 E2E_DATABASE_URL=postgresql://.../saas_e2e
 pnpm test:e2e
 ```
 
-Playwright 会通过 `pnpm start` 启动生产服务，并在测试期间启用仅供测试使用的会话入口：`E2E_TEST_MODE=true`。该入口要求显式配置至少 32 个字符的 `E2E_TEST_SECRET`，测试 cookie 会用该密钥签名，且非本机生产部署会禁用该入口。CI 未提供密钥时，Playwright 会为每次运行生成临时密钥。
+`E2E_DATABASE_URL` 为必填项，必须指向专用的本地 PostgreSQL 数据库，且数据库名需包含独立的 `e2e` 或 `test` 片段。CI 之外，runner 会拒绝使用常规 `DATABASE_URL`，防止测试用户、API Key、CLI token、device code 与限流状态写入开发库或共享库。它会统一执行迁移、构建、启动生产服务，并在测试前后清理 E2E 数据。
+
+测试会话入口仅在 Playwright 连接到声明的 E2E 数据库时启用。该入口还要求显式配置至少 32 个字符的 `E2E_TEST_SECRET`，且会在非本机生产部署中禁用。CI 未提供密钥时，Playwright 会为每次运行生成临时密钥。
 
 #### 包体积分析脚本
 

--- a/e2e/database-fixtures.ts
+++ b/e2e/database-fixtures.ts
@@ -1,0 +1,37 @@
+import postgres from "postgres";
+
+const E2E_USER_ID_PATTERN = "e2e-%";
+const E2E_CLIENT_NAME = "Playwright CLI";
+const MACHINE_AUTH_RATE_LIMIT_SCOPES = [
+  "device_code",
+  "device_pending",
+  "device_refresh",
+];
+
+export async function cleanupE2EFixtures(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required for E2E fixture cleanup.");
+  }
+
+  const sql = postgres(databaseUrl, { max: 1 });
+  try {
+    await sql.begin(async (transaction) => {
+      await transaction`
+        delete from device_codes
+        where "clientName" = ${E2E_CLIENT_NAME}
+           or "userId" like ${E2E_USER_ID_PATTERN}
+      `;
+      await transaction`
+        delete from rate_limit_buckets
+        where scope in ${transaction(MACHINE_AUTH_RATE_LIMIT_SCOPES)}
+      `;
+      await transaction`
+        delete from users
+        where id like ${E2E_USER_ID_PATTERN}
+      `;
+    });
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}

--- a/e2e/environment.ts
+++ b/e2e/environment.ts
@@ -1,0 +1,90 @@
+const DEFAULT_E2E_ORIGIN = "http://127.0.0.1:3100";
+const SAFE_DATABASE_NAME_PATTERN = /(?:^|[_-])(?:e2e|test)(?:[_-]|$)/i;
+const LOCAL_HOSTNAMES = new Set(["127.0.0.1", "[::1]", "localhost"]);
+
+export interface E2EEnvironment {
+  databaseUrl: string;
+  origin: string;
+  port: number;
+}
+
+function getDatabaseTarget(url: URL): string {
+  const databaseName = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
+  return `${url.port || "5432"}/${databaseName}`;
+}
+
+function isPlaywrightWorker(): boolean {
+  return (
+    /^\d+$/.test(process.env.TEST_WORKER_INDEX ?? "") &&
+    /^\d+$/.test(process.env.TEST_PARALLEL_INDEX ?? "")
+  );
+}
+
+function resolveDatabaseUrl(): string {
+  const databaseUrl = process.env.E2E_DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    throw new Error(
+      "E2E_DATABASE_URL is required. Use a dedicated database whose name contains 'e2e' or 'test'.",
+    );
+  }
+
+  const url = new URL(databaseUrl);
+  if (!["postgres:", "postgresql:"].includes(url.protocol)) {
+    throw new Error("E2E_DATABASE_URL must use PostgreSQL.");
+  }
+  if (!LOCAL_HOSTNAMES.has(url.hostname)) {
+    throw new Error("E2E_DATABASE_URL must point to a local database.");
+  }
+
+  const databaseName = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
+  if (!SAFE_DATABASE_NAME_PATTERN.test(databaseName)) {
+    throw new Error(
+      `Refusing to run E2E tests against database "${databaseName}". Its name must contain a standalone 'e2e' or 'test' segment.`,
+    );
+  }
+  if (
+    process.env.CI !== "true" &&
+    !isPlaywrightWorker() &&
+    process.env.DATABASE_URL &&
+    getDatabaseTarget(new URL(process.env.DATABASE_URL)) ===
+      getDatabaseTarget(url)
+  ) {
+    throw new Error(
+      "E2E_DATABASE_URL must differ from DATABASE_URL outside CI.",
+    );
+  }
+
+  return databaseUrl;
+}
+
+function resolveOrigin(): { origin: string; port: number } {
+  const rawOrigin = process.env.E2E_BASE_URL?.trim() || DEFAULT_E2E_ORIGIN;
+  const url = new URL(rawOrigin);
+  if (
+    url.protocol !== "http:" ||
+    !LOCAL_HOSTNAMES.has(url.hostname) ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error(
+      "E2E_BASE_URL must be a local HTTP origin without a path, query, or hash.",
+    );
+  }
+
+  const port = Number(url.port || "80");
+  if (!Number.isSafeInteger(port) || port <= 0) {
+    throw new Error("E2E_BASE_URL must include a valid port.");
+  }
+
+  return { origin: url.origin, port };
+}
+
+export function resolveE2EEnvironment(): E2EEnvironment {
+  return {
+    databaseUrl: resolveDatabaseUrl(),
+    ...resolveOrigin(),
+  };
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,3 @@
+import { cleanupE2EFixtures } from "./database-fixtures";
+
+export default cleanupE2EFixtures;

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,3 @@
+import { cleanupE2EFixtures } from "./database-fixtures";
+
+export default cleanupE2EFixtures;

--- a/env.js
+++ b/env.js
@@ -132,6 +132,7 @@ const env = createEnv({
     CREEM_WEBHOOK_SECRET: requiredCredentialSchema,
 
     // E2E testing
+    E2E_DATABASE_URL: databaseUrlSchema.optional(),
     E2E_TEST_MODE: z.enum(["true", "false"]).optional(),
     E2E_TEST_SECRET: z.string().optional(),
   },
@@ -187,6 +188,7 @@ const env = createEnv({
     CREEM_WEBHOOK_SECRET: process.env.CREEM_WEBHOOK_SECRET,
 
     // E2E testing
+    E2E_DATABASE_URL: process.env.E2E_DATABASE_URL,
     E2E_TEST_MODE: process.env.E2E_TEST_MODE,
     E2E_TEST_SECRET: process.env.E2E_TEST_SECRET,
   },

--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,15 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignoreBinaries": ["xdg-open"],
   "ignoreFiles": ["content-collections.ts"],
+  "playwright": {
+    "config": [],
+    "entry": [
+      "playwright.config.ts",
+      "e2e/**/*.spec.ts",
+      "e2e/global-setup.ts",
+      "e2e/global-teardown.ts"
+    ]
+  },
   "ignoreIssues": {
     "src/database/tables.ts": ["exports"]
   }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "test": "pnpm content:build && SKIP_ENV_VALIDATION=1 jest",
     "test:watch": "pnpm content:build && SKIP_ENV_VALIDATION=1 jest --watch",
     "test:coverage": "pnpm content:build && SKIP_ENV_VALIDATION=1 jest --coverage",
-    "test:e2e": "pnpm build && playwright test",
-    "test:e2e:headed": "pnpm build && playwright test --headed",
+    "test:e2e": "node --env-file-if-exists=.env --import tsx scripts/run-e2e.ts",
+    "test:e2e:headed": "node --env-file-if-exists=.env --import tsx scripts/run-e2e.ts --headed",
     "db:generate": "drizzle-kit generate --config=src/database/config.ts",
     "db:migrate": "drizzle-kit migrate --config=src/database/config.ts",
     "db:push": "drizzle-kit push --config=src/database/config.ts",
@@ -98,7 +98,7 @@
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
     "knip": "^6.29.0",
-    "postcss": "^8.5.15",
+    "postcss": "^8.5.25",
     "postcss-load-config": "^6.0.1",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
@@ -113,7 +113,8 @@
       "@modelcontextprotocol/sdk": "1.29.0",
       "ai": "6.0.197",
       "body-parser": "2.3.0",
-      "brace-expansion@^1.1.0": "1.1.16",
+      "brace-expansion@^1.1.0": "1.1.17",
+      "brace-expansion@^2.0.0": "2.1.3",
       "brace-expansion@^5.0.0": "5.0.8",
       "diff": "8.0.3",
       "effect": "3.21.2",
@@ -129,12 +130,13 @@
       "path-to-regexp": "8.4.2",
       "picomatch@^2.3.1": "2.3.2",
       "picomatch@^4.0.0": "4.0.4",
-      "postcss": "8.5.15",
+      "postcss": "8.5.25",
       "qs": "6.15.2",
       "serialize-javascript": "7.0.5",
       "sharp": "0.35.3",
       "tmp": "0.2.7",
       "uuid": "11.1.1",
+      "valibot": "1.4.2",
       "ws@^8.0.0": "8.21.0",
       "yaml": "2.9.0"
     },
@@ -151,6 +153,11 @@
       "esbuild",
       "sharp",
       "unrs-resolver"
-    ]
+    ],
+    "auditConfig": {
+      "ignoreCves": [
+        "GHSA-mh99-v99m-4gvg"
+      ]
+    }
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,15 +1,19 @@
 import { defineConfig, devices } from "@playwright/test";
 import { randomBytes } from "node:crypto";
+import { resolveE2EEnvironment } from "./e2e/environment";
 
-const port = 3100;
-const baseURL = `http://127.0.0.1:${port}`;
+const { databaseUrl, origin: baseURL, port } = resolveE2EEnvironment();
 const e2eTestSecret =
   process.env.E2E_TEST_SECRET ?? randomBytes(32).toString("hex");
 
+process.env.DATABASE_URL = databaseUrl;
 process.env.E2E_TEST_SECRET = e2eTestSecret;
+process.env.NEXT_PUBLIC_APP_URL = baseURL;
 
 export default defineConfig({
   testDir: "./e2e",
+  globalSetup: "./e2e/global-setup.ts",
+  globalTeardown: "./e2e/global-teardown.ts",
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 2 : 0,
@@ -22,7 +26,16 @@ export default defineConfig({
     video: "retain-on-failure",
   },
   webServer: {
-    command: `PORT=${port} NEXT_PUBLIC_APP_URL=${baseURL} E2E_TEST_MODE=true PLAYWRIGHT=true E2E_TEST_SECRET=${e2eTestSecret} pnpm start`,
+    command: "pnpm start",
+    env: {
+      DATABASE_URL: databaseUrl,
+      E2E_DATABASE_URL: databaseUrl,
+      E2E_TEST_MODE: "true",
+      E2E_TEST_SECRET: e2eTestSecret,
+      NEXT_PUBLIC_APP_URL: baseURL,
+      PLAYWRIGHT: "true",
+      PORT: String(port),
+    },
     url: baseURL,
     reuseExistingServer: false,
     timeout: 120 * 1000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,8 @@ overrides:
   "@modelcontextprotocol/sdk": 1.29.0
   ai: 6.0.197
   body-parser: 2.3.0
-  brace-expansion@^1.1.0: 1.1.16
+  brace-expansion@^1.1.0: 1.1.17
+  brace-expansion@^2.0.0: 2.1.3
   brace-expansion@^5.0.0: 5.0.8
   diff: 8.0.3
   effect: 3.21.2
@@ -25,12 +26,13 @@ overrides:
   path-to-regexp: 8.4.2
   picomatch@^2.3.1: 2.3.2
   picomatch@^4.0.0: 4.0.4
-  postcss: 8.5.15
+  postcss: 8.5.25
   qs: 6.15.2
   serialize-javascript: 7.0.5
   sharp: 0.35.3
   tmp: 0.2.7
   uuid: 11.1.1
+  valibot: 1.4.2
   ws@^8.0.0: 8.21.0
   yaml: 2.9.0
 
@@ -87,7 +89,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@t3-oss/env-nextjs":
         specifier: ^0.13.11
-        version: 0.13.11(typescript@5.9.3)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
+        version: 0.13.11(typescript@5.9.3)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
       better-auth:
         specifier: ^1.6.25
         version: 1.6.25(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.29.4)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)))(mongodb@7.1.0)(mysql2@3.15.3)(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -231,11 +233,11 @@ importers:
         specifier: ^6.29.0
         version: 6.29.0
       postcss:
-        specifier: 8.5.15
-        version: 8.5.15
+        specifier: 8.5.25
+        version: 8.5.25
       postcss-load-config:
         specifier: ^6.0.1
-        version: 6.0.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.3)(yaml@2.9.0)
+        version: 6.0.1(jiti@2.7.0)(postcss@8.5.25)(tsx@4.22.3)(yaml@2.9.0)
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -3669,7 +3671,7 @@ packages:
     peerDependencies:
       arktype: ^2.1.0
       typescript: ">=5.0.0"
-      valibot: ^1.0.0-beta.7 || ^1.0.0
+      valibot: 1.4.2
       zod: ^3.24.0 || ^4.0.0
     peerDependenciesMeta:
       arktype:
@@ -3689,7 +3691,7 @@ packages:
     peerDependencies:
       arktype: ^2.1.0
       typescript: ">=5.0.0"
-      valibot: ^1.0.0-beta.7 || ^1.0.0
+      valibot: 1.4.2
       zod: ^3.24.0 || ^4.0.0
     peerDependenciesMeta:
       arktype:
@@ -4871,16 +4873,16 @@ packages:
         integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==,
       }
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.17:
     resolution:
       {
-        integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==,
+        integrity: sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==,
       }
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.3:
     resolution:
       {
-        integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==,
+        integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==,
       }
 
   brace-expansion@5.0.8:
@@ -8260,10 +8262,10 @@ packages:
       }
     engines: { node: ">=8.0.0" }
 
-  nanoid@3.3.12:
+  nanoid@3.3.16:
     resolution:
       {
-        integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
+        integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==,
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
@@ -8833,7 +8835,7 @@ packages:
     engines: { node: ">= 18" }
     peerDependencies:
       jiti: ">=1.21.0"
-      postcss: 8.5.15
+      postcss: 8.5.25
       tsx: ^4.8.1
       yaml: 2.9.0
     peerDependenciesMeta:
@@ -8846,10 +8848,10 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.15:
+  postcss@8.5.25:
     resolution:
       {
-        integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
+        integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -10311,10 +10313,10 @@ packages:
       }
     engines: { node: ">=10.12.0" }
 
-  valibot@1.2.0:
+  valibot@1.4.2:
     resolution:
       {
-        integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==,
+        integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==,
       }
     peerDependencies:
       typescript: ">=5"
@@ -12173,7 +12175,7 @@ snapshots:
       proper-lockfile: 4.1.2
       remeda: 2.33.4
       std-env: 3.10.0
-      valibot: 1.2.0(typescript@5.9.3)
+      valibot: 1.4.2(typescript@5.9.3)
       zeptomatch: 2.1.0
     transitivePeerDependencies:
       - typescript
@@ -12826,18 +12828,18 @@ snapshots:
     dependencies:
       "@swc/counter": 0.1.3
 
-  "@t3-oss/env-core@0.13.11(typescript@5.9.3)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)":
+  "@t3-oss/env-core@0.13.11(typescript@5.9.3)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)":
     optionalDependencies:
       typescript: 5.9.3
-      valibot: 1.2.0(typescript@5.9.3)
+      valibot: 1.4.2(typescript@5.9.3)
       zod: 4.4.3
 
-  "@t3-oss/env-nextjs@0.13.11(typescript@5.9.3)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)":
+  "@t3-oss/env-nextjs@0.13.11(typescript@5.9.3)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)":
     dependencies:
-      "@t3-oss/env-core": 0.13.11(typescript@5.9.3)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
+      "@t3-oss/env-core": 0.13.11(typescript@5.9.3)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
     optionalDependencies:
       typescript: 5.9.3
-      valibot: 1.2.0(typescript@5.9.3)
+      valibot: 1.4.2(typescript@5.9.3)
       zod: 4.4.3
 
   "@tailwindcss/node@4.3.0":
@@ -12906,7 +12908,7 @@ snapshots:
       "@alloc/quick-lru": 5.2.0
       "@tailwindcss/node": 4.3.0
       "@tailwindcss/oxide": 4.3.0
-      postcss: 8.5.15
+      postcss: 8.5.25
       tailwindcss: 4.3.0
 
   "@testing-library/dom@10.4.1":
@@ -13539,12 +13541,12 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.17:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.3:
     dependencies:
       balanced-match: 1.0.2
 
@@ -16008,11 +16010,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.17
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.3
 
   minimist@1.2.8: {}
 
@@ -16053,7 +16055,7 @@ snapshots:
       lru.min: 1.1.4
     optional: true
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   nanostores@1.4.1: {}
 
@@ -16101,7 +16103,7 @@ snapshots:
       "@swc/helpers": 0.5.15
       baseline-browser-mapping: 2.11.1
       caniuse-lite: 1.0.30001806
-      postcss: 8.5.15
+      postcss: 8.5.25
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(babel-plugin-macros@3.1.0)(react@19.2.6)
@@ -16416,18 +16418,18 @@ snapshots:
 
   postal-mime@2.7.4: {}
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.3)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.25)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
-      postcss: 8.5.15
+      postcss: 8.5.25
       tsx: 4.22.3
       yaml: 2.9.0
 
-  postcss@8.5.15:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -17424,7 +17426,7 @@ snapshots:
       "@types/istanbul-lib-coverage": 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@1.2.0(typescript@5.9.3):
+  valibot@1.4.2(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
     optional: true

--- a/scripts/e2e-environment.test.ts
+++ b/scripts/e2e-environment.test.ts
@@ -15,6 +15,15 @@ function restoreEnvValue(key: string, value: string | undefined): void {
   }
 }
 
+beforeEach(() => {
+  delete process.env.E2E_DATABASE_URL;
+  delete process.env.E2E_BASE_URL;
+  delete process.env.DATABASE_URL;
+  delete process.env.CI;
+  delete process.env.TEST_WORKER_INDEX;
+  delete process.env.TEST_PARALLEL_INDEX;
+});
+
 afterEach(() => {
   restoreEnvValue("E2E_DATABASE_URL", originalDatabaseUrl);
   restoreEnvValue("E2E_BASE_URL", originalBaseUrl);

--- a/scripts/e2e-environment.test.ts
+++ b/scripts/e2e-environment.test.ts
@@ -1,0 +1,174 @@
+import { resolveE2EEnvironment } from "../e2e/environment";
+
+const originalDatabaseUrl = process.env.E2E_DATABASE_URL;
+const originalAppDatabaseUrl = process.env.DATABASE_URL;
+const originalBaseUrl = process.env.E2E_BASE_URL;
+const originalCI = process.env.CI;
+const originalWorkerIndex = process.env.TEST_WORKER_INDEX;
+const originalParallelIndex = process.env.TEST_PARALLEL_INDEX;
+
+function restoreEnvValue(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  restoreEnvValue("E2E_DATABASE_URL", originalDatabaseUrl);
+  restoreEnvValue("E2E_BASE_URL", originalBaseUrl);
+  restoreEnvValue("DATABASE_URL", originalAppDatabaseUrl);
+  restoreEnvValue("CI", originalCI);
+  restoreEnvValue("TEST_WORKER_INDEX", originalWorkerIndex);
+  restoreEnvValue("TEST_PARALLEL_INDEX", originalParallelIndex);
+});
+
+describe("resolveE2EEnvironment", () => {
+  it("requires an explicit E2E database URL", () => {
+    delete process.env.E2E_DATABASE_URL;
+
+    expect(() => resolveE2EEnvironment()).toThrow(
+      "E2E_DATABASE_URL is required",
+    );
+  });
+
+  it("rejects a database without an E2E or test name segment", () => {
+    process.env.E2E_DATABASE_URL =
+      "postgresql://postgres:postgres@localhost:5432/saas";
+
+    expect(() => resolveE2EEnvironment()).toThrow(
+      'Refusing to run E2E tests against database "saas"',
+    );
+  });
+
+  it("rejects a non-PostgreSQL database URL", () => {
+    process.env.E2E_DATABASE_URL = "mysql://root:root@localhost:3306/saas_e2e";
+
+    expect(() => resolveE2EEnvironment()).toThrow(
+      "E2E_DATABASE_URL must use PostgreSQL",
+    );
+  });
+
+  it("rejects a remote E2E database", () => {
+    process.env.E2E_DATABASE_URL =
+      "postgresql://postgres:postgres@db.example.com:5432/saas_e2e";
+
+    expect(() => resolveE2EEnvironment()).toThrow(
+      "E2E_DATABASE_URL must point to a local database",
+    );
+  });
+
+  it("rejects the active development database outside CI", () => {
+    process.env.E2E_DATABASE_URL =
+      "postgresql://postgres:postgres@localhost:5432/saas_e2e";
+    process.env.DATABASE_URL = process.env.E2E_DATABASE_URL;
+    delete process.env.CI;
+
+    expect(() => resolveE2EEnvironment()).toThrow(
+      "E2E_DATABASE_URL must differ from DATABASE_URL outside CI",
+    );
+  });
+
+  it("does not treat a false CI value as CI", () => {
+    process.env.E2E_DATABASE_URL =
+      "postgresql://postgres:postgres@localhost:5432/saas_e2e";
+    process.env.DATABASE_URL = process.env.E2E_DATABASE_URL;
+    process.env.CI = "false";
+
+    expect(() => resolveE2EEnvironment()).toThrow(
+      "E2E_DATABASE_URL must differ from DATABASE_URL outside CI",
+    );
+  });
+
+  it("normalizes local host aliases, protocols, and default ports", () => {
+    process.env.E2E_DATABASE_URL = "postgresql://e2e:e2e@127.0.0.1/saas_e2e";
+    process.env.DATABASE_URL = "postgres://app:app@localhost:5432/saas_e2e";
+    delete process.env.CI;
+
+    expect(() => resolveE2EEnvironment()).toThrow(
+      "E2E_DATABASE_URL must differ from DATABASE_URL outside CI",
+    );
+  });
+
+  it("returns a dedicated database and the default local origin", () => {
+    process.env.E2E_DATABASE_URL =
+      "postgresql://postgres:postgres@localhost:5432/saas_e2e";
+    process.env.DATABASE_URL =
+      "postgresql://postgres:postgres@localhost:5432/saas";
+    delete process.env.E2E_BASE_URL;
+
+    expect(resolveE2EEnvironment()).toEqual({
+      databaseUrl: "postgresql://postgres:postgres@localhost:5432/saas_e2e",
+      origin: "http://127.0.0.1:3100",
+      port: 3100,
+    });
+  });
+
+  it("allows explicit database reuse in CI", () => {
+    process.env.E2E_DATABASE_URL =
+      "postgresql://postgres:postgres@localhost:5432/saas_e2e";
+    process.env.DATABASE_URL = process.env.E2E_DATABASE_URL;
+    process.env.CI = "true";
+
+    expect(resolveE2EEnvironment().databaseUrl).toBe(
+      process.env.E2E_DATABASE_URL,
+    );
+  });
+
+  it("allows the validated database after Playwright starts a worker", () => {
+    process.env.E2E_DATABASE_URL =
+      "postgresql://postgres:postgres@localhost:5432/saas_e2e";
+    process.env.DATABASE_URL = process.env.E2E_DATABASE_URL;
+    process.env.TEST_WORKER_INDEX = "0";
+    process.env.TEST_PARALLEL_INDEX = "0";
+
+    expect(resolveE2EEnvironment().databaseUrl).toBe(
+      process.env.E2E_DATABASE_URL,
+    );
+  });
+
+  it("does not trust a partial Playwright worker marker", () => {
+    process.env.E2E_DATABASE_URL =
+      "postgresql://postgres:postgres@localhost:5432/saas_e2e";
+    process.env.DATABASE_URL = process.env.E2E_DATABASE_URL;
+    process.env.TEST_WORKER_INDEX = "0";
+    delete process.env.TEST_PARALLEL_INDEX;
+
+    expect(() => resolveE2EEnvironment()).toThrow(
+      "E2E_DATABASE_URL must differ from DATABASE_URL outside CI",
+    );
+  });
+
+  it("supports IPv6 loopback URLs", () => {
+    process.env.E2E_DATABASE_URL =
+      "postgresql://postgres:postgres@[::1]:5432/saas_e2e";
+    process.env.DATABASE_URL = "postgresql://postgres:postgres@[::1]:5432/saas";
+    process.env.E2E_BASE_URL = "http://[::1]:3100";
+
+    expect(resolveE2EEnvironment()).toMatchObject({
+      origin: "http://[::1]:3100",
+      port: 3100,
+    });
+  });
+
+  it("rejects non-local E2E origins", () => {
+    process.env.E2E_DATABASE_URL =
+      "postgresql://postgres:postgres@localhost:5432/saas_test";
+    process.env.E2E_BASE_URL = "https://example.com";
+
+    expect(() => resolveE2EEnvironment()).toThrow(
+      "E2E_BASE_URL must be a local HTTP origin",
+    );
+  });
+
+  it("rejects credentials in the E2E origin", () => {
+    process.env.E2E_DATABASE_URL =
+      "postgresql://postgres:postgres@localhost:5432/saas_test";
+    process.env.E2E_BASE_URL = "http://user:password@localhost:3100";
+
+    expect(() => resolveE2EEnvironment()).toThrow(
+      "E2E_BASE_URL must be a local HTTP origin",
+    );
+  });
+});

--- a/scripts/run-e2e.ts
+++ b/scripts/run-e2e.ts
@@ -1,0 +1,39 @@
+import { spawnSync } from "node:child_process";
+
+import { resolveE2EEnvironment } from "../e2e/environment";
+
+function run(command: string, args: string[], env: NodeJS.ProcessEnv): void {
+  const result = spawnSync(command, args, {
+    env,
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+const e2e = resolveE2EEnvironment();
+const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const sharedEnv = {
+  ...process.env,
+  E2E_DATABASE_URL: e2e.databaseUrl,
+  E2E_BASE_URL: e2e.origin,
+  NEXT_PUBLIC_APP_URL: e2e.origin,
+};
+const buildEnv = {
+  ...sharedEnv,
+  DATABASE_URL: e2e.databaseUrl,
+};
+const playwrightEnv = { ...sharedEnv };
+
+run(pnpmCommand, ["db:migrate"], buildEnv);
+run(pnpmCommand, ["build"], buildEnv);
+run(
+  pnpmCommand,
+  ["exec", "playwright", "test", ...process.argv.slice(2)],
+  playwrightEnv,
+);

--- a/src/app/api/test/session/route.test.ts
+++ b/src/app/api/test/session/route.test.ts
@@ -85,6 +85,8 @@ const originalEnv = {
   E2E_TEST_MODE: process.env.E2E_TEST_MODE,
   E2E_TEST_SECRET: process.env.E2E_TEST_SECRET,
   PLAYWRIGHT: process.env.PLAYWRIGHT,
+  DATABASE_URL: process.env.DATABASE_URL,
+  E2E_DATABASE_URL: process.env.E2E_DATABASE_URL,
   NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
   NODE_ENV: process.env.NODE_ENV,
   VERCEL_ENV: process.env.VERCEL_ENV,
@@ -133,6 +135,9 @@ describe("POST /api/test/session", () => {
     process.env.E2E_TEST_MODE = "true";
     process.env.E2E_TEST_SECRET = VALID_SECRET;
     process.env.PLAYWRIGHT = "true";
+    process.env.DATABASE_URL =
+      "postgresql://postgres:postgres@localhost:5432/saas_e2e";
+    process.env.E2E_DATABASE_URL = process.env.DATABASE_URL;
     process.env.NEXT_PUBLIC_APP_URL = "http://127.0.0.1:3100";
     delete process.env.VERCEL_ENV;
     setNodeEnv("test");
@@ -144,6 +149,8 @@ describe("POST /api/test/session", () => {
     restoreEnvValue("E2E_TEST_MODE");
     restoreEnvValue("E2E_TEST_SECRET");
     restoreEnvValue("PLAYWRIGHT");
+    restoreEnvValue("DATABASE_URL");
+    restoreEnvValue("E2E_DATABASE_URL");
     restoreEnvValue("NEXT_PUBLIC_APP_URL");
     restoreEnvValue("VERCEL_ENV");
     if (originalEnv.NODE_ENV === undefined) {

--- a/src/lib/auth/session.test.ts
+++ b/src/lib/auth/session.test.ts
@@ -15,6 +15,8 @@ const originalEnv = {
   E2E_TEST_MODE: process.env.E2E_TEST_MODE,
   E2E_TEST_SECRET: process.env.E2E_TEST_SECRET,
   PLAYWRIGHT: process.env.PLAYWRIGHT,
+  DATABASE_URL: process.env.DATABASE_URL,
+  E2E_DATABASE_URL: process.env.E2E_DATABASE_URL,
   NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
   NODE_ENV: process.env.NODE_ENV,
   VERCEL_ENV: process.env.VERCEL_ENV,
@@ -57,6 +59,9 @@ describe("E2E auth session helpers", () => {
     process.env.E2E_TEST_MODE = "true";
     process.env.E2E_TEST_SECRET = VALID_SECRET;
     process.env.PLAYWRIGHT = "true";
+    process.env.DATABASE_URL =
+      "postgresql://postgres:postgres@localhost:5432/saas_e2e";
+    process.env.E2E_DATABASE_URL = process.env.DATABASE_URL;
     process.env.NEXT_PUBLIC_APP_URL = "http://127.0.0.1:3100";
     delete process.env.VERCEL_ENV;
     setNodeEnv("test");
@@ -66,6 +71,8 @@ describe("E2E auth session helpers", () => {
     restoreEnvValue("E2E_TEST_MODE");
     restoreEnvValue("E2E_TEST_SECRET");
     restoreEnvValue("PLAYWRIGHT");
+    restoreEnvValue("DATABASE_URL");
+    restoreEnvValue("E2E_DATABASE_URL");
     restoreEnvValue("NEXT_PUBLIC_APP_URL");
     restoreEnvValue("VERCEL_ENV");
     if (originalEnv.NODE_ENV === undefined) {
@@ -98,6 +105,13 @@ describe("E2E auth session helpers", () => {
 
   it("rejects E2E access outside Playwright", () => {
     delete process.env.PLAYWRIGHT;
+
+    expect(shouldAllowE2ETestAccess(VALID_SECRET)).toBe(false);
+  });
+
+  it("rejects E2E access when the app uses a different database", () => {
+    process.env.DATABASE_URL =
+      "postgresql://postgres:postgres@localhost:5432/saas";
 
     expect(shouldAllowE2ETestAccess(VALID_SECRET)).toBe(false);
   });

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -64,6 +64,20 @@ function isProductionDeployment(): boolean {
   return process.env.NODE_ENV === "production" && !isLocalAppUrl();
 }
 
+function usesDedicatedE2EDatabase(): boolean {
+  const databaseUrl = process.env.DATABASE_URL;
+  const e2eDatabaseUrl = process.env.E2E_DATABASE_URL;
+  if (!databaseUrl || !e2eDatabaseUrl) {
+    return false;
+  }
+
+  try {
+    return new URL(databaseUrl).href === new URL(e2eDatabaseUrl).href;
+  } catch {
+    return false;
+  }
+}
+
 export function getE2ETestSecret(): string | null {
   const secret = process.env.E2E_TEST_SECRET?.trim();
   if (!secret) {
@@ -84,6 +98,7 @@ function isE2ETestModeEnabled(): boolean {
   return (
     process.env.E2E_TEST_MODE === "true" &&
     process.env.PLAYWRIGHT === "true" &&
+    usesDedicatedE2EDatabase() &&
     !isProductionDeployment() &&
     getE2ETestSecret() !== null
   );


### PR DESCRIPTION
## Summary
- update vulnerable PostCSS, Valibot, and brace-expansion dependency paths
- require a dedicated local E2E database and keep migration, build, and runtime configuration aligned
- clean browser, API, CLI, device-auth, and rate-limit fixtures before and after Playwright runs
- gate the test session route on the actual E2E database and run the hardened workflow in CI

## Validation
- pnpm install --frozen-lockfile
- pnpm lint
- pnpm type-check
- pnpm test --runInBand (1073 tests)
- pnpm dead-code:check
- pnpm prettier:check
- pnpm audit --prod
- pnpm test:e2e (8 browser tests; cleanup verified at zero residual fixtures)
