### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Routine formatting and test-only maintenance are omitted.
 
 ## Unreleased
 
+## 0.1.7 — 2026-08-21
+
+### Agent-ready AI stack
+
+- Added a Vercel AI SDK v7 agent loop behind a provider-neutral
+  OpenAI-compatible endpoint, configured with `LLM_API_KEY`, `LLM_BASE_URL`,
+  and `AI_DEFAULT_MODEL`.
+- Added the `src/lib/ai` module: a tool registry, a composable skill system,
+  and request-scoped agents whose context is built from the session.
+- Added `POST /api/chat` with session auth, per-user rate limiting, body
+  limits, and masked provider errors, plus a streaming chat page at
+  `/dashboard/ai` localized in English and Simplified Chinese.
+- Gated the whole feature behind `SITE_CONFIG.features.ai`. Deployments that
+  keep it enabled must provide `LLM_API_KEY`.
+
 ## 0.1.6 — 2026-08-20
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ullrai-starter",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "engines": {


### PR DESCRIPTION
Version bump and changelog for v0.1.7, which ships the agent-ready AI stack from #77 (closes #76).

**Deployment note:** `SITE_CONFIG.features.ai` is enabled by default, so this release requires `LLM_API_KEY` in the production environment. `env.js` validates it at build time — a deployment without it fails the build rather than starting in a broken state.

After merge, `release/v0.1.7` gets tagged to promote `main` to `prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)