### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Routine formatting and test-only maintenance are omitted.
 
 ## Unreleased
 
+## 0.1.6 — 2026-08-20
+
+### Security
+
+- Resolved the high-severity `deepmerge-ts` and `nanoid` advisories reported
+  by Dependabot, with narrow dependency overrides and a refreshed lockfile.
+
 ## 0.1.5 — 2026-08-20
 
 ### Stripe migration completion

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ullrai-starter",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "engines": {


### PR DESCRIPTION
## Summary
- bump the package version to 0.1.6 after merging the Dependabot security fixes
- document the resolved high-severity dependency advisories

## Verification
- `pnpm audit --prod --audit-level high`
- `pnpm prettier:check`
- `pnpm type-check`

Release follow-up to #74.
