### PR TITLE
fix(billing): complete Stripe migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Routine formatting and test-only maintenance are omitted.
 
 ## Unreleased
 
+## 0.1.5 — 2026-08-20
+
+### Stripe migration completion
+
+- Added the configured Stripe test catalog used by local development and the
+  hosted reference deployment.
+- Replaced the partial Creem customer cleanup with a forward migration that
+  removes all legacy billing records while preserving users and administrator
+  roles, and corrected the provider default without rewriting migration
+  history.
+- Reconciled subscription webhooks against Stripe's current state so
+  same-second, out-of-order deliveries cannot regress access.
+- Added durable asynchronous checkout failure handling and complete dispute
+  closure reconciliation, including access restoration after a won dispute.
+- Made catalog tests accept reviewed test or live IDs instead of requiring an
+  unusable empty configuration.
+
 ## 0.1.4 — 2026-08-19
 
 ### Quality, reliability, and deployment hardening

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -39,10 +39,17 @@ boundary.
 
 Configure the Stripe endpoint as `/api/billing/webhooks/stripe` and subscribe
 to `checkout.session.completed`, `checkout.session.async_payment_succeeded`,
+`checkout.session.async_payment_failed`,
 `customer.subscription.created`, `customer.subscription.updated`,
 `customer.subscription.deleted`, `customer.subscription.paused`,
 `customer.subscription.resumed`, `invoice.paid`, `invoice.payment_failed`,
-`charge.refunded`, and `charge.dispute.created`.
+`charge.refunded`, `charge.dispute.created`, and `charge.dispute.closed`.
+
+Subscription events are reconciled against Stripe's current Subscription
+object before entering the database transaction. This avoids regressing state
+when events generated in the same second arrive out of order. A closed dispute
+uses the current Charge and Subscription state to restore access after a win or
+preserve revocation after a loss.
 
 ## Endpoint API version
 

--- a/docs/webhooks.zh-CN.md
+++ b/docs/webhooks.zh-CN.md
@@ -30,10 +30,15 @@ ID，然后执行该事件涉及的全部计费写入。因此，事件认领与
 
 请将 Stripe Endpoint 配置为 `/api/billing/webhooks/stripe`，并订阅
 `checkout.session.completed`、`checkout.session.async_payment_succeeded`、
+`checkout.session.async_payment_failed`、
 `customer.subscription.created`、`customer.subscription.updated`、
 `customer.subscription.deleted`、`customer.subscription.paused`、
 `customer.subscription.resumed`、`invoice.paid`、`invoice.payment_failed`、
-`charge.refunded` 和 `charge.dispute.created`。
+`charge.refunded`、`charge.dispute.created` 和 `charge.dispute.closed`。
+
+订阅事件会在进入数据库事务前读取 Stripe 当前的 Subscription 对象，以避免同一秒生成的
+事件乱序到达时把状态回退。争议关闭时会根据当前 Charge 与 Subscription 状态，在胜诉后
+恢复访问，或在败诉后保持撤销状态。
 
 ## Endpoint API 版本
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ullrai-starter",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "engines": {

--- a/src/database/migrations.test.ts
+++ b/src/database/migrations.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function readMigration(name: string): string {
+  return readFileSync(
+    resolve(process.cwd(), "src/database/migrations", name),
+    "utf8",
+  );
+}
+
+describe("billing provider migrations", () => {
+  it("keeps the original migration immutable", () => {
+    expect(readMigration("0000_true_mad_thinker.sql")).toContain(
+      "\"provider\" text DEFAULT 'creem' NOT NULL",
+    );
+  });
+
+  it("resets only billing state and applies the Stripe default forward", () => {
+    const migration = readMigration("0019_reset_creem_billing.sql");
+    const entitlementDelete = migration.indexOf(
+      'DELETE FROM "product_entitlements"',
+    );
+    const paymentDelete = migration.indexOf('DELETE FROM "payments"');
+
+    expect(entitlementDelete).toBeGreaterThanOrEqual(0);
+    expect(paymentDelete).toBeGreaterThan(entitlementDelete);
+    expect(migration).toContain('DELETE FROM "subscriptions"');
+    expect(migration).toContain('DELETE FROM "webhook_events"');
+    expect(migration).toContain('SET "paymentProviderCustomerId" = NULL');
+    expect(migration).toContain(
+      "ALTER COLUMN \"provider\" SET DEFAULT 'stripe'",
+    );
+    expect(migration).not.toContain('DELETE FROM "users"');
+  });
+});

--- a/src/database/migrations/0000_true_mad_thinker.sql
+++ b/src/database/migrations/0000_true_mad_thinker.sql
@@ -103,7 +103,7 @@ CREATE TABLE "webhook_events" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"eventId" text NOT NULL,
 	"eventType" text NOT NULL,
-	"provider" text DEFAULT 'stripe' NOT NULL,
+	"provider" text DEFAULT 'creem' NOT NULL,
 	"processed" boolean DEFAULT true NOT NULL,
 	"processedAt" timestamp DEFAULT now() NOT NULL,
 	"payload" text,

--- a/src/database/migrations/0019_reset_creem_billing.sql
+++ b/src/database/migrations/0019_reset_creem_billing.sql
@@ -1,0 +1,14 @@
+-- The reference deployment is a demo. Creem records cannot be managed or
+-- reconciled by Stripe, so reset every provider-owned billing table before
+-- accepting Stripe events. Users and their roles are intentionally preserved.
+DELETE FROM "product_entitlements";
+DELETE FROM "payments";
+DELETE FROM "subscriptions";
+DELETE FROM "webhook_events";
+
+UPDATE "users"
+SET "paymentProviderCustomerId" = NULL
+WHERE "paymentProviderCustomerId" IS NOT NULL;
+
+ALTER TABLE "webhook_events"
+ALTER COLUMN "provider" SET DEFAULT 'stripe';

--- a/src/database/migrations/meta/0000_snapshot.json
+++ b/src/database/migrations/meta/0000_snapshot.json
@@ -752,7 +752,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "processed": {
           "name": "processed",

--- a/src/database/migrations/meta/0001_snapshot.json
+++ b/src/database/migrations/meta/0001_snapshot.json
@@ -1197,7 +1197,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "processed": {
           "name": "processed",

--- a/src/database/migrations/meta/0002_snapshot.json
+++ b/src/database/migrations/meta/0002_snapshot.json
@@ -1203,7 +1203,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "processed": {
           "name": "processed",

--- a/src/database/migrations/meta/0003_snapshot.json
+++ b/src/database/migrations/meta/0003_snapshot.json
@@ -1203,7 +1203,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "processed": {
           "name": "processed",

--- a/src/database/migrations/meta/0004_snapshot.json
+++ b/src/database/migrations/meta/0004_snapshot.json
@@ -1253,7 +1253,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "processed": {
           "name": "processed",

--- a/src/database/migrations/meta/0005_snapshot.json
+++ b/src/database/migrations/meta/0005_snapshot.json
@@ -1318,7 +1318,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "processed": {
           "name": "processed",

--- a/src/database/migrations/meta/0006_snapshot.json
+++ b/src/database/migrations/meta/0006_snapshot.json
@@ -1318,7 +1318,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "processed": {
           "name": "processed",

--- a/src/database/migrations/meta/0007_snapshot.json
+++ b/src/database/migrations/meta/0007_snapshot.json
@@ -1440,7 +1440,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "processed": {
           "name": "processed",

--- a/src/database/migrations/meta/0008_snapshot.json
+++ b/src/database/migrations/meta/0008_snapshot.json
@@ -1440,7 +1440,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "processed": {
           "name": "processed",

--- a/src/database/migrations/meta/0010_snapshot.json
+++ b/src/database/migrations/meta/0010_snapshot.json
@@ -1479,7 +1479,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "processed": {
           "name": "processed",

--- a/src/database/migrations/meta/0011_snapshot.json
+++ b/src/database/migrations/meta/0011_snapshot.json
@@ -1680,7 +1680,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "processed": {
           "name": "processed",

--- a/src/database/migrations/meta/0012_snapshot.json
+++ b/src/database/migrations/meta/0012_snapshot.json
@@ -1694,7 +1694,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "processed": {
           "name": "processed",

--- a/src/database/migrations/meta/0013_snapshot.json
+++ b/src/database/migrations/meta/0013_snapshot.json
@@ -1700,7 +1700,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "processed": {
           "name": "processed",

--- a/src/database/migrations/meta/0014_snapshot.json
+++ b/src/database/migrations/meta/0014_snapshot.json
@@ -1733,7 +1733,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "processed": {
           "name": "processed",

--- a/src/database/migrations/meta/0015_snapshot.json
+++ b/src/database/migrations/meta/0015_snapshot.json
@@ -1733,7 +1733,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "createdAt": {
           "name": "createdAt",

--- a/src/database/migrations/meta/0016_snapshot.json
+++ b/src/database/migrations/meta/0016_snapshot.json
@@ -1715,7 +1715,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'stripe'"
+          "default": "'creem'"
         },
         "createdAt": {
           "name": "createdAt",

--- a/src/database/migrations/meta/0019_snapshot.json
+++ b/src/database/migrations/meta/0019_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "58e8e390-9ef4-4657-9108-747edf71a6aa",
-  "prevId": "9636fa25-caec-493e-a6ad-5a9dad7f766c",
+  "id": "db2ad68e-d594-4c8b-a693-7061de13b714",
+  "prevId": "537a38e7-fee2-4078-b6d0-31ceffb0ddfa",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -99,20 +99,20 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "accounts_userId_users_id_fk": {
           "name": "accounts_userId_users_id_fk",
           "tableFrom": "accounts",
-          "tableTo": "users",
           "columnsFrom": ["userId"],
+          "tableTo": "users",
           "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
@@ -234,9 +234,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "api_keys_keyHash_idx": {
           "name": "api_keys_keyHash_idx",
@@ -249,20 +249,20 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "api_keys_userId_users_id_fk": {
           "name": "api_keys_userId_users_id_fk",
           "tableFrom": "api_keys",
-          "tableTo": "users",
           "columnsFrom": ["userId"],
+          "tableTo": "users",
           "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
@@ -394,33 +394,33 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "cli_tokens_userId_users_id_fk": {
           "name": "cli_tokens_userId_users_id_fk",
           "tableFrom": "cli_tokens",
-          "tableTo": "users",
           "columnsFrom": ["userId"],
+          "tableTo": "users",
           "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "cli_tokens_tokenHash_unique": {
           "name": "cli_tokens_tokenHash_unique",
-          "nullsNotDistinct": false,
-          "columns": ["tokenHash"]
+          "columns": ["tokenHash"],
+          "nullsNotDistinct": false
         },
         "cli_tokens_refreshTokenHash_unique": {
           "name": "cli_tokens_refreshTokenHash_unique",
-          "nullsNotDistinct": false,
-          "columns": ["refreshTokenHash"]
+          "columns": ["refreshTokenHash"],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -533,33 +533,33 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "device_codes_userId_users_id_fk": {
           "name": "device_codes_userId_users_id_fk",
           "tableFrom": "device_codes",
-          "tableTo": "users",
           "columnsFrom": ["userId"],
+          "tableTo": "users",
           "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "device_codes_deviceCode_unique": {
           "name": "device_codes_deviceCode_unique",
-          "nullsNotDistinct": false,
-          "columns": ["deviceCode"]
+          "columns": ["deviceCode"],
+          "nullsNotDistinct": false
         },
         "device_codes_userCode_unique": {
           "name": "device_codes_userCode_unique",
-          "nullsNotDistinct": false,
-          "columns": ["userCode"]
+          "columns": ["userCode"],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -606,6 +606,12 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true
+        },
+        "paymentIntentId": {
+          "name": "paymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         },
         "amount": {
           "name": "amount",
@@ -665,28 +671,97 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
+        },
+        "payments_status_currency_createdAt_idx": {
+          "name": "payments_status_currency_createdAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "payments_paymentIntentId_unique": {
+          "name": "payments_paymentIntentId_unique",
+          "columns": [
+            {
+              "expression": "paymentIntentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "payments_paymentId_userId_productId_unique": {
+          "name": "payments_paymentId_userId_productId_unique",
+          "columns": [
+            {
+              "expression": "paymentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "productId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "payments_userId_users_id_fk": {
           "name": "payments_userId_users_id_fk",
           "tableFrom": "payments",
-          "tableTo": "users",
           "columnsFrom": ["userId"],
+          "tableTo": "users",
           "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "payments_paymentId_unique": {
           "name": "payments_paymentId_unique",
-          "nullsNotDistinct": false,
-          "columns": ["paymentId"]
+          "columns": ["paymentId"],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -760,9 +835,9 @@
             }
           ],
           "isUnique": true,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "product_entitlements_sourcePaymentId_unique": {
           "name": "product_entitlements_sourcePaymentId_unique",
@@ -775,9 +850,9 @@
             }
           ],
           "isUnique": true,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "product_entitlements_userId_createdAt_idx": {
           "name": "product_entitlements_userId_createdAt_idx",
@@ -796,29 +871,29 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "product_entitlements_userId_users_id_fk": {
           "name": "product_entitlements_userId_users_id_fk",
           "tableFrom": "product_entitlements",
-          "tableTo": "users",
           "columnsFrom": ["userId"],
+          "tableTo": "users",
           "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
-        "product_entitlements_sourcePaymentId_payments_paymentId_fk": {
-          "name": "product_entitlements_sourcePaymentId_payments_paymentId_fk",
+        "product_entitlements_payment_owner_product_fk": {
+          "name": "product_entitlements_payment_owner_product_fk",
           "tableFrom": "product_entitlements",
+          "columnsFrom": ["sourcePaymentId", "userId", "productId"],
           "tableTo": "payments",
-          "columnsFrom": ["sourcePaymentId"],
-          "columnsTo": ["paymentId"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "columnsTo": ["paymentId", "userId", "productId"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -875,9 +950,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {},
@@ -938,24 +1013,6 @@
           "primaryKey": false,
           "notNull": false
         },
-        "os": {
-          "name": "os",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "browser": {
-          "name": "browser",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deviceType": {
-          "name": "deviceType",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "impersonatedBy": {
           "name": "impersonatedBy",
           "type": "text",
@@ -981,28 +1038,28 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "sessions_userId_users_id_fk": {
           "name": "sessions_userId_users_id_fk",
           "tableFrom": "sessions",
-          "tableTo": "users",
           "columnsFrom": ["userId"],
+          "tableTo": "users",
           "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "sessions_token_unique": {
           "name": "sessions_token_unique",
-          "nullsNotDistinct": false,
-          "columns": ["token"]
+          "columns": ["token"],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -1107,9 +1164,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "subscriptions_customerId_idx": {
           "name": "subscriptions_customerId_idx",
@@ -1122,32 +1179,224 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "subscriptions_userId_users_id_fk": {
           "name": "subscriptions_userId_users_id_fk",
           "tableFrom": "subscriptions",
-          "tableTo": "users",
           "columnsFrom": ["userId"],
+          "tableTo": "users",
           "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "subscriptions_subscriptionId_unique": {
           "name": "subscriptions_subscriptionId_unique",
-          "nullsNotDistinct": false,
-          "columns": ["subscriptionId"]
+          "columns": ["subscriptionId"],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
       "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upload_intents": {
+      "name": "upload_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileKey": {
+          "name": "fileKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "upload_intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleteCheckedAt": {
+          "name": "deleteCheckedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanupAttempts": {
+          "name": "cleanupAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastCleanupError": {
+          "name": "lastCleanupError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upload_intents_fileKey_unique": {
+          "name": "upload_intents_fileKey_unique",
+          "columns": [
+            {
+              "expression": "fileKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "upload_intents_userId_status_expiresAt_idx": {
+          "name": "upload_intents_userId_status_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "upload_intents_cleanup_queue_idx": {
+          "name": "upload_intents_cleanup_queue_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cleanupAttempts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "upload_intents_userId_users_id_fk": {
+          "name": "upload_intents_userId_users_id_fk",
+          "tableFrom": "upload_intents",
+          "columnsFrom": ["userId"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "upload_intents_fileSize_positive": {
+          "name": "upload_intents_fileSize_positive",
+          "value": "\"upload_intents\".\"fileSize\" > 0"
+        },
+        "upload_intents_cleanupAttempts_non_negative": {
+          "name": "upload_intents_cleanupAttempts_non_negative",
+          "value": "\"upload_intents\".\"cleanupAttempts\" >= 0"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.uploads": {
@@ -1166,6 +1415,12 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true
+        },
+        "uploadIntentId": {
+          "name": "uploadIntentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
         },
         "fileKey": {
           "name": "fileKey",
@@ -1223,9 +1478,24 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
+        },
+        "uploads_uploadIntentId_unique": {
+          "name": "uploads_uploadIntentId_unique",
+          "columns": [
+            {
+              "expression": "uploadIntentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
         },
         "uploads_fileKey_unique": {
           "name": "uploads_fileKey_unique",
@@ -1238,26 +1508,40 @@
             }
           ],
           "isUnique": true,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "uploads_userId_users_id_fk": {
           "name": "uploads_userId_users_id_fk",
           "tableFrom": "uploads",
-          "tableTo": "users",
           "columnsFrom": ["userId"],
+          "tableTo": "users",
           "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "uploads_uploadIntentId_upload_intents_id_fk": {
+          "name": "uploads_uploadIntentId_upload_intents_id_fk",
+          "tableFrom": "uploads",
+          "columnsFrom": ["uploadIntentId"],
+          "tableTo": "upload_intents",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "uploads_fileSize_positive": {
+          "name": "uploads_fileSize_positive",
+          "value": "\"uploads\".\"fileSize\" > 0"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.users": {
@@ -1346,13 +1630,13 @@
       "uniqueConstraints": {
         "users_email_unique": {
           "name": "users_email_unique",
-          "nullsNotDistinct": false,
-          "columns": ["email"]
+          "columns": ["email"],
+          "nullsNotDistinct": false
         },
         "users_paymentProviderCustomerId_unique": {
           "name": "users_paymentProviderCustomerId_unique",
-          "nullsNotDistinct": false,
-          "columns": ["paymentProviderCustomerId"]
+          "columns": ["paymentProviderCustomerId"],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -1412,9 +1696,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {},
@@ -1452,27 +1736,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'creem'"
-        },
-        "processed": {
-          "name": "processed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "processedAt": {
-          "name": "processedAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "payload": {
-          "name": "payload",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
+          "default": "'stripe'"
         },
         "createdAt": {
           "name": "createdAt",
@@ -1500,9 +1764,9 @@
             }
           ],
           "isUnique": true,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "webhook_events_provider_idx": {
           "name": "webhook_events_provider_idx",
@@ -1515,9 +1779,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         }
       },
       "foreignKeys": {},
@@ -1529,6 +1793,11 @@
     }
   },
   "enums": {
+    "public.upload_intent_status": {
+      "name": "upload_intent_status",
+      "schema": "public",
+      "values": ["pending", "cancelled", "cleaning", "completed"]
+    },
     "public.user_role": {
       "name": "user_role",
       "schema": "public",
@@ -1536,10 +1805,10 @@
     }
   },
   "schemas": {},
+  "views": {},
   "sequences": {},
   "roles": {},
   "policies": {},
-  "views": {},
   "_meta": {
     "columns": {},
     "schemas": {},

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1787130237051,
       "tag": "0018_eminent_human_robot",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1787214321240,
+      "tag": "0019_reset_creem_billing",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/billing/stripe/prices.test.ts
+++ b/src/lib/billing/stripe/prices.test.ts
@@ -12,18 +12,14 @@ describe("Stripe price configuration", () => {
       PRODUCT_TIERS.map(({ id }) => id).sort(),
     );
     for (const tier of PRODUCT_TIERS) {
-      expect(getStripeCatalogItem(tier.id, "test_mode")).toEqual({
-        productId: "",
-        oneTime: "",
-        monthly: "",
-        yearly: "",
-      });
-      expect(getStripeCatalogItem(tier.id, "live_mode")).toEqual({
-        productId: "",
-        oneTime: "",
-        monthly: "",
-        yearly: "",
-      });
+      for (const environment of ["test_mode", "live_mode"] as const) {
+        expect(getStripeCatalogItem(tier.id, environment)).toEqual({
+          productId: expect.any(String),
+          oneTime: expect.any(String),
+          monthly: expect.any(String),
+          yearly: expect.any(String),
+        });
+      }
     }
   });
 
@@ -58,9 +54,6 @@ describe("Stripe price configuration", () => {
     expect(getStripeCatalogItem("unknown", "live_mode")).toBeUndefined();
     expect(
       getActiveStripePriceId("unknown", "live_mode", "monthly"),
-    ).toBeUndefined();
-    expect(
-      getActiveStripePriceId("plus", "live_mode", "monthly"),
     ).toBeUndefined();
     expect(getProductTierByStripeProductId("")).toBeUndefined();
     expect(getProductTierByStripeProductId("prod_unknown")).toBeUndefined();

--- a/src/lib/billing/stripe/prices.ts
+++ b/src/lib/billing/stripe/prices.ts
@@ -18,10 +18,10 @@ export const STRIPE_CATALOG: Record<
 > = {
   plus: {
     test_mode: {
-      productId: "",
-      oneTime: "",
-      monthly: "",
-      yearly: "",
+      productId: "prod_V6eg0UZMwGjBT6",
+      oneTime: "price_1U6RMjB9KYdWZZKtlQUyf7aW",
+      monthly: "price_1U6RMkB9KYdWZZKtImJZZsqe",
+      yearly: "price_1U6RMkB9KYdWZZKtxrLaUgRf",
     },
     live_mode: {
       productId: "",
@@ -32,10 +32,10 @@ export const STRIPE_CATALOG: Record<
   },
   pro: {
     test_mode: {
-      productId: "",
-      oneTime: "",
-      monthly: "",
-      yearly: "",
+      productId: "prod_V6egfyOPZCZZYI",
+      oneTime: "price_1U6RMlB9KYdWZZKtkzZEqTNY",
+      monthly: "price_1U6RMmB9KYdWZZKtudqfcH8X",
+      yearly: "price_1U6RMnB9KYdWZZKtDuKMIn0g",
     },
     live_mode: {
       productId: "",
@@ -46,10 +46,10 @@ export const STRIPE_CATALOG: Record<
   },
   team: {
     test_mode: {
-      productId: "",
-      oneTime: "",
-      monthly: "",
-      yearly: "",
+      productId: "prod_V6egOauLh3UuUg",
+      oneTime: "price_1U6RMoB9KYdWZZKtLepHKFnh",
+      monthly: "price_1U6RMoB9KYdWZZKtMnyLViuT",
+      yearly: "price_1U6RMpB9KYdWZZKtpXWw05x6",
     },
     live_mode: {
       productId: "",

--- a/src/lib/billing/stripe/product-sync.test.ts
+++ b/src/lib/billing/stripe/product-sync.test.ts
@@ -6,6 +6,7 @@ import {
   buildStripePriceSpecs,
   updatePricesConfigSource,
 } from "./product-sync";
+import { STRIPE_CATALOG } from "./prices";
 
 describe("Stripe product sync", () => {
   it("builds one-time, monthly, and yearly prices for every tier", () => {
@@ -74,8 +75,9 @@ describe("Stripe product sync", () => {
     expect(updated).toContain(
       'test_mode: {\n      productId: "prod_plus",\n      oneTime: "price_one_time",\n      monthly: "price_monthly"',
     );
+    const liveCatalog = STRIPE_CATALOG.plus.live_mode;
     expect(updated).toContain(
-      'live_mode: {\n      productId: "",\n      oneTime: "",\n      monthly: ""',
+      `live_mode: {\n      productId: "${liveCatalog.productId}",\n      oneTime: "${liveCatalog.oneTime}",\n      monthly: "${liveCatalog.monthly}"`,
     );
   });
 

--- a/src/lib/billing/stripe/provider.test.ts
+++ b/src/lib/billing/stripe/provider.test.ts
@@ -138,6 +138,22 @@ describe("Stripe provider", () => {
     });
   });
 
+  it("uses the durable asynchronous failure marker", async () => {
+    mockStripeClient.checkout.sessions.retrieve.mockResolvedValue({
+      status: "complete",
+      payment_status: "unpaid",
+      client_reference_id: "user_123",
+      metadata: {
+        paymentMode: "subscription",
+        asyncPaymentStatus: "failed",
+      },
+    });
+
+    await expect(
+      stripeProvider.getCheckoutStatus("cs_failed"),
+    ).resolves.toEqual(expect.objectContaining({ status: "failed" }));
+  });
+
   it("reuses the canonical customer found after an idempotency window", async () => {
     mockStripeClient.customers.search.mockResolvedValue({
       data: [{ id: "cus_existing" }],
@@ -251,8 +267,39 @@ describe("Stripe provider", () => {
           paymentMode: "subscription",
         },
       );
+      expect(mockStripeClient.checkout.sessions.retrieve).toHaveBeenCalledWith(
+        "cs_123",
+        { expand: ["payment_intent", "subscription"] },
+      );
     },
   );
+
+  it.each([
+    {
+      payment_intent: { status: "requires_payment_method" },
+      subscription: null,
+    },
+    {
+      payment_intent: null,
+      subscription: { status: "incomplete_expired" },
+    },
+  ])("maps terminal asynchronous failures to failed", async (expandedState) => {
+    mockStripeClient.checkout.sessions.retrieve.mockResolvedValue({
+      status: "complete",
+      payment_status: "unpaid",
+      client_reference_id: "user_123",
+      metadata: { paymentMode: "subscription" },
+      ...expandedState,
+    });
+
+    await expect(
+      stripeProvider.getCheckoutStatus("cs_failed"),
+    ).resolves.toEqual({
+      status: "failed",
+      ownerId: "user_123",
+      paymentMode: "subscription",
+    });
+  });
 
   it("creates portal sessions and supports both cancellation modes", async () => {
     mockStripeClient.billingPortal.sessions.create.mockResolvedValue({

--- a/src/lib/billing/stripe/provider.ts
+++ b/src/lib/billing/stripe/provider.ts
@@ -69,6 +69,31 @@ function resolveCheckoutStatus(
   ) {
     return "success";
   }
+  if (session.metadata?.asyncPaymentStatus === "failed") return "failed";
+  if (session.status === "complete" && session.payment_status === "unpaid") {
+    const paymentIntent =
+      session.payment_intent && typeof session.payment_intent !== "string"
+        ? session.payment_intent
+        : null;
+    if (
+      paymentIntent?.status === "canceled" ||
+      paymentIntent?.status === "requires_payment_method"
+    ) {
+      return "failed";
+    }
+
+    const subscription =
+      session.subscription && typeof session.subscription !== "string"
+        ? session.subscription
+        : null;
+    if (
+      subscription?.status === "canceled" ||
+      subscription?.status === "incomplete_expired" ||
+      subscription?.status === "unpaid"
+    ) {
+      return "failed";
+    }
+  }
   return "pending";
 }
 
@@ -143,8 +168,10 @@ const stripeProvider: PaymentProvider = {
   },
 
   async getCheckoutStatus(checkoutId): Promise<CheckoutStatusResult> {
-    const session =
-      await getStripeClient().checkout.sessions.retrieve(checkoutId);
+    const session = await getStripeClient().checkout.sessions.retrieve(
+      checkoutId,
+      { expand: ["payment_intent", "subscription"] },
+    );
     const paymentMode = session.metadata?.paymentMode;
 
     return {

--- a/src/lib/billing/stripe/webhook-processors.test.ts
+++ b/src/lib/billing/stripe/webhook-processors.test.ts
@@ -4,6 +4,7 @@ const mockFindUserByCustomerId = jest.fn();
 const mockGrantProductEntitlement = jest.fn();
 const mockLockBillingProductScope = jest.fn();
 const mockLockPaymentAdjustmentScope = jest.fn();
+const mockReconcilePaymentAfterDispute = jest.fn();
 const mockRevokeProductEntitlementByPaymentId = jest.fn();
 const mockSuspendSubscriptionAccess = jest.fn();
 const mockUpdatePaymentStatus = jest.fn();
@@ -16,6 +17,7 @@ jest.mock("@/lib/database/subscription", () => ({
   grantProductEntitlement: mockGrantProductEntitlement,
   lockBillingProductScope: mockLockBillingProductScope,
   lockPaymentAdjustmentScope: mockLockPaymentAdjustmentScope,
+  reconcilePaymentAfterDispute: mockReconcilePaymentAfterDispute,
   revokeProductEntitlementByPaymentId: mockRevokeProductEntitlementByPaymentId,
   suspendSubscriptionAccess: mockSuspendSubscriptionAccess,
   updatePaymentStatus: mockUpdatePaymentStatus,
@@ -66,6 +68,7 @@ describe("Stripe webhook processors", () => {
     mockFindUserByCustomerId.mockResolvedValue({ id: "user_123" });
     mockGetProductTierByStripeProductId.mockReturnValue(tier);
     mockUpsertPayment.mockResolvedValue([{ status: "succeeded" }]);
+    mockReconcilePaymentAfterDispute.mockResolvedValue([]);
   });
 
   it("records a paid one-time checkout and grants its entitlement", async () => {
@@ -121,6 +124,36 @@ describe("Stripe webhook processors", () => {
       tx,
     );
     expect(mockUpsertPayment).not.toHaveBeenCalled();
+    expect(mockGrantProductEntitlement).not.toHaveBeenCalled();
+  });
+
+  it("records a failed asynchronous one-time checkout without granting access", async () => {
+    const { processCheckoutSession } = await import("./webhook-processors");
+    mockUpsertPayment.mockResolvedValue([{ status: "failed" }]);
+    const session = {
+      id: "cs_failed",
+      customer: "cus_123",
+      client_reference_id: "user_123",
+      payment_status: "unpaid",
+      payment_intent: "pi_failed",
+      amount_total: 2999,
+      currency: "usd",
+      metadata: {
+        userId: "user_123",
+        tierId: "pro",
+        paymentMode: "one_time",
+      },
+    } as unknown as Stripe.Checkout.Session;
+
+    await processCheckoutSession(session, new Date(), tx, "failed");
+
+    expect(mockUpsertPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentId: "pi_failed",
+        status: "failed",
+      }),
+      tx,
+    );
     expect(mockGrantProductEntitlement).not.toHaveBeenCalled();
   });
 
@@ -538,7 +571,12 @@ describe("Stripe webhook processors", () => {
       tx,
     );
 
-    await processDispute(["pi_123"], createdAt, tx);
+    await processDispute(
+      { status: "needs_response" } as Stripe.Dispute,
+      ["pi_123"],
+      createdAt,
+      tx,
+    );
     expect(mockUpdatePaymentStatus).toHaveBeenCalledWith(
       "pi_123",
       "disputed",
@@ -547,6 +585,113 @@ describe("Stripe webhook processors", () => {
     expect(mockSuspendSubscriptionAccess).toHaveBeenCalledWith(
       "sub_123",
       createdAt,
+      tx,
+    );
+  });
+
+  it("ignores warning disputes that have not withdrawn funds", async () => {
+    const { processDispute } = await import("./webhook-processors");
+
+    await processDispute(
+      { status: "warning_needs_response" } as Stripe.Dispute,
+      ["pi_123"],
+      new Date(),
+      tx,
+    );
+
+    expect(mockLockPaymentAdjustmentScope).not.toHaveBeenCalled();
+    expect(mockUpdatePaymentStatus).not.toHaveBeenCalled();
+  });
+
+  it("restores a won one-time dispute from the authoritative charge", async () => {
+    const { processClosedDispute } = await import("./webhook-processors");
+    mockLockPaymentAdjustmentScope.mockResolvedValue("pi_123");
+    mockReconcilePaymentAfterDispute.mockResolvedValue([
+      {
+        paymentId: "pi_123",
+        paymentType: "one_time",
+        productId: "pro",
+        subscriptionId: null,
+        userId: "user_123",
+      },
+    ]);
+
+    await processClosedDispute(
+      { status: "won" } as Stripe.Dispute,
+      {
+        amount: 2999,
+        amount_refunded: 0,
+        refunded: false,
+      } as Stripe.Charge,
+      ["pi_123"],
+      new Date(),
+      tx,
+      null,
+    );
+
+    expect(mockReconcilePaymentAfterDispute).toHaveBeenCalledWith(
+      "pi_123",
+      "succeeded",
+      tx,
+    );
+    expect(mockGrantProductEntitlement).toHaveBeenCalledWith(
+      {
+        userId: "user_123",
+        productId: "pro",
+        sourcePaymentId: "pi_123",
+      },
+      tx,
+    );
+  });
+
+  it("reconciles subscription access after a won dispute", async () => {
+    const { processClosedDispute } = await import("./webhook-processors");
+    const currentSubscription = {
+      id: "sub_123",
+      customer: "cus_123",
+      status: "active",
+      cancel_at_period_end: false,
+      canceled_at: null,
+      metadata: { userId: "user_123", tierId: "pro" },
+      items: {
+        data: [
+          {
+            price: { product: "prod_pro" },
+            current_period_start: 1_700_000_000,
+            current_period_end: 1_702_592_000,
+          },
+        ],
+      },
+    } as unknown as Stripe.Subscription;
+    mockLockPaymentAdjustmentScope.mockResolvedValue("in_123");
+    mockReconcilePaymentAfterDispute.mockResolvedValue([
+      {
+        paymentId: "in_123",
+        paymentType: "subscription",
+        productId: "pro",
+        subscriptionId: "sub_123",
+        userId: "user_123",
+      },
+    ]);
+
+    await processClosedDispute(
+      { status: "won" } as Stripe.Dispute,
+      {
+        amount: 1999,
+        amount_refunded: 0,
+        refunded: false,
+      } as Stripe.Charge,
+      ["pi_123"],
+      new Date("2026-08-20T00:00:00Z"),
+      tx,
+      currentSubscription,
+    );
+
+    expect(mockUpsertSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subscriptionId: "sub_123",
+        status: "active",
+      }),
       tx,
     );
   });

--- a/src/lib/billing/stripe/webhook-processors.ts
+++ b/src/lib/billing/stripe/webhook-processors.ts
@@ -8,6 +8,7 @@ import {
   grantProductEntitlement,
   lockBillingProductScope,
   lockPaymentAdjustmentScope,
+  reconcilePaymentAfterDispute,
   revokeProductEntitlementByPaymentId,
   suspendSubscriptionAccess,
   type Tx,
@@ -237,8 +238,10 @@ export async function processCheckoutSession(
   session: Stripe.Checkout.Session,
   _eventCreatedAt: Date,
   tx: Tx,
+  outcome: "completed" | "failed" = "completed",
 ): Promise<void> {
   if (
+    outcome === "completed" &&
     session.payment_status !== "paid" &&
     session.payment_status !== "no_payment_required"
   ) {
@@ -295,7 +298,7 @@ export async function processCheckoutSession(
       paymentIntentId: getOptionalId(session.payment_intent),
       amount: session.amount_total,
       currency: session.currency,
-      status: "succeeded",
+      status: outcome === "failed" ? "failed" : "succeeded",
       paymentType: "one_time",
     },
     tx,
@@ -427,14 +430,93 @@ export async function processRefund(
 }
 
 export async function processDispute(
+  dispute: Stripe.Dispute,
   paymentReferences: string[],
   eventCreatedAt: Date,
   tx: Tx,
 ): Promise<void> {
+  if (dispute.status.startsWith("warning_") || dispute.status === "prevented") {
+    return;
+  }
+
   const paymentId = await lockPaymentAdjustmentScope(paymentReferences, tx);
   const [payment] = await updatePaymentStatus(paymentId, "disputed", tx);
   await revokeProductEntitlementByPaymentId(paymentId, "disputed", tx);
   if (payment?.subscriptionId) {
     await suspendSubscriptionAccess(payment.subscriptionId, eventCreatedAt, tx);
+  }
+}
+
+export async function processClosedDispute(
+  dispute: Stripe.Dispute,
+  charge: Stripe.Charge,
+  paymentReferences: string[],
+  eventCreatedAt: Date,
+  tx: Tx,
+  currentSubscription: Stripe.Subscription | null,
+): Promise<void> {
+  if (dispute.status === "warning_closed" || dispute.status === "prevented") {
+    return;
+  }
+  if (dispute.status === "lost") {
+    await processDispute(dispute, paymentReferences, eventCreatedAt, tx);
+    return;
+  }
+  if (dispute.status !== "won") {
+    throw new InvalidWebhookPayloadError(
+      `Closed Stripe dispute has unsupported status: ${dispute.status}`,
+    );
+  }
+
+  const paymentId = await lockPaymentAdjustmentScope(paymentReferences, tx);
+  const reconciledStatus =
+    charge.refunded && charge.amount_refunded >= charge.amount
+      ? "refunded"
+      : charge.amount_refunded > 0
+        ? "partially_refunded"
+        : "succeeded";
+  const [payment] = await reconcilePaymentAfterDispute(
+    paymentId,
+    reconciledStatus,
+    tx,
+  );
+  if (!payment) {
+    throw new Error(`Payment ${paymentId} could not be reconciled.`);
+  }
+
+  if (reconciledStatus === "refunded") {
+    await revokeProductEntitlementByPaymentId(paymentId, "refunded", tx);
+    if (payment.subscriptionId) {
+      await suspendSubscriptionAccess(
+        payment.subscriptionId,
+        eventCreatedAt,
+        tx,
+      );
+    }
+    return;
+  }
+
+  if (payment.paymentType === "one_time") {
+    await grantProductEntitlement(
+      {
+        userId: payment.userId,
+        productId: payment.productId,
+        sourcePaymentId: payment.paymentId,
+      },
+      tx,
+    );
+    return;
+  }
+
+  if (payment.subscriptionId) {
+    if (
+      !currentSubscription ||
+      currentSubscription.id !== payment.subscriptionId
+    ) {
+      throw new Error(
+        `Subscription ${payment.subscriptionId} is not available for dispute reconciliation yet.`,
+      );
+    }
+    await processSubscription(currentSubscription, eventCreatedAt, tx);
   }
 }

--- a/src/lib/billing/stripe/webhook.test.ts
+++ b/src/lib/billing/stripe/webhook.test.ts
@@ -2,11 +2,16 @@ import type Stripe from "stripe";
 
 const mockConstructEvent = jest.fn();
 const mockListInvoicePayments = jest.fn();
+const mockRetrieveCharge = jest.fn();
+const mockRetrieveSubscription = jest.fn();
+const mockUpdateCheckoutSession = jest.fn();
 const mockTransaction = jest.fn();
 const mockClaimWebhookEvent = jest.fn();
+const mockFindPaymentByReferences = jest.fn();
 const mockIsWebhookEventProcessed = jest.fn();
 const mockLogStripeWebhook = jest.fn();
 const mockProcessCheckoutSession = jest.fn();
+const mockProcessClosedDispute = jest.fn();
 const mockProcessSubscription = jest.fn();
 const mockProcessInvoice = jest.fn();
 const mockProcessRefund = jest.fn();
@@ -24,12 +29,16 @@ jest.mock("@/lib/config/integrations", () => ({
 }));
 jest.mock("@/lib/database/subscription", () => ({
   claimWebhookEvent: mockClaimWebhookEvent,
+  findPaymentByReferences: mockFindPaymentByReferences,
   isWebhookEventProcessed: mockIsWebhookEventProcessed,
 }));
 jest.mock("./client", () => ({
   getStripeClient: () => ({
     webhooks: { constructEvent: mockConstructEvent },
+    checkout: { sessions: { update: mockUpdateCheckoutSession } },
+    charges: { retrieve: mockRetrieveCharge },
     invoicePayments: { list: mockListInvoicePayments },
+    subscriptions: { retrieve: mockRetrieveSubscription },
   }),
 }));
 jest.mock("./webhook-log", () => ({
@@ -44,6 +53,7 @@ jest.mock("./webhook-processors", () => {
   }
   return {
     InvalidWebhookPayloadError,
+    processClosedDispute: mockProcessClosedDispute,
     processCheckoutSession: mockProcessCheckoutSession,
     processSubscription: mockProcessSubscription,
     processInvoice: mockProcessInvoice,
@@ -77,6 +87,7 @@ describe("Stripe webhook handler", () => {
     mockClaimWebhookEvent.mockResolvedValue(true);
     mockIsWebhookEventProcessed.mockResolvedValue(false);
     mockListInvoicePayments.mockResolvedValue({ data: [] });
+    mockFindPaymentByReferences.mockResolvedValue(null);
     mockTransaction.mockImplementation(async (callback) => callback({}));
   });
 
@@ -174,6 +185,45 @@ describe("Stripe webhook handler", () => {
     });
   });
 
+  it("records terminal asynchronous checkout failures", async () => {
+    const checkout = { id: "cs_failed" };
+    mockConstructEvent.mockReturnValue(
+      event("checkout.session.async_payment_failed", checkout),
+    );
+    const { handleStripeWebhook } = await import("./webhook");
+
+    await handleStripeWebhook("payload", "signature");
+
+    expect(mockProcessCheckoutSession).toHaveBeenCalledWith(
+      checkout,
+      new Date(1_700_000_000_000),
+      {},
+      "failed",
+    );
+    expect(mockUpdateCheckoutSession).toHaveBeenCalledWith("cs_failed", {
+      metadata: { asyncPaymentStatus: "failed" },
+    });
+  });
+
+  it("reconciles subscription events from Stripe's current state", async () => {
+    const eventSubscription = { id: "sub_123", status: "incomplete" };
+    const currentSubscription = { id: "sub_123", status: "active" };
+    mockConstructEvent.mockReturnValue(
+      event("customer.subscription.created", eventSubscription),
+    );
+    mockRetrieveSubscription.mockResolvedValue(currentSubscription);
+    const { handleStripeWebhook } = await import("./webhook");
+
+    await handleStripeWebhook("payload", "signature");
+
+    expect(mockRetrieveSubscription).toHaveBeenCalledWith("sub_123");
+    expect(mockProcessSubscription).toHaveBeenCalledWith(
+      currentSubscription,
+      new Date(1_700_000_000_000),
+      {},
+    );
+  });
+
   it("short-circuits redeliveries before touching Stripe or the database", async () => {
     mockConstructEvent.mockReturnValue(
       event("charge.refunded", { id: "ch_1" }),
@@ -224,6 +274,42 @@ describe("Stripe webhook handler", () => {
       ["ch_123", "pi_123"],
       new Date(1_700_000_000_000),
       {},
+    );
+  });
+
+  it("prepares authoritative state for a won dispute", async () => {
+    const dispute = {
+      id: "dp_123",
+      status: "won",
+      charge: "ch_123",
+      payment_intent: "pi_123",
+    };
+    const charge = {
+      id: "ch_123",
+      amount: 2999,
+      amount_refunded: 0,
+      refunded: false,
+    };
+    const subscription = { id: "sub_123", status: "active" };
+    mockConstructEvent.mockReturnValue(event("charge.dispute.closed", dispute));
+    mockRetrieveCharge.mockResolvedValue(charge);
+    mockFindPaymentByReferences.mockResolvedValue({
+      subscriptionId: "sub_123",
+    });
+    mockRetrieveSubscription.mockResolvedValue(subscription);
+    const { handleStripeWebhook } = await import("./webhook");
+
+    await handleStripeWebhook("payload", "signature");
+
+    expect(mockRetrieveCharge).toHaveBeenCalledWith("ch_123");
+    expect(mockRetrieveSubscription).toHaveBeenCalledWith("sub_123");
+    expect(mockProcessClosedDispute).toHaveBeenCalledWith(
+      dispute,
+      charge,
+      ["ch_123", "pi_123"],
+      new Date(1_700_000_000_000),
+      {},
+      subscription,
     );
   });
 

--- a/src/lib/billing/stripe/webhook.ts
+++ b/src/lib/billing/stripe/webhook.ts
@@ -4,6 +4,7 @@ import { db } from "@/database";
 import { getBillingConfig } from "@/lib/config/integrations";
 import {
   claimWebhookEvent,
+  findPaymentByReferences,
   isWebhookEventProcessed,
   type Tx,
 } from "@/lib/database/subscription";
@@ -13,6 +14,7 @@ import { getStripeClient } from "./client";
 import { logStripeWebhook } from "./webhook-log";
 import {
   InvalidWebhookPayloadError,
+  processClosedDispute,
   processCheckoutSession,
   processDispute,
   processInvoice,
@@ -60,7 +62,10 @@ function getAdjustmentPaymentReferences(event: Stripe.Event): string[] {
   if (event.type === "charge.refunded") {
     chargeId = event.data.object.id;
     paymentIntentId = getOptionalId(event.data.object.payment_intent);
-  } else if (event.type === "charge.dispute.created") {
+  } else if (
+    event.type === "charge.dispute.created" ||
+    event.type === "charge.dispute.closed"
+  ) {
     chargeId = getOptionalId(event.data.object.charge);
     paymentIntentId = getOptionalId(event.data.object.payment_intent);
   } else {
@@ -74,6 +79,62 @@ function getAdjustmentPaymentReferences(event: Stripe.Event): string[] {
   // refunds deterministic and avoids a second Stripe API call inside webhook
   // handling; a missing record causes Stripe to retry the event.
   return [...new Set(references)];
+}
+
+interface PreparedStripeState {
+  currentSubscription: Stripe.Subscription | null;
+  disputeCharge: Stripe.Charge | null;
+}
+
+async function prepareStripeState(
+  event: Stripe.Event,
+  paymentReferences: string[],
+): Promise<PreparedStripeState> {
+  switch (event.type) {
+    case "customer.subscription.created":
+    case "customer.subscription.updated":
+    case "customer.subscription.deleted":
+    case "customer.subscription.paused":
+    case "customer.subscription.resumed":
+      return {
+        currentSubscription: await getStripeClient().subscriptions.retrieve(
+          event.data.object.id,
+        ),
+        disputeCharge: null,
+      };
+  }
+
+  if (event.type === "checkout.session.async_payment_failed") {
+    await getStripeClient().checkout.sessions.update(event.data.object.id, {
+      metadata: { asyncPaymentStatus: "failed" },
+    });
+    return { currentSubscription: null, disputeCharge: null };
+  }
+
+  if (event.type !== "charge.dispute.closed") {
+    return { currentSubscription: null, disputeCharge: null };
+  }
+
+  const chargeId = getOptionalId(event.data.object.charge);
+  if (!chargeId) {
+    throw new InvalidWebhookPayloadError(
+      "Closed Stripe dispute is missing its charge reference.",
+    );
+  }
+  const disputeCharge = await getStripeClient().charges.retrieve(chargeId);
+  const payment = await findPaymentByReferences(paymentReferences);
+  const shouldRestoreSubscription =
+    event.data.object.status === "won" &&
+    !(
+      disputeCharge.refunded &&
+      disputeCharge.amount_refunded >= disputeCharge.amount
+    ) &&
+    Boolean(payment?.subscriptionId);
+  const currentSubscription = shouldRestoreSubscription
+    ? await getStripeClient().subscriptions.retrieve(payment!.subscriptionId!)
+    : null;
+
+  return { currentSubscription, disputeCharge };
 }
 
 async function getInvoicePaymentIntentId(
@@ -115,6 +176,7 @@ async function dispatchStripeWebhook(
   eventCreatedAt: Date,
   adjustmentPaymentReferences: string[],
   invoicePaymentIntentId: string | null,
+  preparedState: PreparedStripeState,
   tx: Tx,
 ): Promise<"ignored" | "processed"> {
   switch (event.type) {
@@ -122,12 +184,29 @@ async function dispatchStripeWebhook(
     case "checkout.session.async_payment_succeeded":
       await processCheckoutSession(event.data.object, eventCreatedAt, tx);
       return "processed";
+    case "checkout.session.async_payment_failed":
+      await processCheckoutSession(
+        event.data.object,
+        eventCreatedAt,
+        tx,
+        "failed",
+      );
+      return "processed";
     case "customer.subscription.created":
     case "customer.subscription.updated":
     case "customer.subscription.deleted":
     case "customer.subscription.paused":
     case "customer.subscription.resumed":
-      await processSubscription(event.data.object, eventCreatedAt, tx);
+      if (!preparedState.currentSubscription) {
+        throw new InvalidWebhookPayloadError(
+          "Stripe subscription state could not be resolved.",
+        );
+      }
+      await processSubscription(
+        preparedState.currentSubscription,
+        eventCreatedAt,
+        tx,
+      );
       return "processed";
     case "invoice.paid":
       await processInvoice(
@@ -156,7 +235,27 @@ async function dispatchStripeWebhook(
       );
       return "processed";
     case "charge.dispute.created":
-      await processDispute(adjustmentPaymentReferences, eventCreatedAt, tx);
+      await processDispute(
+        event.data.object,
+        adjustmentPaymentReferences,
+        eventCreatedAt,
+        tx,
+      );
+      return "processed";
+    case "charge.dispute.closed":
+      if (!preparedState.disputeCharge) {
+        throw new InvalidWebhookPayloadError(
+          "Stripe dispute charge could not be resolved.",
+        );
+      }
+      await processClosedDispute(
+        event.data.object,
+        preparedState.disputeCharge,
+        adjustmentPaymentReferences,
+        eventCreatedAt,
+        tx,
+        preparedState.currentSubscription,
+      );
       return "processed";
     default:
       return "ignored";
@@ -241,6 +340,10 @@ export async function handleStripeWebhook(
             event.type,
           )
         : null;
+    const preparedState = await prepareStripeState(
+      event,
+      adjustmentPaymentReferences,
+    );
     const outcome = await db.transaction<ProcessingOutcome>(async (tx) => {
       const claimed = await claimWebhookEvent(
         event.id,
@@ -254,6 +357,7 @@ export async function handleStripeWebhook(
         eventCreatedAt,
         adjustmentPaymentReferences,
         invoicePaymentIntentId,
+        preparedState,
         tx,
       );
     });

--- a/src/lib/database/subscription.ts
+++ b/src/lib/database/subscription.ts
@@ -55,6 +55,15 @@ interface GrantProductEntitlementData {
   sourcePaymentId: string;
 }
 
+export interface PaymentReferenceRecord {
+  paymentId: string;
+  paymentType: string;
+  productId: string;
+  status: string;
+  subscriptionId: string | null;
+  userId: string;
+}
+
 const getDb = (tx?: Tx) => tx || db;
 
 export async function upsertSubscription(
@@ -294,36 +303,70 @@ export async function updatePaymentStatus(
   return rows;
 }
 
-export async function lockPaymentAdjustmentScope(
-  paymentReferences: string[],
-  tx: Tx,
-): Promise<string> {
-  const references = [
-    ...new Set(paymentReferences.map((value) => value.trim()).filter(Boolean)),
-  ];
-  if (references.length === 0) {
-    throw new Error("A payment reference is required for an adjustment.");
+export async function reconcilePaymentAfterDispute(
+  paymentId: string,
+  status: "partially_refunded" | "refunded" | "succeeded",
+  tx?: Tx,
+) {
+  const rows = await getDb(tx)
+    .update(payments)
+    .set({ status, updatedAt: new Date() })
+    .where(eq(payments.paymentId, paymentId))
+    .returning();
+
+  if (rows.length === 0) {
+    throw new Error(
+      `Payment ${paymentId} is not available for dispute reconciliation yet.`,
+    );
   }
 
-  let payment:
-    | { paymentId: string; userId: string; productId: string }
-    | undefined;
+  return rows;
+}
+
+function normalizePaymentReferences(paymentReferences: string[]): string[] {
+  return [
+    ...new Set(paymentReferences.map((value) => value.trim()).filter(Boolean)),
+  ];
+}
+
+export async function findPaymentByReferences(
+  paymentReferences: string[],
+  tx?: Tx,
+): Promise<PaymentReferenceRecord | null> {
+  const references = normalizePaymentReferences(paymentReferences);
+  const dbase = getDb(tx);
+
   for (const reference of references) {
-    [payment] = await tx
+    const [payment] = await dbase
       .select({
         paymentId: payments.paymentId,
-        userId: payments.userId,
+        paymentType: payments.paymentType,
         productId: payments.productId,
+        status: payments.status,
+        subscriptionId: payments.subscriptionId,
+        userId: payments.userId,
       })
       .from(payments)
       .where(
         sql`${payments.paymentId} = ${reference} or ${payments.paymentIntentId} = ${reference}`,
       )
       .limit(1);
-    if (payment) {
-      break;
-    }
+    if (payment) return payment;
   }
+
+  return null;
+}
+
+export async function lockPaymentAdjustmentScope(
+  paymentReferences: string[],
+  tx: Tx,
+): Promise<string> {
+  const references = normalizePaymentReferences(paymentReferences);
+  if (references.length === 0) {
+    throw new Error("A payment reference is required for an adjustment.");
+  }
+
+  const payment = await findPaymentByReferences(references, tx);
 
   if (!payment) {
     throw new Error(


### PR DESCRIPTION
## Summary
- finish the Creem-to-Stripe cutover with a configured test-mode product catalog
- reset legacy demo billing state in a forward migration while preserving users and roles
- reconcile asynchronous checkout failures, current subscription state, and dispute closure outcomes
- document the required Stripe webhook events and release as v0.1.5

## Verification
- `pnpm lint`
- `pnpm dead-code:check`
- `pnpm prettier:check`
- `pnpm type-check`
- `pnpm test --runInBand` (127 suites, 1105 tests)
- `pnpm build`
- local migration and signed webhook smoke test
- Stripe test API catalog verification (3 products, 9 prices)
