### PR TITLE
chore: release v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ullrai-starter",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "engines": {


### PR DESCRIPTION
## Summary

- bump the package version from `0.1.1` to `0.1.2`
- prepare the reviewed `main` changes for the matching `release/v0.1.2` tag

## Release scope

- dependency security advisory fixes
- i18n ICU placeholder corrections
- Next.js 16.3 root params migration and device verification navigation fix

## Database

- no schema or committed migration files changed since `release/v0.1.1`
- production migration is therefore a no-op for this release

## Validation

- `git diff --check`
- `pnpm prettier:check`
- full Quality workflow required before merge and tagging
