### PR TITLE
Fix subscription selection and billing boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ No analytics provider or tracking script is bundled. Add your own provider only 
 #### Creem product setup
 
 Test and live product IDs are intentionally separate in
-`src/lib/config/products.ts`. Set `CREEM_ENVIRONMENT` and its matching API key,
+`src/lib/billing/creem/products.ts`. Set `CREEM_ENVIRONMENT` and its matching API key,
 then run `pnpm creem:sync-products`. The command reuses or creates the catalog
 products and updates only the selected environment namespace. Review and commit
 that configuration change before deploying. Checkout fails closed when the

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -126,7 +126,7 @@ cp .env.example .env
 
 #### Creem 产品配置
 
-`src/lib/config/products.ts` 会明确分开测试与生产产品 ID。先设置
+`src/lib/billing/creem/products.ts` 会明确分开测试与生产产品 ID。先设置
 `CREEM_ENVIRONMENT` 及其对应 API Key，再运行 `pnpm creem:sync-products`。
 该命令会复用或创建产品，并且只更新当前环境的命名空间。部署前请审查并提交这次配置
 变更；如果当前环境没有产品 ID，checkout 会安全失败，不会误用另一环境的产品。

--- a/scripts/sync-creem-products.ts
+++ b/scripts/sync-creem-products.ts
@@ -110,7 +110,7 @@ async function writeResolvedProducts(
 ): Promise<void> {
   const productsConfigPath = resolve(
     process.cwd(),
-    "src/lib/config/products.ts",
+    "src/lib/billing/creem/products.ts",
   );
   const source = await readFile(productsConfigPath, "utf8");
   const nextSource = updateProductsConfigSource(

--- a/src/app/api/payment-status/route.test.ts
+++ b/src/app/api/payment-status/route.test.ts
@@ -1,9 +1,10 @@
 type CheckoutResult = {
-  status?: string;
-  metadata?: Record<string, unknown>;
+  status: "success" | "failed" | "pending" | "cancelled";
+  ownerId: string | null;
+  paymentMode: "subscription" | "one_time" | null;
 };
 
-const mockRetrieveCheckout = jest.fn<
+const mockGetCheckoutStatus = jest.fn<
   Promise<CheckoutResult>,
   [checkoutId: string]
 >();
@@ -13,11 +14,9 @@ const mockGetAuthSessionFromHeaders = jest.fn();
 
 beforeAll(() => {
   jest.resetModules();
-  jest.doMock("@/lib/billing/creem/client", () => ({
-    creemClient: {
-      checkouts: {
-        retrieve: mockRetrieveCheckout,
-      },
+  jest.doMock("@/lib/billing", () => ({
+    billing: {
+      getCheckoutStatus: mockGetCheckoutStatus,
     },
   }));
   jest.doMock("@/lib/rate-limit", () => ({
@@ -68,7 +67,7 @@ describe("Payment Status API", () => {
     expect(missing.status).toBe(400);
     expect(oversized.status).toBe(400);
     expect(mockGetAuthSessionFromHeaders).not.toHaveBeenCalled();
-    expect(mockRetrieveCheckout).not.toHaveBeenCalled();
+    expect(mockGetCheckoutStatus).not.toHaveBeenCalled();
   });
 
   it("rate limits before authentication or provider calls", async () => {
@@ -91,7 +90,7 @@ describe("Payment Status API", () => {
     expect(response.headers.get("Retry-After")).toBeTruthy();
     expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(mockGetAuthSessionFromHeaders).not.toHaveBeenCalled();
-    expect(mockRetrieveCheckout).not.toHaveBeenCalled();
+    expect(mockGetCheckoutStatus).not.toHaveBeenCalled();
   });
 
   it("requires an authenticated session", async () => {
@@ -107,13 +106,14 @@ describe("Payment Status API", () => {
     expect(await response.json()).toEqual({
       error: "Authentication required",
     });
-    expect(mockRetrieveCheckout).not.toHaveBeenCalled();
+    expect(mockGetCheckoutStatus).not.toHaveBeenCalled();
   });
 
   it("returns owned checkout status without exposing its identifier", async () => {
-    mockRetrieveCheckout.mockResolvedValue({
-      status: "completed",
-      metadata: { userId: "user-1" },
+    mockGetCheckoutStatus.mockResolvedValue({
+      status: "success",
+      ownerId: "user-1",
+      paymentMode: null,
     });
 
     const response = await GET(
@@ -125,19 +125,19 @@ describe("Payment Status API", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Cache-Control")).toBe("private, no-store");
-    expect(mockRetrieveCheckout).toHaveBeenCalledWith("checkout-1");
+    expect(mockGetCheckoutStatus).toHaveBeenCalledWith("checkout-1");
     expect(data).toEqual({
       status: "success",
-      message: "Payment completed successfully",
       paymentMode: null,
     });
     expect(data).not.toHaveProperty("sessionId");
   });
 
   it("returns an allowlisted one-time payment mode", async () => {
-    mockRetrieveCheckout.mockResolvedValue({
-      status: "completed",
-      metadata: { userId: "user-1", paymentMode: "one_time" },
+    mockGetCheckoutStatus.mockResolvedValue({
+      status: "success",
+      ownerId: "user-1",
+      paymentMode: "one_time",
     });
 
     const response = await GET(
@@ -151,29 +151,36 @@ describe("Payment Status API", () => {
     );
   });
 
+  it.each(["pending", "cancelled", "failed"] as const)(
+    "returns normalized provider state %s",
+    async (status) => {
+      mockGetCheckoutStatus.mockResolvedValue({
+        status,
+        ownerId: "user-1",
+        paymentMode: null,
+      });
+
+      const response = await GET(
+        createRequest(
+          "http://localhost:3000/api/payment-status?session_id=checkout-1",
+        ),
+      );
+
+      expect(await response.json()).toEqual(
+        expect.objectContaining({ status }),
+      );
+    },
+  );
+
   it.each([
-    [{ status: "open", metadata: { userId: "user-1" } }, "pending"],
-    [{ status: "canceled", metadata: { userId: "user-1" } }, "cancelled"],
-    [{ status: "expired", metadata: { userId: "user-1" } }, "failed"],
-  ])("maps provider state %#", async (checkout, expectedStatus) => {
-    mockRetrieveCheckout.mockResolvedValue(checkout);
-
-    const response = await GET(
-      createRequest(
-        "http://localhost:3000/api/payment-status?session_id=checkout-1",
-      ),
-    );
-
-    expect(await response.json()).toEqual(
-      expect.objectContaining({ status: expectedStatus }),
-    );
-  });
-
-  it.each([
-    { status: "completed", metadata: { userId: "other-user" } },
-    { status: "completed" },
+    {
+      status: "success" as const,
+      ownerId: "other-user",
+      paymentMode: null,
+    },
+    { status: "success" as const, ownerId: null, paymentMode: null },
   ])("hides foreign or unowned checkouts", async (checkout) => {
-    mockRetrieveCheckout.mockResolvedValue(checkout);
+    mockGetCheckoutStatus.mockResolvedValue(checkout);
 
     const response = await GET(
       createRequest(
@@ -186,7 +193,9 @@ describe("Payment Status API", () => {
   });
 
   it("returns a controlled gateway error and ignores URL status claims", async () => {
-    mockRetrieveCheckout.mockRejectedValue(new Error("Creem unavailable"));
+    mockGetCheckoutStatus.mockRejectedValue(
+      new Error("Payment provider unavailable"),
+    );
 
     const response = await GET(
       createRequest(

--- a/src/app/api/payment-status/route.ts
+++ b/src/app/api/payment-status/route.ts
@@ -1,64 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthSessionFromHeaders } from "@/lib/auth/session";
+import { billing } from "@/lib/billing";
 import { checkRateLimit, getClientRateLimitKey } from "@/lib/rate-limit";
-
-type ResolvedPaymentStatus = "success" | "failed" | "pending" | "cancelled";
 
 const PAYMENT_STATUS_RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const PAYMENT_STATUS_RATE_LIMIT_MAX_REQUESTS = 30;
-
-const CHECKOUT_STATUS_MAP = {
-  completed: {
-    status: "success",
-    message: "Payment completed successfully",
-  },
-  succeeded: {
-    status: "success",
-    message: "Payment completed successfully",
-  },
-  failed: {
-    status: "failed",
-    message: "Payment failed",
-  },
-  expired: {
-    status: "failed",
-    message: "Payment session expired",
-  },
-  canceled: {
-    status: "cancelled",
-    message: "Payment was cancelled",
-  },
-  cancelled: {
-    status: "cancelled",
-    message: "Payment was cancelled",
-  },
-  pending: {
-    status: "pending",
-    message: "Payment is being processed. This may take a few minutes.",
-  },
-  processing: {
-    status: "pending",
-    message: "Payment is being processed. This may take a few minutes.",
-  },
-  open: {
-    status: "pending",
-    message: "Payment is being processed. This may take a few minutes.",
-  },
-} as const;
-
-function resolveCheckoutStatus(normalizedStatus: string): {
-  status: ResolvedPaymentStatus;
-  message: string;
-} {
-  return (
-    CHECKOUT_STATUS_MAP[
-      normalizedStatus as keyof typeof CHECKOUT_STATUS_MAP
-    ] ?? {
-      status: "pending",
-      message: "Payment is being processed. This may take a few minutes.",
-    }
-  );
-}
 
 function getCheckoutReference(searchParams: URLSearchParams): string | null {
   const value =
@@ -72,29 +18,6 @@ function privateJson(body: unknown, init?: ResponseInit): NextResponse {
   const headers = new Headers(init?.headers);
   headers.set("Cache-Control", "private, no-store");
   return NextResponse.json(body, { ...init, headers });
-}
-
-function getCheckoutOwnerId(checkout: { metadata?: unknown }): string | null {
-  if (!checkout.metadata || typeof checkout.metadata !== "object") {
-    return null;
-  }
-
-  const userId = (checkout.metadata as Record<string, unknown>).userId;
-  return typeof userId === "string" ? userId : null;
-}
-
-function getCheckoutPaymentMode(checkout: {
-  metadata?: unknown;
-}): "subscription" | "one_time" | null {
-  if (!checkout.metadata || typeof checkout.metadata !== "object") {
-    return null;
-  }
-
-  const paymentMode = (checkout.metadata as Record<string, unknown>)
-    .paymentMode;
-  return paymentMode === "subscription" || paymentMode === "one_time"
-    ? paymentMode
-    : null;
 }
 
 export async function GET(request: NextRequest) {
@@ -141,23 +64,18 @@ export async function GET(request: NextRequest) {
     }
 
     try {
-      const { creemClient } = await import("@/lib/billing/creem/client");
-      const checkoutResponse = await creemClient.checkouts.retrieve(checkoutId);
+      const checkout = await billing.getCheckoutStatus(checkoutId);
 
-      if (getCheckoutOwnerId(checkoutResponse) !== session.user.id) {
+      if (checkout.ownerId !== session.user.id) {
         return privateJson({ error: "Checkout not found" }, { status: 404 });
       }
 
-      const resolvedStatus = resolveCheckoutStatus(
-        String(checkoutResponse.status ?? "").toLowerCase(),
-      );
       return privateJson({
-        status: resolvedStatus.status,
-        message: resolvedStatus.message,
-        paymentMode: getCheckoutPaymentMode(checkoutResponse),
+        status: checkout.status,
+        paymentMode: checkout.paymentMode,
       });
     } catch (error) {
-      console.error("Error checking Creem payment status:", error);
+      console.error("Error checking payment provider status:", error);
       return privateJson(
         { error: "Unable to verify payment status" },
         { status: 502 },

--- a/src/lib/actions/admin.test.ts
+++ b/src/lib/actions/admin.test.ts
@@ -92,15 +92,10 @@ const mockNot = jest.fn();
 const mockInArray = jest.fn();
 
 const mockGetProductTierById = jest.fn();
-const mockGetProductTierByProductId = jest.fn();
 
 const mockRequireAdmin = jest.fn();
 
-const mockCreemClient = {
-  subscriptions: {
-    cancel: jest.fn(),
-  },
-};
+const mockCancelSubscription = jest.fn();
 
 const mockDeleteFileFromR2 = jest.fn();
 const mockDeleteFilesFromR2 = jest.fn();
@@ -168,7 +163,6 @@ jest.mock("drizzle-orm", () => ({
 
 jest.mock("@/lib/config/products", () => ({
   getProductTierById: mockGetProductTierById,
-  getProductTierByProductId: mockGetProductTierByProductId,
 }));
 
 jest.mock("next-safe-action", () => ({
@@ -191,8 +185,10 @@ jest.mock("next/cache", () => ({
   revalidatePath: mockRevalidatePath,
 }));
 
-jest.mock("../billing/creem/client", () => ({
-  creemClient: mockCreemClient,
+jest.mock("../billing", () => ({
+  billing: {
+    cancelSubscription: mockCancelSubscription,
+  },
 }));
 
 jest.mock("@/env", () => mockEnv);
@@ -636,7 +632,7 @@ describe("Admin Actions", () => {
       mockDb.select
         .mockReturnValueOnce(mockQuery)
         .mockReturnValueOnce(mockTotalQuery);
-      mockGetProductTierByProductId.mockReturnValue({ name: "Pro Tier" });
+      mockGetProductTierById.mockReturnValue({ name: "Pro Tier" });
 
       const { getPayments } = await import("./admin");
 
@@ -1150,7 +1146,7 @@ describe("Admin Actions", () => {
         }),
       });
 
-      mockCreemClient.subscriptions.cancel.mockResolvedValue({ success: true });
+      mockCancelSubscription.mockResolvedValue(undefined);
 
       const { cancelSubscriptionAction } = await import("./admin");
 
@@ -1158,10 +1154,9 @@ describe("Admin Actions", () => {
         parsedInput: { subscriptionId: "sub_123" },
       });
 
-      expect(mockCreemClient.subscriptions.cancel).toHaveBeenCalledWith(
-        "sub_123",
-        { mode: "immediate" },
-      );
+      expect(mockCancelSubscription).toHaveBeenCalledWith("sub_123", {
+        mode: "immediate",
+      });
       expect(result).toEqual({
         success: true,
         message: "Subscription cancellation initiated.",

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -30,15 +30,12 @@ import type {
   SubscriptionWithUser,
   SubscriptionStatus,
 } from "@/types/billing";
-import {
-  getProductTierById,
-  getProductTierByProductId,
-} from "@/lib/config/products";
+import { getProductTierById } from "@/lib/config/products";
 import { createSafeActionClient } from "next-safe-action";
 import { z } from "zod";
 import { requireAdmin } from "../auth/permissions";
 import { revalidatePath } from "next/cache";
-import { creemClient } from "../billing/creem/client";
+import { billing } from "../billing";
 import {
   deleteFiles as deleteFilesFromR2,
   deleteFile as deleteFileFromR2,
@@ -249,9 +246,7 @@ export async function getPayments({
       ...payment,
       user: payment.user!,
       tierName:
-        getProductTierByProductId(payment.productId)?.name ||
-        getProductTierById(payment.productId)?.name ||
-        "Unknown Product",
+        getProductTierById(payment.productId)?.name || "Unknown Product",
     }));
 
   return {
@@ -343,9 +338,7 @@ export async function getSubscriptions({
         sub.user !== null,
     )
     .map((sub) => {
-      const productTier =
-        getProductTierById(sub.productId) ||
-        getProductTierByProductId(sub.productId);
+      const productTier = getProductTierById(sub.productId);
       return {
         ...sub,
         tierId: sub.productId,
@@ -571,7 +564,7 @@ export const cancelSubscriptionAction = adminAction
       throw new Error("Subscription not found");
     }
 
-    await creemClient.subscriptions.cancel(subscription.subscriptionId, {
+    await billing.cancelSubscription(subscription.subscriptionId, {
       mode: "immediate",
     });
 

--- a/src/lib/billing/creem/product-sync.test.ts
+++ b/src/lib/billing/creem/product-sync.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./product-sync";
 import { PRODUCT_TIERS } from "@/lib/config/products";
 import type { CreemClient } from "./api-client";
+import { getCreemProductIds } from "./products";
 
 describe("product-sync", () => {
   describe("buildCreemProductSpecs", () => {
@@ -215,10 +216,10 @@ describe("product-sync", () => {
     it("replaces product ids for the matching tier and variant", () => {
       const productsConfigPath = resolve(
         process.cwd(),
-        "src/lib/config/products.ts",
+        "src/lib/billing/creem/products.ts",
       );
       const source = readFileSync(productsConfigPath, "utf8");
-      const currentPlusTier = PRODUCT_TIERS.find((tier) => tier.id === "plus");
+      const currentLiveProductIds = getCreemProductIds("plus", "live_mode");
 
       const updated = updateProductsConfigSource(
         source,
@@ -237,13 +238,11 @@ describe("product-sync", () => {
         "test_mode",
       );
 
-      expect(currentPlusTier).toBeDefined();
+      expect(currentLiveProductIds).toBeDefined();
       expect(updated).toContain(
-        'test_mode: {\n          oneTime: "prod_new_one_time",\n          monthly: "prod_new_monthly"',
+        'test_mode: {\n      oneTime: "prod_new_one_time",\n      monthly: "prod_new_monthly"',
       );
-      expect(updated).toContain(
-        `oneTime: "${currentPlusTier!.pricing.creem.live_mode.oneTime}"`,
-      );
+      expect(updated).toContain(`oneTime: "${currentLiveProductIds!.oneTime}"`);
     });
   });
 });

--- a/src/lib/billing/creem/product-sync.ts
+++ b/src/lib/billing/creem/product-sync.ts
@@ -1,10 +1,7 @@
 import { createHash } from "node:crypto";
-import type {
-  CreemEnvironment,
-  CreemProductVariant,
-  PricingTier,
-} from "@/lib/config/products";
+import type { PricingTier } from "@/lib/config/products";
 import type { CreemClient, CreemProduct } from "./api-client";
+import type { CreemEnvironment, CreemProductVariant } from "./products";
 
 type ProductBillingType = CreemProduct["billingType"];
 type ProductBillingPeriod = "every-month" | "every-year";
@@ -205,7 +202,7 @@ function getEnvironmentBlock(source: string, environment: CreemEnvironment) {
     throw new Error(`Unable to find ${environment} product configuration.`);
   }
 
-  const end = source.indexOf("\n        },", start);
+  const end = source.indexOf("\n    },", start);
   if (end === -1) {
     throw new Error(`Unable to determine ${environment} product block.`);
   }
@@ -218,18 +215,20 @@ function getEnvironmentBlock(source: string, environment: CreemEnvironment) {
 }
 
 function getTierBlock(source: string, tierId: string) {
-  const tierMarker = `id: "${tierId}"`;
+  const tierMarker = `${tierId}: {`;
   const start = source.indexOf(tierMarker);
 
   if (start === -1) {
     throw new Error(`Unable to find tier "${tierId}" in products config.`);
   }
 
-  const nextTierStart = source.indexOf(
-    '\n  {\n    id: "',
-    start + tierMarker.length,
-  );
-  const arrayEnd = source.indexOf("\n];", start);
+  const remainingSource = source.slice(start + tierMarker.length);
+  const nextTierMatch = /\n  [A-Za-z0-9_-]+: \{/.exec(remainingSource);
+  const nextTierStart =
+    nextTierMatch?.index === undefined
+      ? -1
+      : start + tierMarker.length + nextTierMatch.index;
+  const arrayEnd = source.indexOf("\n};", start);
   const end =
     nextTierStart === -1 ? arrayEnd : Math.min(nextTierStart, arrayEnd);
 

--- a/src/lib/billing/creem/products.test.ts
+++ b/src/lib/billing/creem/products.test.ts
@@ -1,0 +1,46 @@
+import { PRODUCT_TIERS } from "@/lib/config/products";
+import {
+  CREEM_PRODUCT_IDS,
+  getCreemProductIds,
+  getProductTierByCreemProductId,
+} from "./products";
+
+describe("Creem product configuration", () => {
+  it("configures every catalog tier in separate test and live namespaces", () => {
+    for (const tier of PRODUCT_TIERS) {
+      expect(getCreemProductIds(tier.id, "test_mode")).toEqual({
+        oneTime: "",
+        monthly: "",
+        yearly: "",
+      });
+
+      const liveProductIds = getCreemProductIds(tier.id, "live_mode");
+      expect(liveProductIds).toBeDefined();
+      for (const productId of Object.values(liveProductIds!)) {
+        expect(productId).toMatch(/^prod_[A-Za-z0-9]+$/);
+      }
+    }
+
+    expect(Object.keys(CREEM_PRODUCT_IDS).sort()).toEqual(
+      PRODUCT_TIERS.map(({ id }) => id).sort(),
+    );
+  });
+
+  it("limits product lookups to the requested environment", () => {
+    const productId = getCreemProductIds("plus", "live_mode")!.monthly;
+
+    expect(getProductTierByCreemProductId(productId, "live_mode")?.id).toBe(
+      "plus",
+    );
+    expect(
+      getProductTierByCreemProductId(productId, "test_mode"),
+    ).toBeUndefined();
+    expect(getProductTierByCreemProductId(productId)?.id).toBe("plus");
+  });
+
+  it("ignores unknown tiers and product ids", () => {
+    expect(getCreemProductIds("unknown", "live_mode")).toBeUndefined();
+    expect(getProductTierByCreemProductId("")).toBeUndefined();
+    expect(getProductTierByCreemProductId("prod_unknown")).toBeUndefined();
+  });
+});

--- a/src/lib/billing/creem/products.ts
+++ b/src/lib/billing/creem/products.ts
@@ -1,0 +1,78 @@
+import { getProductTierById, type PricingTier } from "@/lib/config/products";
+
+export type CreemEnvironment = "test_mode" | "live_mode";
+export type CreemProductVariant = "oneTime" | "monthly" | "yearly";
+export type CreemProductIds = Record<CreemProductVariant, string>;
+
+export const CREEM_PRODUCT_IDS: Record<
+  string,
+  Record<CreemEnvironment, CreemProductIds>
+> = {
+  plus: {
+    test_mode: {
+      oneTime: "",
+      monthly: "",
+      yearly: "",
+    },
+    live_mode: {
+      oneTime: "prod_1xvCrHVxDLPdoptwdH8Ake",
+      monthly: "prod_1szT3Q4qCWKYeIVk56FD0v",
+      yearly: "prod_2DyqDup95VCqxUv7rB6zWD",
+    },
+  },
+  pro: {
+    test_mode: {
+      oneTime: "",
+      monthly: "",
+      yearly: "",
+    },
+    live_mode: {
+      oneTime: "prod_707V6jfaKsrUb9HckzuWpA",
+      monthly: "prod_6E1zx5skxroRjjbPGcHMGs",
+      yearly: "prod_3vq08mIOjo04eWmDlM5LKB",
+    },
+  },
+  team: {
+    test_mode: {
+      oneTime: "",
+      monthly: "",
+      yearly: "",
+    },
+    live_mode: {
+      oneTime: "prod_2msXlwJ3tbbUUp7hVIKJWk",
+      monthly: "prod_2ZXku6CgdRY38k7VQff0me",
+      yearly: "prod_2l5IMno8y3iv7KPg5QBuWM",
+    },
+  },
+};
+
+export function getCreemProductIds(
+  tierId: string,
+  environment: CreemEnvironment,
+): CreemProductIds | undefined {
+  return CREEM_PRODUCT_IDS[tierId]?.[environment];
+}
+
+export function getProductTierByCreemProductId(
+  productId: string,
+  environment?: CreemEnvironment,
+): PricingTier | undefined {
+  if (!productId.trim()) return undefined;
+
+  for (const [tierId, productIdsByEnvironment] of Object.entries(
+    CREEM_PRODUCT_IDS,
+  )) {
+    const productGroups = environment
+      ? [productIdsByEnvironment[environment]]
+      : Object.values(productIdsByEnvironment);
+    if (
+      productGroups.some((productIds) =>
+        Object.values(productIds).includes(productId),
+      )
+    ) {
+      return getProductTierById(tierId);
+    }
+  }
+
+  return undefined;
+}

--- a/src/lib/billing/creem/provider.test.ts
+++ b/src/lib/billing/creem/provider.test.ts
@@ -2,10 +2,11 @@ import type { CreateCheckoutOptions } from "@/types/billing";
 import type { PaymentProvider } from "../provider";
 
 const mockCreemClient = {
-  checkouts: { create: jest.fn() },
+  checkouts: { create: jest.fn(), retrieve: jest.fn() },
   customers: { generateBillingLinks: jest.fn() },
+  subscriptions: { cancel: jest.fn() },
 };
-const mockGetProductTierById = jest.fn();
+const mockGetCreemProductIds = jest.fn();
 const mockHandleCreemWebhook = jest.fn();
 
 jest.mock("./client", () => ({
@@ -13,8 +14,8 @@ jest.mock("./client", () => ({
   creemEnvironment: "live_mode",
   creemWebhookSecret: "webhook-secret",
 }));
-jest.mock("@/lib/config/products", () => ({
-  getProductTierById: mockGetProductTierById,
+jest.mock("./products", () => ({
+  getCreemProductIds: mockGetCreemProductIds,
 }));
 jest.mock("./webhook", () => ({
   handleCreemWebhook: mockHandleCreemWebhook,
@@ -22,19 +23,10 @@ jest.mock("./webhook", () => ({
 
 let creemProvider: PaymentProvider;
 
-const tier = {
-  id: "plus",
-  name: "Plus",
-  pricing: {
-    creem: {
-      test_mode: { oneTime: "", monthly: "", yearly: "" },
-      live_mode: {
-        oneTime: "prod_once",
-        monthly: "prod_monthly",
-        yearly: "prod_yearly",
-      },
-    },
-  },
+const productIds = {
+  oneTime: "prod_once",
+  monthly: "prod_monthly",
+  yearly: "prod_yearly",
 };
 
 const checkoutOptions: CreateCheckoutOptions = {
@@ -58,7 +50,7 @@ describe("Creem provider", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, "error").mockImplementation(() => undefined);
-    mockGetProductTierById.mockReturnValue(tier);
+    mockGetCreemProductIds.mockReturnValue(productIds);
   });
 
   afterEach(() => {
@@ -104,7 +96,7 @@ describe("Creem provider", () => {
   );
 
   it("rejects unknown tiers before contacting Creem", async () => {
-    mockGetProductTierById.mockReturnValue(undefined);
+    mockGetCreemProductIds.mockReturnValue(undefined);
 
     await expect(
       creemProvider.createCheckoutSession(checkoutOptions),
@@ -113,14 +105,9 @@ describe("Creem provider", () => {
   });
 
   it("rejects missing product configuration", async () => {
-    mockGetProductTierById.mockReturnValue({
-      ...tier,
-      pricing: {
-        creem: {
-          ...tier.pricing.creem,
-          live_mode: { ...tier.pricing.creem.live_mode, monthly: "" },
-        },
-      },
+    mockGetCreemProductIds.mockReturnValue({
+      ...productIds,
+      monthly: "",
     });
 
     await expect(
@@ -171,6 +158,68 @@ describe("Creem provider", () => {
     await expect(
       creemProvider.createCustomerPortalUrl("cust_123"),
     ).rejects.toThrow("Failed to parse customer portal response from Creem");
+  });
+
+  it.each([
+    ["completed", "success"],
+    ["succeeded", "success"],
+    ["failed", "failed"],
+    ["expired", "failed"],
+    ["canceled", "cancelled"],
+    ["cancelled", "cancelled"],
+    ["processing", "pending"],
+    ["unknown", "pending"],
+  ] as const)("normalizes checkout status %s", async (status, expected) => {
+    mockCreemClient.checkouts.retrieve.mockResolvedValue({
+      status,
+      metadata: {
+        userId: "user_123",
+        paymentMode: "subscription",
+      },
+    });
+
+    await expect(
+      creemProvider.getCheckoutStatus("checkout_123"),
+    ).resolves.toEqual({
+      status: expected,
+      ownerId: "user_123",
+      paymentMode: "subscription",
+    });
+  });
+
+  it("allowlists checkout ownership metadata", async () => {
+    mockCreemClient.checkouts.retrieve.mockResolvedValue({
+      status: "open",
+      metadata: {
+        userId: 123,
+        paymentMode: "invalid",
+      },
+    });
+
+    await expect(
+      creemProvider.getCheckoutStatus("checkout_123"),
+    ).resolves.toEqual({
+      status: "pending",
+      ownerId: null,
+      paymentMode: null,
+    });
+  });
+
+  it("cancels subscriptions through the Creem client", async () => {
+    mockCreemClient.subscriptions.cancel.mockResolvedValue({
+      id: "subscription_123",
+      status: "canceled",
+    });
+
+    await expect(
+      creemProvider.cancelSubscription("subscription_123", {
+        mode: "immediate",
+      }),
+    ).resolves.toBeUndefined();
+    expect(mockCreemClient.subscriptions.cancel).toHaveBeenCalledWith(
+      "subscription_123",
+      { mode: "immediate" },
+    );
   });
 
   it("delegates verified webhook processing", async () => {

--- a/src/lib/billing/creem/provider.ts
+++ b/src/lib/billing/creem/provider.ts
@@ -1,9 +1,13 @@
-import type { PaymentProvider } from "../provider";
+import type {
+  CheckoutStatus,
+  CheckoutStatusResult,
+  PaymentProvider,
+} from "../provider";
 import type { CreateCheckoutOptions } from "@/types/billing";
 import { z } from "zod";
 import { creemClient, creemEnvironment, creemWebhookSecret } from "./client";
-import { getProductTierById } from "@/lib/config/products";
 import { handleCreemWebhook } from "./webhook";
+import { getCreemProductIds } from "./products";
 
 const CreemCheckoutResponseSchema = z.object({
   checkoutUrl: z.string().url(),
@@ -13,18 +17,48 @@ const CreemCustomerPortalResponseSchema = z.object({
   customerPortalLink: z.string().url(),
 });
 
+const CHECKOUT_STATUS_MAP: Record<string, CheckoutStatus> = {
+  completed: "success",
+  succeeded: "success",
+  failed: "failed",
+  expired: "failed",
+  canceled: "cancelled",
+  cancelled: "cancelled",
+  pending: "pending",
+  processing: "pending",
+  open: "pending",
+};
+
+function resolveCheckoutStatus(status: string): CheckoutStatus {
+  return CHECKOUT_STATUS_MAP[status.toLowerCase()] ?? "pending";
+}
+
+function mapCheckoutStatus(
+  checkout: Awaited<ReturnType<typeof creemClient.checkouts.retrieve>>,
+): CheckoutStatusResult {
+  const ownerId = checkout.metadata?.userId;
+  const paymentMode = checkout.metadata?.paymentMode;
+
+  return {
+    status: resolveCheckoutStatus(checkout.status),
+    ownerId: typeof ownerId === "string" ? ownerId : null,
+    paymentMode:
+      paymentMode === "subscription" || paymentMode === "one_time"
+        ? paymentMode
+        : null,
+  };
+}
+
 const creemProvider: PaymentProvider = {
   async createCheckoutSession(
     options: CreateCheckoutOptions,
   ): Promise<{ checkoutUrl: string }> {
     try {
-      const tier = getProductTierById(options.tierId);
-      if (!tier) {
+      let creemProductId: string;
+      const productIds = getCreemProductIds(options.tierId, creemEnvironment);
+      if (!productIds) {
         throw new Error(`Pricing tier with id "${options.tierId}" not found.`);
       }
-
-      let creemProductId: string;
-      const productIds = tier.pricing.creem[creemEnvironment];
       if (options.paymentMode === "one_time") {
         creemProductId = productIds.oneTime;
       } else {
@@ -95,6 +129,18 @@ const creemProvider: PaymentProvider = {
         error instanceof Error ? error.message : "An unknown error occurred.";
       throw new Error(`Failed to create customer portal session: ${message}`);
     }
+  },
+
+  async getCheckoutStatus(checkoutId: string): Promise<CheckoutStatusResult> {
+    const checkout = await creemClient.checkouts.retrieve(checkoutId);
+    return mapCheckoutStatus(checkout);
+  },
+
+  async cancelSubscription(
+    subscriptionId: string,
+    options: { mode: "immediate" | "scheduled" },
+  ): Promise<void> {
+    await creemClient.subscriptions.cancel(subscriptionId, options);
   },
 
   async handleWebhook(

--- a/src/lib/billing/creem/webhook.test.ts
+++ b/src/lib/billing/creem/webhook.test.ts
@@ -41,7 +41,8 @@ const mockRevokeProductEntitlementByPaymentId = jest.fn();
 const mockSuspendSubscriptionAccess = jest.fn();
 const mockUpdatePaymentStatus = jest.fn();
 
-const mockGetProductTierByProductId = jest.fn();
+const mockGetProductTierByCreemProductId = jest.fn();
+const mockGetCreemProductIds = jest.fn();
 const mockGetProductTierById = jest.fn();
 
 const mockEq = jest.fn();
@@ -82,7 +83,11 @@ jest.mock("@/lib/database/subscription", () => ({
 
 jest.mock("@/lib/config/products", () => ({
   getProductTierById: mockGetProductTierById,
-  getProductTierByProductId: mockGetProductTierByProductId,
+}));
+
+jest.mock("./products", () => ({
+  getCreemProductIds: mockGetCreemProductIds,
+  getProductTierByCreemProductId: mockGetProductTierByCreemProductId,
 }));
 
 jest.mock("crypto", () => ({
@@ -134,23 +139,18 @@ describe("Creem Webhook Handler", () => {
     mockLockPaymentAdjustmentScope.mockImplementation(
       async ([paymentReference]: string[]) => paymentReference,
     );
-    mockGetProductTierByProductId.mockReturnValue({
+    mockGetProductTierByCreemProductId.mockReturnValue({
       id: "tier_pro",
       name: "Pro Tier",
-      pricing: {
-        creem: {
-          live_mode: { oneTime: "prod_one_time" },
-        },
-      },
     });
     mockGetProductTierById.mockReturnValue({
       id: "tier_pro",
       name: "Pro Tier",
-      pricing: {
-        creem: {
-          live_mode: { oneTime: "prod_one_time" },
-        },
-      },
+    });
+    mockGetCreemProductIds.mockReturnValue({
+      oneTime: "prod_one_time",
+      monthly: "prod_monthly",
+      yearly: "prod_yearly",
     });
   });
 
@@ -618,13 +618,11 @@ describe("Creem Webhook Handler", () => {
       });
       mockGetProductTierById.mockReturnValue({
         id: "tier_pro",
-        pricing: {
-          creem: {
-            live_mode: {
-              oneTime: "prod_6tW66i0oZM7Uao6h7G0SGN",
-            },
-          },
-        },
+      });
+      mockGetCreemProductIds.mockReturnValue({
+        oneTime: "prod_6tW66i0oZM7Uao6h7G0SGN",
+        monthly: "prod_monthly",
+        yearly: "prod_yearly",
       });
       const { handleCreemWebhook } = await import("./webhook");
 
@@ -1060,7 +1058,7 @@ describe("Creem Webhook Handler", () => {
       const result = await handleCreemWebhook(payload, "test-signature");
 
       expect(result).toEqual({ received: true });
-      expect(mockGetProductTierByProductId).toHaveBeenCalledWith(
+      expect(mockGetProductTierByCreemProductId).toHaveBeenCalledWith(
         "prod_123",
         "live_mode",
       );
@@ -1307,7 +1305,10 @@ describe("Creem Webhook Handler", () => {
         paymentProviderCustomerId: "cus_123",
       });
       mockRecordWebhookEvent.mockResolvedValue(true);
-      mockGetProductTierByProductId.mockResolvedValue("pro");
+      mockGetProductTierByCreemProductId.mockReturnValue({
+        id: "pro",
+        name: "Pro",
+      });
       mockTimingSafeEqual.mockReturnValue(true);
       mockCreateHmacFunction.mockReturnValue({
         update: jest.fn().mockReturnValue({

--- a/src/lib/billing/creem/webhook.ts
+++ b/src/lib/billing/creem/webhook.ts
@@ -25,10 +25,8 @@ import {
   updatePaymentStatus,
 } from "@/lib/database/subscription";
 import type { Tx } from "@/lib/database/subscription";
-import {
-  getProductTierById,
-  getProductTierByProductId,
-} from "@/lib/config/products";
+import { getProductTierById } from "@/lib/config/products";
+import { getCreemProductIds, getProductTierByCreemProductId } from "./products";
 
 export class CreemWebhookSignatureError extends Error {
   constructor(message = "Invalid signature.") {
@@ -466,16 +464,20 @@ async function processCheckoutCompletedEvent(
       typeof subscription.product === "string"
         ? subscription.product
         : subscription.product.id;
-    const tier = getProductTierByProductId(productId, creemEnvironment);
-    const storedProductId = tier?.id || productId;
+    const tier = getProductTierByCreemProductId(productId, creemEnvironment);
+    if (!tier) {
+      throw new InvalidWebhookPayloadError(
+        "Subscription references an unknown Creem product.",
+      );
+    }
 
-    await lockBillingProductScope(userId, storedProductId, tx);
+    await lockBillingProductScope(userId, tier.id, tx);
     await upsertSubscription(
       {
         userId,
         customerId,
         subscriptionId: subscription.id,
-        productId: storedProductId,
+        productId: tier.id,
         status: subscription.status,
         currentPeriodStart: parseOptionalWebhookDate(
           subscription.current_period_start_date,
@@ -504,7 +506,7 @@ async function processCheckoutCompletedEvent(
         userId,
         customerId,
         subscriptionId: subscription.id,
-        productId: storedProductId,
+        productId: tier.id,
         paymentId,
         amount,
         currency: order.currency,
@@ -533,7 +535,10 @@ async function processCheckoutCompletedEvent(
       typeof checkoutData.product === "string"
         ? checkoutData.product
         : checkoutData.product.id;
-    if (checkoutProductId !== tier.pricing.creem[creemEnvironment].oneTime) {
+    if (
+      checkoutProductId !==
+      getCreemProductIds(tier.id, creemEnvironment)?.oneTime
+    ) {
       throw new InvalidWebhookPayloadError(
         "One-time checkout product does not match its tier metadata.",
       );
@@ -646,16 +651,20 @@ async function processSubscriptionEvent(
     typeof subscriptionData.product === "string"
       ? subscriptionData.product
       : subscriptionData.product.id;
-  const tier = getProductTierByProductId(productId, creemEnvironment);
-  const storedProductId = tier?.id || productId;
+  const tier = getProductTierByCreemProductId(productId, creemEnvironment);
+  if (!tier) {
+    throw new InvalidWebhookPayloadError(
+      "Subscription references an unknown Creem product.",
+    );
+  }
 
-  await lockBillingProductScope(user.id, storedProductId, tx);
+  await lockBillingProductScope(user.id, tier.id, tx);
   await upsertSubscription(
     {
       userId: user.id,
       customerId,
       subscriptionId: subscriptionData.id,
-      productId: storedProductId,
+      productId: tier.id,
       status: subscriptionData.status,
       currentPeriodStart: parseOptionalWebhookDate(
         subscriptionData.current_period_start_date,
@@ -752,16 +761,20 @@ async function processSubscriptionRenewal(
   if (!productId)
     throw new InvalidWebhookPayloadError("Product ID missing in renewal event");
 
-  const tier = getProductTierByProductId(productId, creemEnvironment);
-  const storedProductId = tier?.id || productId;
+  const tier = getProductTierByCreemProductId(productId, creemEnvironment);
+  if (!tier) {
+    throw new InvalidWebhookPayloadError(
+      "Subscription renewal references an unknown Creem product.",
+    );
+  }
 
-  await lockBillingProductScope(user.id, storedProductId, tx);
+  await lockBillingProductScope(user.id, tier.id, tx);
   await upsertSubscription(
     {
       userId: user.id,
       customerId,
       subscriptionId,
-      productId: storedProductId,
+      productId: tier.id,
       status: "active",
       currentPeriodStart,
       currentPeriodEnd,
@@ -792,14 +805,19 @@ async function processPaymentSucceededEvent(
   if (!productId)
     throw new InvalidWebhookPayloadError("Product ID missing in payment event");
 
-  const tier = getProductTierByProductId(productId, creemEnvironment);
+  const tier = getProductTierByCreemProductId(productId, creemEnvironment);
+  if (!tier) {
+    throw new InvalidWebhookPayloadError(
+      "Payment references an unknown Creem product.",
+    );
+  }
 
   await upsertPayment(
     {
       userId: user.id,
       customerId,
       subscriptionId: paymentData.subscription_id || paymentData.subscription,
-      productId: tier?.id || productId,
+      productId: tier.id,
       paymentId: paymentData.id,
       amount: paymentData.amount ?? paymentData.amount_paid ?? 0,
       currency: paymentData.currency ?? "usd",

--- a/src/lib/billing/index.test.ts
+++ b/src/lib/billing/index.test.ts
@@ -9,6 +9,12 @@ const mockCreemProvider: PaymentProvider = {
   createCustomerPortalUrl: jest.fn() as jest.MockedFunction<
     PaymentProvider["createCustomerPortalUrl"]
   >,
+  getCheckoutStatus: jest.fn() as jest.MockedFunction<
+    PaymentProvider["getCheckoutStatus"]
+  >,
+  cancelSubscription: jest.fn() as jest.MockedFunction<
+    PaymentProvider["cancelSubscription"]
+  >,
   handleWebhook: jest.fn() as jest.MockedFunction<
     PaymentProvider["handleWebhook"]
   >,
@@ -43,6 +49,8 @@ describe("Billing Index", () => {
       expect(billing).toBe(mockCreemProvider);
       expect(typeof billing.createCheckoutSession).toBe("function");
       expect(typeof billing.createCustomerPortalUrl).toBe("function");
+      expect(typeof billing.getCheckoutStatus).toBe("function");
+      expect(typeof billing.cancelSubscription).toBe("function");
       expect(typeof billing.handleWebhook).toBe("function");
     });
 
@@ -277,11 +285,15 @@ describe("Billing Index", () => {
       // Verify the billing object implements PaymentProvider interface
       expect(billing).toHaveProperty("createCheckoutSession");
       expect(billing).toHaveProperty("createCustomerPortalUrl");
+      expect(billing).toHaveProperty("getCheckoutStatus");
+      expect(billing).toHaveProperty("cancelSubscription");
       expect(billing).toHaveProperty("handleWebhook");
 
       // Verify method signatures match interface
       expect(typeof billing.createCheckoutSession).toBe("function");
       expect(typeof billing.createCustomerPortalUrl).toBe("function");
+      expect(typeof billing.getCheckoutStatus).toBe("function");
+      expect(typeof billing.cancelSubscription).toBe("function");
       expect(typeof billing.handleWebhook).toBe("function");
     });
 

--- a/src/lib/billing/provider.ts
+++ b/src/lib/billing/provider.ts
@@ -1,14 +1,27 @@
-import type { CreateCheckoutOptions } from "@/types/billing";
+import type { CreateCheckoutOptions, PaymentMode } from "@/types/billing";
+
+export type CheckoutStatus = "success" | "failed" | "pending" | "cancelled";
+
+export interface CheckoutStatusResult {
+  status: CheckoutStatus;
+  ownerId: string | null;
+  paymentMode: PaymentMode | null;
+}
 
 export interface PaymentProvider {
   createCheckoutSession(
     options: CreateCheckoutOptions,
   ): Promise<{ checkoutUrl: string }>;
   createCustomerPortalUrl(customerId: string): Promise<{ portalUrl: string }>;
+  getCheckoutStatus(checkoutId: string): Promise<CheckoutStatusResult>;
+  cancelSubscription(
+    subscriptionId: string,
+    options: { mode: "immediate" | "scheduled" },
+  ): Promise<void>;
 
   /**
    * @param payload - The raw request body as a string.
-   * @param signature - The signature from the 'creem-signature' header.
+   * @param signature - The provider webhook signature.
    */
   handleWebhook(
     payload: string,

--- a/src/lib/config/products.test.ts
+++ b/src/lib/config/products.test.ts
@@ -1,7 +1,6 @@
 import {
   PRODUCT_TIERS,
   getProductTierById,
-  getProductTierByProductId,
   type PricingTier,
 } from "./products";
 
@@ -22,19 +21,6 @@ describe("product configuration", () => {
     }
   });
 
-  it("keeps test and live Creem product namespaces separate", () => {
-    for (const tier of PRODUCT_TIERS) {
-      expect(tier.pricing.creem.test_mode).toEqual({
-        oneTime: "",
-        monthly: "",
-        yearly: "",
-      });
-      for (const productId of Object.values(tier.pricing.creem.live_mode)) {
-        expect(productId).toMatch(/^prod_[A-Za-z0-9]+$/);
-      }
-    }
-  });
-
   it("finds catalog tiers by id", () => {
     expect(getProductTierById("plus")?.name).toBe("Plus");
     expect(getProductTierById("pro")?.name).toBe("Professional");
@@ -42,42 +28,15 @@ describe("product configuration", () => {
     expect(getProductTierById("unknown")).toBeUndefined();
   });
 
-  it("limits environment-specific product lookups to that environment", () => {
-    const productId = PRODUCT_TIERS[0]!.pricing.creem.live_mode.monthly;
-
-    expect(getProductTierByProductId(productId, "live_mode")?.id).toBe("plus");
-    expect(getProductTierByProductId(productId, "test_mode")).toBeUndefined();
-    expect(getProductTierByProductId(productId)?.id).toBe("plus");
-  });
-
-  it("ignores empty and unknown product ids", () => {
-    expect(getProductTierByProductId("")).toBeUndefined();
-    expect(getProductTierByProductId("prod_unknown")).toBeUndefined();
-  });
-
-  it("exports an explicit environment-aware tier type", () => {
+  it("exports a provider-neutral tier type", () => {
     const tier: PricingTier = {
       id: "test",
       name: "Test",
       isPopular: false,
-      pricing: {
-        creem: {
-          test_mode: {
-            oneTime: "prod_test_once",
-            monthly: "prod_test_monthly",
-            yearly: "prod_test_yearly",
-          },
-          live_mode: {
-            oneTime: "prod_live_once",
-            monthly: "prod_live_monthly",
-            yearly: "prod_live_yearly",
-          },
-        },
-      },
       prices: { oneTime: 10, monthly: 5, yearly: 50 },
       currency: "USD",
     };
 
-    expect(tier.pricing.creem.live_mode.monthly).toBe("prod_live_monthly");
+    expect(tier.prices.monthly).toBe(5);
   });
 });

--- a/src/lib/config/products.ts
+++ b/src/lib/config/products.ts
@@ -1,14 +1,7 @@
-export type CreemEnvironment = "test_mode" | "live_mode";
-export type CreemProductVariant = "oneTime" | "monthly" | "yearly";
-type CreemProductIds = Record<CreemProductVariant, string>;
-
 export interface PricingTier {
   id: string;
   name: string;
   isPopular: boolean;
-  pricing: {
-    creem: Record<CreemEnvironment, CreemProductIds>;
-  };
   prices: {
     oneTime: number;
     monthly: number;
@@ -22,20 +15,6 @@ export const PRODUCT_TIERS: PricingTier[] = [
     id: "plus",
     name: "Plus",
     isPopular: false,
-    pricing: {
-      creem: {
-        test_mode: {
-          oneTime: "",
-          monthly: "",
-          yearly: "",
-        },
-        live_mode: {
-          oneTime: "prod_1xvCrHVxDLPdoptwdH8Ake",
-          monthly: "prod_1szT3Q4qCWKYeIVk56FD0v",
-          yearly: "prod_2DyqDup95VCqxUv7rB6zWD",
-        },
-      },
-    },
     prices: {
       oneTime: 19.99,
       monthly: 9.99,
@@ -47,20 +26,6 @@ export const PRODUCT_TIERS: PricingTier[] = [
     id: "pro",
     name: "Professional",
     isPopular: true,
-    pricing: {
-      creem: {
-        test_mode: {
-          oneTime: "",
-          monthly: "",
-          yearly: "",
-        },
-        live_mode: {
-          oneTime: "prod_707V6jfaKsrUb9HckzuWpA",
-          monthly: "prod_6E1zx5skxroRjjbPGcHMGs",
-          yearly: "prod_3vq08mIOjo04eWmDlM5LKB",
-        },
-      },
-    },
     prices: {
       oneTime: 29.99,
       monthly: 19.99,
@@ -72,20 +37,6 @@ export const PRODUCT_TIERS: PricingTier[] = [
     id: "team",
     name: "Team",
     isPopular: false,
-    pricing: {
-      creem: {
-        test_mode: {
-          oneTime: "",
-          monthly: "",
-          yearly: "",
-        },
-        live_mode: {
-          oneTime: "prod_2msXlwJ3tbbUUp7hVIKJWk",
-          monthly: "prod_2ZXku6CgdRY38k7VQff0me",
-          yearly: "prod_2l5IMno8y3iv7KPg5QBuWM",
-        },
-      },
-    },
     prices: {
       oneTime: 59.99,
       monthly: 49.99,
@@ -97,28 +48,4 @@ export const PRODUCT_TIERS: PricingTier[] = [
 
 export const getProductTierById = (id: string): PricingTier | undefined => {
   return PRODUCT_TIERS.find((tier) => tier.id === id);
-};
-
-export const getProductTierByProductId = (
-  productId: string,
-  environment?: CreemEnvironment,
-): PricingTier | undefined => {
-  if (!productId.trim()) {
-    return undefined;
-  }
-
-  for (const tier of PRODUCT_TIERS) {
-    const productGroups = environment
-      ? [tier.pricing.creem[environment]]
-      : Object.values(tier.pricing.creem);
-    if (
-      productGroups.some((productIds) =>
-        Object.values(productIds).includes(productId),
-      )
-    ) {
-      return tier;
-    }
-  }
-
-  return undefined;
 };

--- a/src/lib/database/subscription.test.ts
+++ b/src/lib/database/subscription.test.ts
@@ -74,7 +74,6 @@ const mockSql = jest.fn(
   }),
 );
 
-const mockGetProductTierByProductId = jest.fn();
 const mockGetProductTierById = jest.fn();
 
 // Mock all imports
@@ -99,7 +98,6 @@ jest.mock("drizzle-orm", () => ({
 }));
 
 jest.mock("@/lib/config/products", () => ({
-  getProductTierByProductId: mockGetProductTierByProductId,
   getProductTierById: mockGetProductTierById,
 }));
 
@@ -141,14 +139,9 @@ describe("Database Subscription Functions", () => {
       }),
     });
 
-    mockGetProductTierByProductId.mockReturnValue({
+    mockGetProductTierById.mockReturnValue({
       id: "tier_pro",
       name: "Pro Plan",
-    });
-
-    mockGetProductTierById.mockReturnValue({
-      id: "tier_basic",
-      name: "Basic Plan",
     });
   });
 
@@ -162,7 +155,7 @@ describe("Database Subscription Functions", () => {
         userId: "user-123",
         customerId: "customer-123",
         subscriptionId: "sub-123",
-        productId: "product-123",
+        productId: "tier_pro",
         status: "active" as const,
         currentPeriodStart: new Date("2024-01-01"),
         currentPeriodEnd: new Date("2024-02-01"),
@@ -722,7 +715,7 @@ describe("Database Subscription Functions", () => {
         userId: "user-123",
         customerId: "customer-123",
         subscriptionId: "sub-123",
-        productId: "product-123",
+        productId: "tier_pro",
         status: "active",
         currentPeriodStart: new Date("2024-01-01"),
         currentPeriodEnd: new Date("2024-02-01"),
@@ -753,8 +746,6 @@ describe("Database Subscription Functions", () => {
         currentPeriodEnd: mockSubscription.currentPeriodEnd,
         canceledAt: null,
       });
-
-      expect(mockGetProductTierByProductId).toHaveBeenCalledWith("product-123");
     });
 
     it("should prefer active subscription over canceled ones", async () => {
@@ -790,6 +781,112 @@ describe("Database Subscription Functions", () => {
       const result = await getUserSubscription("user-123");
 
       expect(result?.subscriptionId).toBe("sub-active");
+    });
+
+    it("should prefer an unexpired canceled subscription over a newer incomplete one", async () => {
+      const mockSubscriptions = [
+        {
+          id: "sub-incomplete",
+          userId: "user-123",
+          subscriptionId: "sub-incomplete",
+          productId: "product-123",
+          status: "incomplete",
+          createdAt: new Date("2024-01-02"),
+        },
+        {
+          id: "sub-canceled",
+          userId: "user-123",
+          subscriptionId: "sub-canceled",
+          productId: "product-123",
+          status: "canceled",
+          currentPeriodEnd: new Date("2099-01-01"),
+          createdAt: new Date("2024-01-01"),
+        },
+      ];
+
+      mockDb.select.mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            orderBy: jest.fn().mockResolvedValue(mockSubscriptions),
+          }),
+        }),
+      });
+
+      const { getUserSubscription } = await import("./subscription");
+
+      const result = await getUserSubscription("user-123");
+
+      expect(result?.subscriptionId).toBe("sub-canceled");
+    });
+
+    it("should prefer scheduled cancellation over a newer expired subscription", async () => {
+      const mockSubscriptions = [
+        {
+          id: "sub-expired",
+          userId: "user-123",
+          subscriptionId: "sub-expired",
+          productId: "product-123",
+          status: "expired",
+          createdAt: new Date("2024-01-02"),
+        },
+        {
+          id: "sub-scheduled",
+          userId: "user-123",
+          subscriptionId: "sub-scheduled",
+          productId: "product-123",
+          status: "scheduled_cancel",
+          createdAt: new Date("2024-01-01"),
+        },
+      ];
+
+      mockDb.select.mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            orderBy: jest.fn().mockResolvedValue(mockSubscriptions),
+          }),
+        }),
+      });
+
+      const { getUserSubscription } = await import("./subscription");
+
+      const result = await getUserSubscription("user-123");
+
+      expect(result?.subscriptionId).toBe("sub-scheduled");
+    });
+
+    it("should prefer a manageable subscription over a newer terminal one", async () => {
+      const mockSubscriptions = [
+        {
+          id: "sub-expired",
+          userId: "user-123",
+          subscriptionId: "sub-expired",
+          productId: "product-123",
+          status: "expired",
+          createdAt: new Date("2024-01-02"),
+        },
+        {
+          id: "sub-past-due",
+          userId: "user-123",
+          subscriptionId: "sub-past-due",
+          productId: "product-123",
+          status: "past_due",
+          createdAt: new Date("2024-01-01"),
+        },
+      ];
+
+      mockDb.select.mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            orderBy: jest.fn().mockResolvedValue(mockSubscriptions),
+          }),
+        }),
+      });
+
+      const { getUserSubscription } = await import("./subscription");
+
+      const result = await getUserSubscription("user-123");
+
+      expect(result?.subscriptionId).toBe("sub-past-due");
     });
 
     it("should handle trialing subscriptions", async () => {
@@ -853,7 +950,7 @@ describe("Database Subscription Functions", () => {
 
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          "User user-123 has 2 active/trialing subscriptions",
+          "User user-123 has 2 currently accessible subscriptions",
         ),
         expect.objectContaining({
           userId: "user-123",
@@ -885,9 +982,6 @@ describe("Database Subscription Functions", () => {
           }),
         }),
       });
-
-      mockGetProductTierByProductId.mockReturnValue(null);
-
       const { getUserSubscription } = await import("./subscription");
 
       const result = await getUserSubscription("user-123");
@@ -1032,7 +1126,7 @@ describe("Database Subscription Functions", () => {
         },
       ]);
 
-      expect(mockGetProductTierByProductId).toHaveBeenCalledWith("product-123");
+      expect(mockGetProductTierById).toHaveBeenCalledWith("product-123");
     });
 
     it("should respect custom limit", async () => {
@@ -1055,7 +1149,7 @@ describe("Database Subscription Functions", () => {
       expect(mockLimit).toHaveBeenCalledWith(25);
     });
 
-    it("should fallback to tier by ID when product tier not found", async () => {
+    it("should map stored tier ids to catalog metadata", async () => {
       const mockPayments = [
         {
           id: "payment1",
@@ -1079,7 +1173,10 @@ describe("Database Subscription Functions", () => {
         }),
       });
 
-      mockGetProductTierByProductId.mockReturnValue(null);
+      mockGetProductTierById.mockReturnValue({
+        id: "tier_basic",
+        name: "Basic Plan",
+      });
 
       const { getUserPayments } = await import("./subscription");
 
@@ -1114,7 +1211,6 @@ describe("Database Subscription Functions", () => {
         }),
       });
 
-      mockGetProductTierByProductId.mockReturnValue(null);
       mockGetProductTierById.mockReturnValue(null);
 
       const { getUserPayments } = await import("./subscription");

--- a/src/lib/database/subscription.ts
+++ b/src/lib/database/subscription.ts
@@ -11,10 +11,11 @@ import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import type { PgTransaction } from "drizzle-orm/pg-core";
 import type { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js";
 import type { Subscription, SubscriptionStatus } from "@/types/billing";
+import { getProductTierById } from "@/lib/config/products";
 import {
-  getProductTierByProductId,
-  getProductTierById,
-} from "@/lib/config/products";
+  canManageSubscription,
+  hasCurrentSubscriptionAccess,
+} from "@/lib/billing/access";
 import { ExtractTablesWithRelations } from "drizzle-orm";
 
 export type Tx = PgTransaction<
@@ -417,50 +418,50 @@ export async function getUserSubscription(
     .where(eq(subscriptions.userId, userId))
     .orderBy(desc(subscriptions.createdAt)); // Order by creation date descending for deterministic behavior
 
-  if (!userSubscriptions || userSubscriptions.length === 0) return null;
-
-  // Filter active or trialing subscriptions
-  const activeSubscriptions = userSubscriptions.filter(
-    (sub) => sub.status === "active" || sub.status === "trialing",
+  const mappedSubscriptions: Subscription[] = userSubscriptions.map(
+    (subscription) => ({
+      id: subscription.id,
+      userId: subscription.userId,
+      customerId: subscription.customerId,
+      subscriptionId: subscription.subscriptionId,
+      status: subscription.status as SubscriptionStatus,
+      tierId: subscription.productId,
+      currentPeriodStart: subscription.currentPeriodStart,
+      currentPeriodEnd: subscription.currentPeriodEnd,
+      canceledAt: subscription.canceledAt,
+    }),
   );
 
-  let subToReturn: (typeof userSubscriptions)[0] | undefined;
+  const now = new Date();
+  const accessibleSubscriptions = mappedSubscriptions.filter((subscription) =>
+    hasCurrentSubscriptionAccess(subscription, now),
+  );
+  const manageableSubscriptions = mappedSubscriptions.filter(
+    (subscription) =>
+      !hasCurrentSubscriptionAccess(subscription, now) &&
+      canManageSubscription(subscription),
+  );
 
-  if (activeSubscriptions.length > 0) {
-    // If multiple active/trialing subscriptions exist, log warning and return the most recent one
-    if (activeSubscriptions.length > 1) {
-      console.warn(
-        `User ${userId} has ${activeSubscriptions.length} active/trialing subscriptions. ` +
-          `This may indicate a data consistency issue. Returning the most recent one.`,
-        {
-          userId,
-          subscriptionIds: activeSubscriptions.map((s) => s.subscriptionId),
-          statuses: activeSubscriptions.map((s) => s.status),
-        },
-      );
-    }
-    // Return the most recently created active/trialing subscription
-    subToReturn = activeSubscriptions[0]; // Already sorted by createdAt desc
-  } else {
-    // If no active or trialing subscription, take the most recently created one
-    subToReturn = userSubscriptions[0]; // Already sorted by createdAt desc
+  if (accessibleSubscriptions.length > 1) {
+    console.warn(
+      `User ${userId} has ${accessibleSubscriptions.length} currently accessible subscriptions. ` +
+        "This may indicate a data consistency issue. Returning the most recent one.",
+      {
+        userId,
+        subscriptionIds: accessibleSubscriptions.map(
+          ({ subscriptionId }) => subscriptionId,
+        ),
+        statuses: accessibleSubscriptions.map(({ status }) => status),
+      },
+    );
   }
 
-  if (!subToReturn) return null; // Should not happen if userSubscriptions is not empty
-
-  const tier = getProductTierByProductId(subToReturn.productId);
-
-  return {
-    id: subToReturn.id,
-    userId: subToReturn.userId,
-    customerId: subToReturn.customerId,
-    subscriptionId: subToReturn.subscriptionId,
-    status: subToReturn.status as SubscriptionStatus,
-    tierId: tier?.id || subToReturn.productId, // Fallback to raw product ID if tier mapping is missing
-    currentPeriodStart: subToReturn.currentPeriodStart,
-    currentPeriodEnd: subToReturn.currentPeriodEnd,
-    canceledAt: subToReturn.canceledAt,
-  };
+  return (
+    accessibleSubscriptions[0] ??
+    manageableSubscriptions[0] ??
+    mappedSubscriptions[0] ??
+    null
+  );
 }
 
 export async function getUserPayments(userId: string, limit: number = 10) {
@@ -472,11 +473,7 @@ export async function getUserPayments(userId: string, limit: number = 10) {
     .limit(limit);
 
   return userPayments.map((payment) => {
-    let tier = getProductTierByProductId(payment.productId);
-    // If tier is not found by Creem's product ID, try to find it by our internal tier ID
-    if (!tier) {
-      tier = getProductTierById(payment.productId);
-    }
+    const tier = getProductTierById(payment.productId);
     return {
       ...payment,
       tierId: tier?.id || payment.productId,


### PR DESCRIPTION
## Summary
- choose subscriptions by current access, then manageability, before terminal recency
- add provider-neutral checkout status and subscription cancellation operations
- keep Creem product IDs and status normalization inside the Creem adapter
- reject unknown provider products before persisting billing records
- remove an unused payment-status response message

## Validation
- 10 targeted suites / 210 tests
- pnpm test --runInBand (115 suites / 1086 tests)
- pnpm lint
- pnpm type-check
- pnpm dead-code:check
- pnpm prettier:check
- pnpm build
- pnpm db:generate (no schema changes)
