### PR TITLE
fix: keep AI image streams alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Routine formatting and test-only maintenance are omitted.
 
 ## Unreleased
 
+## 0.1.9 — 2026-08-22
+
+### AI image streaming reliability
+
+- Added SSE comment heartbeats to keep long-running image generations connected
+  through mobile networks and reverse proxies without changing the AI message
+  protocol or adding partial-image costs.
+
 ## 0.1.8 — 2026-08-22
 
 ### Responses API and AI workspace

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ullrai-starter",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "engines": {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -16,6 +16,7 @@ import {
   readJsonBodyWithLimit,
   RequestBodyTooLargeError,
 } from "@/lib/http/request-body";
+import { withSseKeepAlive } from "@/lib/http/sse-keep-alive";
 import { getRequestLocale } from "@/lib/i18n/server-locale";
 import { checkRateLimit } from "@/lib/rate-limit";
 
@@ -118,7 +119,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    return await createAgentUIStreamResponse({
+    const response = await createAgentUIStreamResponse({
       agent,
       uiMessages: parsed.data.messages,
       sendSources: true,
@@ -137,6 +138,7 @@ export async function POST(request: NextRequest) {
         return "The assistant hit an unexpected error. Please try again.";
       },
     });
+    return withSseKeepAlive(response);
   } catch (error) {
     // Rejection before streaming starts, e.g. malformed UI messages.
     console.error("AI chat request failed:", error);

--- a/src/lib/http/sse-keep-alive.test.ts
+++ b/src/lib/http/sse-keep-alive.test.ts
@@ -1,0 +1,69 @@
+/** @jest-environment node */
+
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import { withSseKeepAlive } from "./sse-keep-alive";
+
+const decoder = new TextDecoder();
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("withSseKeepAlive", () => {
+  it("preserves SSE data and sends comments while the stream is idle", async () => {
+    jest.useFakeTimers();
+    let sourceController: ReadableStreamDefaultController<Uint8Array>;
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        sourceController = controller;
+        controller.enqueue(
+          new TextEncoder().encode('data: {"type":"start"}\n\n'),
+        );
+      },
+    });
+    const response = withSseKeepAlive(
+      new Response(source, {
+        status: 202,
+        headers: { "content-type": "text/event-stream" },
+      }),
+      100,
+    );
+    const reader = response.body?.getReader();
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+    expect(decoder.decode((await reader?.read())?.value)).toBe(
+      'data: {"type":"start"}\n\n',
+    );
+
+    jest.advanceTimersByTime(100);
+    expect(decoder.decode((await reader?.read())?.value)).toBe(
+      ": keep-alive\n\n",
+    );
+
+    sourceController!.close();
+    expect((await reader?.read())?.done).toBe(true);
+  });
+
+  it("leaves non-SSE responses unchanged", () => {
+    const response = Response.json({ ok: true });
+
+    expect(withSseKeepAlive(response)).toBe(response);
+  });
+
+  it("cancels the source and clears the timer with the client", async () => {
+    jest.useFakeTimers();
+    const cancel = jest.fn();
+    const response = withSseKeepAlive(
+      new Response(new ReadableStream({ cancel }), {
+        headers: { "content-type": "text/event-stream" },
+      }),
+      100,
+    );
+
+    await response.body?.cancel("client disconnected");
+
+    expect(cancel).toHaveBeenCalledWith("client disconnected");
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/src/lib/http/sse-keep-alive.ts
+++ b/src/lib/http/sse-keep-alive.ts
@@ -1,0 +1,60 @@
+const DEFAULT_KEEP_ALIVE_INTERVAL_MS = 10_000;
+const KEEP_ALIVE_COMMENT = new TextEncoder().encode(": keep-alive\n\n");
+
+export function withSseKeepAlive(
+  response: Response,
+  intervalMs = DEFAULT_KEEP_ALIVE_INTERVAL_MS,
+) {
+  if (
+    !response.body ||
+    !response.headers.get("content-type")?.startsWith("text/event-stream")
+  ) {
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let finished = false;
+
+  const clearTimer = () => {
+    finished = true;
+    if (timer !== undefined) clearInterval(timer);
+  };
+
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      timer = setInterval(() => {
+        if (!finished) controller.enqueue(KEEP_ALIVE_COMMENT);
+      }, intervalMs);
+
+      void (async () => {
+        try {
+          while (true) {
+            const chunk = await reader.read();
+            if (chunk.done) {
+              if (finished) return;
+              clearTimer();
+              controller.close();
+              return;
+            }
+            if (!finished) controller.enqueue(chunk.value);
+          }
+        } catch (error) {
+          if (finished) return;
+          clearTimer();
+          controller.error(error);
+        }
+      })();
+    },
+    async cancel(reason) {
+      clearTimer();
+      await reader.cancel(reason);
+    },
+  });
+
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}


### PR DESCRIPTION
## Summary

- keep AI SSE connections active during long-running image generation with protocol-safe comment heartbeats
- preserve response status and headers while propagating source cancellation
- add lifecycle tests for idle heartbeats, non-SSE responses, and client disconnects
- release as v0.1.9

## Root cause

OpenAI Responses image generation can leave the browser-facing SSE stream idle while the provider tool is working. Mobile networks and reverse proxies can close that idle connection even though generation is still healthy.

## Verification

- real Next /api/chat request with production gpt-5.6-luna and GPT Image 2: 200 in 25.7s
- two 10s SSE heartbeats observed, maximum client gap 10.002s, no error event, completed stream
- pnpm lint
- pnpm type-check
- pnpm test (139 suites, 1157 tests)
- pnpm dead-code:check
- pnpm prettier:check
- SKIP_ENV_VALIDATION=1 pnpm build