### PR TITLE
feat: add durable background job runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Database URL
 DATABASE_URL="postgres://<user>:<password>@<url>:<port>/<db_name>"
+# Optional queue database override. Defaults to DATABASE_URL.
+# JOB_DATABASE_URL="postgres://<user>:<password>@<url>:<port>/<db_name>"
 
 # --- Database connection pool settings for traditional servers ---
 # These values are suitable for development and will be overridden by the logic
@@ -8,6 +10,10 @@ DATABASE_URL="postgres://<user>:<password>@<url>:<port>/<db_name>"
 # DB_IDLE_TIMEOUT=300
 # DB_MAX_LIFETIME=14400
 # DB_CONNECT_TIMEOUT=4
+# Small pg-boss pool per Web/Worker replica. Defaults to 3.
+# JOB_DB_POOL_SIZE=3
+# Worker SIGTERM drain deadline in milliseconds. Defaults to 30000.
+# WORKER_GRACEFUL_TIMEOUT_MS=30000
 # Optional override for non-Zeabur ingress. Defaults to x-forwarded-for.
 # RATE_LIMIT_IP_HEADER=x-forwarded-for
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ never be added to `SITE_CONFIG`.
 | Variable Name                    | Description                                                     | Example                                             |
 | :------------------------------- | :-------------------------------------------------------------- | :-------------------------------------------------- |
 | `DATABASE_URL`                   | **Required.** PostgreSQL connection string.                     | `postgresql://user:password@localhost:5432/db_name` |
+| `JOB_DATABASE_URL`               | Optional pg-boss database; defaults to `DATABASE_URL`.          | `postgresql://user:password@localhost:5432/db_name` |
+| `JOB_DB_POOL_SIZE`               | Optional pg-boss pool size per process; defaults to `3`.        | `3`                                                 |
+| `WORKER_GRACEFUL_TIMEOUT_MS`     | Optional Worker SIGTERM drain deadline; defaults to 30 seconds. | `30000`                                             |
 | `RATE_LIMIT_IP_HEADER`           | Optional trusted client-IP header; defaults to Zeabur.          | `x-forwarded-for`                                   |
 | `NEXT_PUBLIC_APP_URL`            | **Required.** Public URL of your deployed app.                  | `http://localhost:3000` or `https://yourdomain.com` |
 | `BING_SITE_VERIFICATION`         | Optional Bing Webmaster `msvalidate.01` verification token.     | Value issued for your deployed hostname             |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,36 +100,39 @@ cp .env.example .env
 
 #### 环境变量说明
 
-| 变量名                           | 描述                                               | 示例                                                |
-| :------------------------------- | :------------------------------------------------- | :-------------------------------------------------- |
-| `DATABASE_URL`                   | **必需。** PostgreSQL 连接字符串。                 | `postgresql://user:password@localhost:5432/db_name` |
-| `RATE_LIMIT_IP_HEADER`           | **选填。** 可信客户端 IP 请求头，默认适配 Zeabur。 | `x-forwarded-for`                                   |
-| `NEXT_PUBLIC_APP_URL`            | **必需。** 您应用部署后的公开 URL。                | `http://localhost:3000` 或 `https://yourdomain.com` |
-| `BETTER_AUTH_SECRET`             | **必需。** 至少 32 个字符的随机会话密钥。          | 使用 `openssl rand -base64 32` 生成                 |
-| `RESEND_API_KEY`                 | 启用 `emailAuth` 时必需。Resend API Key。          | `re_xxxxxxxxxxxxxxxx`                               |
-| `RESEND_EMAIL_FROM`              | 启用 `emailAuth` 时必需。已验证的发件地址。        | `noreply@your-verified-domain.com`                  |
-| `LLM_API_KEY`                    | 启用 `ai` 时必需。LLM 端点的 API Key。             | `sk-...`                                            |
-| `LLM_BASE_URL`                   | 可选的 OpenAI 兼容端点，默认为 OpenAI 官方 API。   | `https://api.openai.com/v1`                         |
-| `AI_DEFAULT_MODEL`               | 可选的聊天模型 id，默认 `gpt-5.6-luna`。           | `gpt-5.6-luna`                                      |
-| `STRIPE_SECRET_KEY`              | 启用 `billing` 时必需。需与环境模式匹配。          | `sk_test_...` 或 `sk_live_...`                      |
-| `STRIPE_ENVIRONMENT`             | Stripe 环境模式，默认为 `test_mode`。              | `test_mode` 或 `live_mode`                          |
-| `STRIPE_WEBHOOK_SECRET`          | 启用 `billing` 时必需。Endpoint 签名密钥。         | `whsec_your_webhook_secret`                         |
-| `R2_ENDPOINT`                    | 启用 `uploads` 时必需。Cloudflare R2 API 端点。    | `https://<ACCOUNT_ID>.r2.cloudflarestorage.com`     |
-| `R2_ACCESS_KEY_ID`               | 启用 `uploads` 时必需。R2 访问密钥 ID。            | `your_r2_access_key_id`                             |
-| `R2_SECRET_ACCESS_KEY`           | 启用 `uploads` 时必需。R2 秘密访问密钥。           | `your_r2_secret_access_key`                         |
-| `R2_BUCKET_NAME`                 | 启用 `uploads` 时必需。R2 存储桶名称。             | `your_r2_bucket_name`                               |
-| `R2_PUBLIC_URL`                  | 启用 `uploads` 时必需。R2 公共访问 URL。           | `https://your-bucket.your-account.r2.dev`           |
-| `UPLOAD_CLEANUP_SECRET`          | 启用 `uploads` 时必需。32 位以上清理密钥。         | 使用 `openssl rand -base64 32` 生成                 |
-| `UPLOAD_DAILY_QUOTA_BYTES`       | 可选。每用户滚动 24 小时上传额度。                 | `1073741824`（1 GiB）                               |
-| `UPLOAD_TOTAL_QUOTA_BYTES`       | 可选。每用户已存储与预留的总字节额度。             | `5368709120`（5 GiB）                               |
-| `UPLOAD_LEGACY_COMPLETION_SINCE` | 可选。v1 有界兼容窗口的 ISO-8601 开始时间。        | 仅与 `UPLOAD_LEGACY_COMPLETION_UNTIL` 同时设置      |
-| `UPLOAD_LEGACY_COMPLETION_UNTIL` | 可选。v1 有界兼容窗口的 ISO-8601 结束时间。        | 最多晚于对应开始时间 24 小时                        |
-| `GITHUB_CLIENT_ID`               | _可选。_ 用于 GitHub OAuth 的 Client ID。          | `your_github_client_id`                             |
-| `GITHUB_CLIENT_SECRET`           | _可选。_ 用于 GitHub OAuth 的 Client Secret。      | `your_github_client_secret`                         |
-| `GOOGLE_CLIENT_ID`               | _可选。_ 用于 Google OAuth 的 Client ID。          | `your_google_client_id`                             |
-| `GOOGLE_CLIENT_SECRET`           | _可选。_ 用于 Google OAuth 的 Client Secret。      | `your_google_client_secret`                         |
-| `LINKEDIN_CLIENT_ID`             | _可选。_ 用于 LinkedIn OAuth 的 Client ID。        | `your_linkedin_client_id`                           |
-| `LINKEDIN_CLIENT_SECRET`         | _可选。_ 用于 LinkedIn OAuth 的 Client Secret。    | `your_linkedin_client_secret`                       |
+| 变量名                           | 描述                                                 | 示例                                                |
+| :------------------------------- | :--------------------------------------------------- | :-------------------------------------------------- |
+| `DATABASE_URL`                   | **必需。** PostgreSQL 连接字符串。                   | `postgresql://user:password@localhost:5432/db_name` |
+| `JOB_DATABASE_URL`               | 可选。pg-boss 数据库，默认使用 `DATABASE_URL`。      | `postgresql://user:password@localhost:5432/db_name` |
+| `JOB_DB_POOL_SIZE`               | 可选。每进程 pg-boss 连接池大小，默认 `3`。          | `3`                                                 |
+| `WORKER_GRACEFUL_TIMEOUT_MS`     | 可选。Worker 收到 SIGTERM 后的排空时限，默认 30 秒。 | `30000`                                             |
+| `RATE_LIMIT_IP_HEADER`           | **选填。** 可信客户端 IP 请求头，默认适配 Zeabur。   | `x-forwarded-for`                                   |
+| `NEXT_PUBLIC_APP_URL`            | **必需。** 您应用部署后的公开 URL。                  | `http://localhost:3000` 或 `https://yourdomain.com` |
+| `BETTER_AUTH_SECRET`             | **必需。** 至少 32 个字符的随机会话密钥。            | 使用 `openssl rand -base64 32` 生成                 |
+| `RESEND_API_KEY`                 | 启用 `emailAuth` 时必需。Resend API Key。            | `re_xxxxxxxxxxxxxxxx`                               |
+| `RESEND_EMAIL_FROM`              | 启用 `emailAuth` 时必需。已验证的发件地址。          | `noreply@your-verified-domain.com`                  |
+| `LLM_API_KEY`                    | 启用 `ai` 时必需。LLM 端点的 API Key。               | `sk-...`                                            |
+| `LLM_BASE_URL`                   | 可选的 OpenAI 兼容端点，默认为 OpenAI 官方 API。     | `https://api.openai.com/v1`                         |
+| `AI_DEFAULT_MODEL`               | 可选的聊天模型 id，默认 `gpt-5.6-luna`。             | `gpt-5.6-luna`                                      |
+| `STRIPE_SECRET_KEY`              | 启用 `billing` 时必需。需与环境模式匹配。            | `sk_test_...` 或 `sk_live_...`                      |
+| `STRIPE_ENVIRONMENT`             | Stripe 环境模式，默认为 `test_mode`。                | `test_mode` 或 `live_mode`                          |
+| `STRIPE_WEBHOOK_SECRET`          | 启用 `billing` 时必需。Endpoint 签名密钥。           | `whsec_your_webhook_secret`                         |
+| `R2_ENDPOINT`                    | 启用 `uploads` 时必需。Cloudflare R2 API 端点。      | `https://<ACCOUNT_ID>.r2.cloudflarestorage.com`     |
+| `R2_ACCESS_KEY_ID`               | 启用 `uploads` 时必需。R2 访问密钥 ID。              | `your_r2_access_key_id`                             |
+| `R2_SECRET_ACCESS_KEY`           | 启用 `uploads` 时必需。R2 秘密访问密钥。             | `your_r2_secret_access_key`                         |
+| `R2_BUCKET_NAME`                 | 启用 `uploads` 时必需。R2 存储桶名称。               | `your_r2_bucket_name`                               |
+| `R2_PUBLIC_URL`                  | 启用 `uploads` 时必需。R2 公共访问 URL。             | `https://your-bucket.your-account.r2.dev`           |
+| `UPLOAD_CLEANUP_SECRET`          | 启用 `uploads` 时必需。32 位以上清理密钥。           | 使用 `openssl rand -base64 32` 生成                 |
+| `UPLOAD_DAILY_QUOTA_BYTES`       | 可选。每用户滚动 24 小时上传额度。                   | `1073741824`（1 GiB）                               |
+| `UPLOAD_TOTAL_QUOTA_BYTES`       | 可选。每用户已存储与预留的总字节额度。               | `5368709120`（5 GiB）                               |
+| `UPLOAD_LEGACY_COMPLETION_SINCE` | 可选。v1 有界兼容窗口的 ISO-8601 开始时间。          | 仅与 `UPLOAD_LEGACY_COMPLETION_UNTIL` 同时设置      |
+| `UPLOAD_LEGACY_COMPLETION_UNTIL` | 可选。v1 有界兼容窗口的 ISO-8601 结束时间。          | 最多晚于对应开始时间 24 小时                        |
+| `GITHUB_CLIENT_ID`               | _可选。_ 用于 GitHub OAuth 的 Client ID。            | `your_github_client_id`                             |
+| `GITHUB_CLIENT_SECRET`           | _可选。_ 用于 GitHub OAuth 的 Client Secret。        | `your_github_client_secret`                         |
+| `GOOGLE_CLIENT_ID`               | _可选。_ 用于 Google OAuth 的 Client ID。            | `your_google_client_id`                             |
+| `GOOGLE_CLIENT_SECRET`           | _可选。_ 用于 Google OAuth 的 Client Secret。        | `your_google_client_secret`                         |
+| `LINKEDIN_CLIENT_ID`             | _可选。_ 用于 LinkedIn OAuth 的 Client ID。          | `your_linkedin_client_id`                           |
+| `LINKEDIN_CLIENT_SECRET`         | _可选。_ 用于 LinkedIn OAuth 的 Client Secret。      | `your_linkedin_client_secret`                       |
 
 > **提示:** 您可以使用以下命令生成一个安全的密钥：
 > `openssl rand -base64 32`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,6 +57,7 @@ RUN apk add --no-cache su-exec \
 
 # Copy the self-contained application prepared by the build script
 COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/dist/worker ./dist/worker
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint
 
 # Set correct permissions

--- a/docker/README.md
+++ b/docker/README.md
@@ -40,8 +40,8 @@ This directory contains Docker configuration for running the UllrAI Starter appl
    ```
 
    Compose waits for PostgreSQL, applies every committed migration with the
-   one-shot `migrate` service, and starts the application only after migration
-   succeeds.
+   one-shot `migrate` service, and starts the Web and Worker services only after
+   both the application and pg-boss migrations succeed.
 
 3. **Access the application**
    - Application: http://localhost:3000
@@ -55,9 +55,15 @@ This directory contains Docker configuration for running the UllrAI Starter appl
 - **Dependencies**: PostgreSQL
 - **Health check**: Next.js application readiness
 
+### worker
+
+- **Purpose**: Claims and executes durable pg-boss jobs outside the Web process
+- **Entrypoint**: `node dist/worker/worker.mjs` (Node is PID 1)
+- **Shutdown**: Stops claiming, drains active handlers for 30 seconds, then closes both pools
+
 ### migrate
 
-- **Purpose**: Applies committed Drizzle migrations before `app` starts
+- **Purpose**: Applies committed Drizzle migrations and pg-boss schema migrations before runtime services start
 - **Lifecycle**: Exits successfully after migrations complete
 
 ### postgres
@@ -82,8 +88,9 @@ This directory contains Docker configuration for running the UllrAI Starter appl
 2. **Logs**
 
    ```bash
-   # View application logs
+   # View application and Worker logs
    docker compose logs -f app
+   docker compose logs -f worker
 
    # View all services
    docker compose logs -f
@@ -115,6 +122,9 @@ For production deployment:
    or place the container on a private network behind a reverse proxy. The
    proxy must overwrite `RATE_LIMIT_IP_HEADER`; exposing port 3000 publicly
    while trusting a client-supplied header makes IP rate limits bypassable.
+10. **Connection budget**: Budget `DB_POOL_SIZE + JOB_DB_POOL_SIZE` per Worker,
+    and the application pool plus `JOB_DB_POOL_SIZE` for each Web replica that
+    enqueues tasks. The Compose defaults use 8 connections per Worker.
 
 ## Troubleshooting
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     restart: "no"
     environment:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/ullrai_starter
+      JOB_DATABASE_URL: postgresql://postgres:postgres@postgres:5432/ullrai_starter
+      JOB_DB_POOL_SIZE: 3
       SKIP_ENV_VALIDATION: "1"
     depends_on:
       postgres:
@@ -48,12 +50,14 @@ services:
     environment:
       # Database
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/ullrai_starter
+      JOB_DATABASE_URL: postgresql://postgres:postgres@postgres:5432/ullrai_starter
 
       # Database connection pool settings
       DB_POOL_SIZE: 20
       DB_IDLE_TIMEOUT: 300
       DB_MAX_LIFETIME: 14400
       DB_CONNECT_TIMEOUT: 4
+      JOB_DB_POOL_SIZE: 3
       RATE_LIMIT_IP_HEADER: ${RATE_LIMIT_IP_HEADER:-x-forwarded-for}
 
       # Application URL
@@ -108,6 +112,31 @@ services:
       timeout: 5s
       retries: 5
       start_period: 20s
+
+  worker:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    command: ["node", "dist/worker/worker.mjs"]
+    restart: unless-stopped
+    stop_grace_period: 45s
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/ullrai_starter
+      JOB_DATABASE_URL: postgresql://postgres:postgres@postgres:5432/ullrai_starter
+      DB_POOL_SIZE: 5
+      DB_IDLE_TIMEOUT: 300
+      DB_MAX_LIFETIME: 14400
+      DB_CONNECT_TIMEOUT: 4
+      JOB_DB_POOL_SIZE: 3
+      WORKER_GRACEFUL_TIMEOUT_MS: 30000
+      LLM_API_KEY: ${LLM_API_KEY:-}
+      LLM_BASE_URL: ${LLM_BASE_URL:-https://api.openai.com/v1}
+      AI_DEFAULT_MODEL: ${AI_DEFAULT_MODEL:-gpt-5.6-luna}
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    networks:
+      - ullrai-network
 
 volumes:
   postgres_data:

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -1,0 +1,96 @@
+# Durable background jobs
+
+SaaS-Starter runs durable work in a separate Node process backed by PostgreSQL
+and pg-boss. Web routes create and observe product state in `task_runs`; Worker
+replicas claim queue records and execute typed handlers. Closing a page or
+restarting the Web service does not stop accepted work.
+
+## Runtime commands
+
+```bash
+pnpm db:migrate       # Drizzle public schema + pg-boss schema/queues
+pnpm build:worker     # dist/worker/worker.mjs
+pnpm worker:dev       # local TypeScript Worker with optional .env
+pnpm worker:start     # production artifact
+pnpm worker:smoke     # production import smoke test
+```
+
+`pnpm build` includes the Worker artifact. Production runs Web and Worker as
+separate services from the same image:
+
+```text
+Web:    node server.js
+Worker: node dist/worker/worker.mjs
+```
+
+## Defining and creating work
+
+Declare workload queues with `defineJob()` and add them to
+`src/lib/jobs/catalog.ts`. The Zod schema validates every claimed payload before
+the handler runs. Product routes call `createBackgroundTask()` with a concrete
+definition; there is no browser-facing endpoint that accepts an arbitrary queue
+name. `example.process` and `POST /api/tasks/example` provide an end-to-end
+reference.
+
+Use an application idempotency key when the business operation is idempotent.
+The partial unique index on `(scopeKey, kind, idempotencyKey)` resolves concurrent
+requests without a check-then-insert race. Queue job IDs prevent duplicate queue
+rows independently. `scopeKey` is `user:<id>` in V1 and is also assigned as the
+pg-boss group and singleton key. `groupConcurrency` expresses tenant fairness;
+the singleton queue policy closes concurrent-claim races at a limit of one. It
+does not implement provider rate limits, quotas, or billing.
+
+## State and cancellation
+
+Product state follows these guarded transitions:
+
+```text
+queued  -> running | cancelled
+running -> waiting | completed | failed | cancelled
+waiting -> queued | cancelled
+```
+
+Every transition is a conditional `UPDATE ... WHERE status IN (...)`. Terminal
+updates and stale continuations become no-ops. Retry attempts leave a task in
+`running`; only the last failed attempt changes it to `failed`.
+
+Authenticated clients poll `GET /api/tasks/:id` and cancel with
+`POST /api/tasks/:id/cancel`. Both routes scope the query to the current user and
+never expose raw pg-boss records.
+
+At each meaningful handler boundary, check `context.isCancelled()`. Persist
+progress only for useful steps, not tokens or tight polling loops. For providers
+that take minutes, call `context.scheduleContinuation(payload, startAfter)`
+after submitting. It moves the task to `waiting`, enqueues a delayed claim, and
+lets the current handler finish so the Worker slot is released. Provider
+webhooks can call `enqueueBackgroundTaskContinuation()` with a stable provider
+event UUID to deduplicate the same typed continuation without polling in a
+handler.
+
+## External provider idempotency
+
+Call `context.submitProviderJob()` for paid submissions. It passes the stable
+task ID as the provider idempotency key, reuses a persisted `providerJobId`, and
+stores the accepted provider job ID with a guarded update. A provider must
+support idempotency or lookup by that key to close the crash window between
+remote acceptance and local persistence.
+
+## Operations and tests
+
+Worker logs are structured JSON and include the job name, task ID, scope,
+attempt, retry limit, and structured error. Startup logs include queue backlog
+and oldest pending age. SIGTERM stops new claims, drains active handlers within
+`WORKER_GRACEFUL_TIMEOUT_MS`, closes pg-boss and the application database, then
+exits.
+
+Run real PostgreSQL integration coverage only against a dedicated database:
+
+```bash
+JOBS_TEST_DATABASE_URL=postgresql://localhost/starter_test \
+  pnpm test:jobs:integration
+```
+
+The runner rejects database names without an `e2e` or `test` segment. It covers
+migration, queue/app deduplication, retry and terminal failure, two Worker
+replicas, scope concurrency, cancellation races, stale continuations, and the
+provider-accepted-before-crash recovery path.

--- a/docs/deployment-zeabur.md
+++ b/docs/deployment-zeabur.md
@@ -1,7 +1,7 @@
 # Zeabur deployment
 
 This repository's production reference deployment uses a Git-backed Zeabur
-service and PostgreSQL.
+Web service, Worker service, and PostgreSQL.
 
 > **Save 10% on a Zeabur server:** Purchase a server at
 > [Zeabur](https://zeabur.com/) and enter referral code `visoar` at checkout.
@@ -87,6 +87,33 @@ uses a different supported header.
 Migrations are a release step, not an application startup hook. This prevents
 multiple replicas from racing on schema changes. The Web service must start
 only after the migration command succeeds.
+
+## Durable Worker service
+
+Create a second Zeabur service from the same repository, release, and
+`docker/Dockerfile` as the Web service. Override only its start command:
+
+```text
+node dist/worker/worker.mjs
+```
+
+Do not wrap the command in `pnpm`; Node must receive SIGTERM directly. Configure
+the Worker with `DATABASE_URL`, optional `JOB_DATABASE_URL`,
+`JOB_DB_POOL_SIZE`, and the credentials required by its handlers. Set the
+platform stop window above `WORKER_GRACEFUL_TIMEOUT_MS` (30 seconds by default).
+The Worker is a required always-on service whenever durable tasks are enabled,
+but its health is intentionally independent from Web readiness.
+
+Run `pnpm db:migrate` before starting either service. It applies committed
+Drizzle migrations, installs/upgrades the separate `pgboss` schema, and creates
+the declared workload queues. Web and Worker runtime connections disable schema
+migration, so their database roles do not need DDL permission. Drizzle is
+restricted to the `public` schema and does not manage pg-boss objects.
+
+For connection capacity, budget the application pool plus the pg-boss pool for
+every replica. A Worker with `DB_POOL_SIZE=5` and `JOB_DB_POOL_SIZE=3` consumes
+up to eight connections. A Web replica uses its application pool and opens its
+small pg-boss pool only after enqueueing work.
 
 ## Runtime probes
 

--- a/e2e/background-tasks.spec.ts
+++ b/e2e/background-tasks.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import { loginAs } from "./helpers/auth";
+
+test("creates, polls, deduplicates, authorizes, and cancels a background task", async ({
+  browser,
+  page,
+}) => {
+  await loginAs(page, "user");
+
+  const idempotencyKey = `playwright-${Date.now()}`;
+  const createResponse = await page.request.post("/api/tasks/example", {
+    data: { message: "durable work", idempotencyKey },
+  });
+  expect(createResponse.status()).toBe(202);
+  const created = await createResponse.json();
+  expect(created.task).toMatchObject({
+    kind: "example.process",
+    status: "queued",
+    scopeKey: "user:e2e-user",
+    idempotencyKey,
+  });
+
+  const duplicateResponse = await page.request.post("/api/tasks/example", {
+    data: { message: "durable work", idempotencyKey },
+  });
+  expect(duplicateResponse.status()).toBe(200);
+  expect((await duplicateResponse.json()).task.id).toBe(created.task.id);
+
+  const pollResponse = await page.request.get(`/api/tasks/${created.task.id}`);
+  expect(pollResponse.status()).toBe(200);
+  expect((await pollResponse.json()).task.id).toBe(created.task.id);
+
+  const foreignContext = await browser.newContext();
+  const foreignPage = await foreignContext.newPage();
+  await loginAs(foreignPage, "admin");
+  const foreignResponse = await foreignPage.request.get(
+    `/api/tasks/${created.task.id}`,
+  );
+  expect(foreignResponse.status()).toBe(404);
+  await foreignContext.close();
+
+  const cancelResponse = await page.request.post(
+    `/api/tasks/${created.task.id}/cancel`,
+  );
+  expect(cancelResponse.status()).toBe(200);
+  expect((await cancelResponse.json()).task.status).toBe("cancelled");
+
+  const cancelledPoll = await page.request.get(`/api/tasks/${created.task.id}`);
+  expect((await cancelledPoll.json()).task.status).toBe("cancelled");
+});

--- a/e2e/database-fixtures.ts
+++ b/e2e/database-fixtures.ts
@@ -1,6 +1,7 @@
 import postgres from "postgres";
 
 const E2E_USER_ID_PATTERN = "e2e-%";
+const E2E_TASK_SCOPE_PATTERN = "user:e2e-%";
 const E2E_CLIENT_NAME = "Playwright CLI";
 const MACHINE_AUTH_RATE_LIMIT_SCOPES = [
   "device_code",
@@ -17,6 +18,14 @@ export async function cleanupE2EFixtures(): Promise<void> {
   const sql = postgres(databaseUrl, { max: 1 });
   try {
     await sql.begin(async (transaction) => {
+      await transaction`
+        delete from pgboss.job
+        where group_id like ${E2E_TASK_SCOPE_PATTERN}
+      `;
+      await transaction`
+        delete from task_runs
+        where "scopeKey" like ${E2E_TASK_SCOPE_PATTERN}
+      `;
       await transaction`
         delete from device_codes
         where "clientName" = ${E2E_CLIENT_NAME}

--- a/env.js
+++ b/env.js
@@ -55,12 +55,19 @@ const env = createEnv({
   server: {
     // Database URL
     DATABASE_URL: databaseUrlSchema,
+    JOB_DATABASE_URL: databaseUrlSchema.optional(),
 
     // Database connection pool settings
     DB_POOL_SIZE: z.coerce.number().int().positive().default(20),
     DB_IDLE_TIMEOUT: z.coerce.number().int().nonnegative().default(300),
     DB_MAX_LIFETIME: z.coerce.number().int().nonnegative().default(14400),
     DB_CONNECT_TIMEOUT: z.coerce.number().int().positive().max(4).default(4),
+    JOB_DB_POOL_SIZE: z.coerce.number().int().positive().max(20).default(3),
+    WORKER_GRACEFUL_TIMEOUT_MS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(30000),
     RATE_LIMIT_IP_HEADER: z
       .enum([
         "cf-connecting-ip",
@@ -188,12 +195,15 @@ const env = createEnv({
   runtimeEnv: {
     // Database URL
     DATABASE_URL: process.env.DATABASE_URL,
+    JOB_DATABASE_URL: process.env.JOB_DATABASE_URL,
 
     // Database connection pool settings
     DB_POOL_SIZE: process.env.DB_POOL_SIZE,
     DB_IDLE_TIMEOUT: process.env.DB_IDLE_TIMEOUT,
     DB_MAX_LIFETIME: process.env.DB_MAX_LIFETIME,
     DB_CONNECT_TIMEOUT: process.env.DB_CONNECT_TIMEOUT,
+    JOB_DB_POOL_SIZE: process.env.JOB_DB_POOL_SIZE,
+    WORKER_GRACEFUL_TIMEOUT_MS: process.env.WORKER_GRACEFUL_TIMEOUT_MS,
     RATE_LIMIT_IP_HEADER: process.env.RATE_LIMIT_IP_HEADER,
     BING_SITE_VERIFICATION: process.env.BING_SITE_VERIFICATION,
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,7 +15,11 @@ const eslintConfig = defineConfig([
     },
   },
   {
-    files: ["jest.config.js", "jest.global-setup.js"],
+    files: [
+      "jest.config.js",
+      "jest.global-setup.js",
+      "jest.jobs-integration.config.js",
+    ],
     rules: {
       "@typescript-eslint/no-require-imports": "off",
     },
@@ -33,6 +37,7 @@ const eslintConfig = defineConfig([
     ".next/**",
     "out/**",
     "build/**",
+    "dist/**",
     "coverage/**",
     "playwright-report/**",
     "test-results/**",

--- a/integration/jobs/background-jobs.test.ts
+++ b/integration/jobs/background-jobs.test.ts
@@ -1,0 +1,344 @@
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import { eq } from "drizzle-orm";
+import { PgBoss } from "pg-boss";
+import { z } from "zod";
+import { createDatabaseClient } from "@/database/client";
+import { taskRuns } from "@/database/schema";
+import { defineJob } from "@/lib/jobs/definition";
+import { JobQueue } from "@/lib/jobs/queue";
+import { ensureProviderJobSubmitted } from "@/lib/tasks/provider-submission";
+import {
+  cancelTaskRun,
+  createTaskRun,
+  getTaskRun,
+  transitionTaskRun,
+} from "@/lib/tasks/repository";
+import {
+  createBackgroundTask,
+  enqueueBackgroundTaskContinuation,
+} from "@/lib/tasks/service";
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) throw new Error("DATABASE_URL is required.");
+
+const queueName = "integration.background-jobs";
+const scopePrefix = `user:jobs-integration-${process.pid}`;
+const calls = new Map<string, number>();
+const activeByScope = new Map<string, number>();
+const maxActiveByScope = new Map<string, number>();
+let totalActive = 0;
+let maxTotalActive = 0;
+
+const integrationJob = defineJob(
+  queueName,
+  z.discriminatedUnion("mode", [
+    z.object({ mode: z.literal("success"), delayMs: z.number().int().min(0) }),
+    z.object({ mode: z.literal("retry"), failures: z.number().int().min(0) }),
+    z.object({ mode: z.literal("fail") }),
+    z.object({
+      mode: z.literal("defer"),
+      step: z.enum(["submit", "poll"]),
+    }),
+  ]),
+  async (payload, context) => {
+    calls.set(context.taskRunId, (calls.get(context.taskRunId) ?? 0) + 1);
+
+    if (payload.mode === "retry" && context.attempt <= payload.failures) {
+      throw new Error(`retry attempt ${context.attempt}`);
+    }
+    if (payload.mode === "fail") {
+      throw new Error("permanent test failure after retries");
+    }
+    if (payload.mode === "defer" && payload.step === "submit") {
+      await context.scheduleContinuation(
+        { mode: "defer", step: "poll" },
+        new Date(Date.now() + 500),
+      );
+      return { deferred: true };
+    }
+    if (payload.mode === "success" && payload.delayMs > 0) {
+      const scopeActive = (activeByScope.get(context.scopeKey) ?? 0) + 1;
+      activeByScope.set(context.scopeKey, scopeActive);
+      maxActiveByScope.set(
+        context.scopeKey,
+        Math.max(maxActiveByScope.get(context.scopeKey) ?? 0, scopeActive),
+      );
+      totalActive += 1;
+      maxTotalActive = Math.max(maxTotalActive, totalActive);
+      await new Promise((resolve) => setTimeout(resolve, payload.delayMs));
+      activeByScope.set(context.scopeKey, scopeActive - 1);
+      totalActive -= 1;
+    }
+
+    return { attempt: context.attempt };
+  },
+  {
+    queue: {
+      retryLimit: 1,
+      retryDelay: 0,
+      retryBackoff: false,
+      expireInSeconds: 30,
+    },
+    localConcurrency: 4,
+    groupConcurrency: 1,
+  },
+);
+
+const database = createDatabaseClient({
+  url: databaseUrl,
+  max: 8,
+  connectTimeout: 4,
+});
+const queueConfig = { connectionString: databaseUrl, poolSize: 3 };
+const workerA = new JobQueue(queueConfig, { supervise: true });
+const workerB = new JobQueue(queueConfig, { supervise: true });
+
+async function waitForTask(
+  taskRunId: string,
+  statuses: readonly string[],
+  timeoutMs = 15_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const taskRun = await getTaskRun(database.db, taskRunId);
+    if (taskRun && statuses.includes(taskRun.status)) return taskRun;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(
+    `Task ${taskRunId} did not reach ${statuses.join("/")} within ${timeoutMs}ms.`,
+  );
+}
+
+async function createTask(
+  scopeKey: string,
+  payload: z.infer<typeof integrationJob.schema>,
+  idempotencyKey?: string,
+) {
+  return createBackgroundTask({
+    db: database.db,
+    queue: workerA,
+    definition: integrationJob,
+    scopeKey,
+    payload,
+    idempotencyKey,
+  });
+}
+
+beforeAll(async () => {
+  const migrationBoss = new PgBoss({
+    connectionString: databaseUrl,
+    schema: "pgboss",
+    max: 2,
+    migrate: false,
+    createSchema: false,
+    supervise: false,
+    schedule: false,
+  });
+  await migrationBoss.start();
+  if (await migrationBoss.getQueue(queueName)) {
+    await migrationBoss.deleteAllJobs(queueName);
+    await migrationBoss.deleteQueue(queueName);
+  }
+  await migrationBoss.createQueue(queueName, {
+    policy: "singleton",
+    ...integrationJob.queue,
+  });
+  await migrationBoss.updateQueue(queueName, integrationJob.queue);
+  expect(await migrationBoss.schemaVersion()).toBeGreaterThan(0);
+  await migrationBoss.stop({ close: true });
+
+  await database.db
+    .delete(taskRuns)
+    .where(eq(taskRuns.kind, integrationJob.name));
+  await Promise.all([
+    workerA.registerWorker(database.db, integrationJob),
+    workerB.registerWorker(database.db, integrationJob),
+  ]);
+}, 30_000);
+
+afterAll(async () => {
+  await Promise.all([workerA.stop(10_000), workerB.stop(10_000)]);
+  await database.db
+    .delete(taskRuns)
+    .where(eq(taskRuns.kind, integrationJob.name));
+  await database.close();
+}, 30_000);
+
+describe("background jobs with PostgreSQL", () => {
+  it("deduplicates task creation in the application and queue layers", async () => {
+    const scopeKey = `${scopePrefix}:dedup`;
+    const [first, second] = await Promise.all([
+      createTask(scopeKey, { mode: "success", delayMs: 100 }, "same-request"),
+      createTask(scopeKey, { mode: "success", delayMs: 100 }, "same-request"),
+    ]);
+
+    expect(first.taskRun.id).toBe(second.taskRun.id);
+    expect([first.created, second.created].sort()).toEqual([false, true]);
+    await waitForTask(first.taskRun.id, ["completed"]);
+    expect(calls.get(first.taskRun.id)).toBe(1);
+  });
+
+  it("retries and exposes the final failed product state", async () => {
+    const retried = await createTask(`${scopePrefix}:retry`, {
+      mode: "retry",
+      failures: 1,
+    });
+    const completed = await waitForTask(retried.taskRun.id, ["completed"]);
+    expect(completed.result).toEqual({ attempt: 2 });
+    expect(calls.get(retried.taskRun.id)).toBe(2);
+
+    const failed = await createTask(`${scopePrefix}:failed`, { mode: "fail" });
+    const terminal = await waitForTask(failed.taskRun.id, ["failed"]);
+    expect(terminal.error).toMatchObject({
+      code: "JOB_HANDLER_FAILED",
+      retryable: false,
+      attempt: 2,
+    });
+    expect(calls.get(failed.taskRun.id)).toBe(2);
+  });
+
+  it("enforces group concurrency globally while allowing other scopes", async () => {
+    maxTotalActive = 0;
+    const scopeA = `${scopePrefix}:group-a`;
+    const scopeB = `${scopePrefix}:group-b`;
+    const tasks = await Promise.all([
+      createTask(scopeA, { mode: "success", delayMs: 250 }),
+      createTask(scopeA, { mode: "success", delayMs: 250 }),
+      createTask(scopeB, { mode: "success", delayMs: 250 }),
+    ]);
+
+    await Promise.all(
+      tasks.map(({ taskRun }) => waitForTask(taskRun.id, ["completed"])),
+    );
+    expect(maxActiveByScope.get(scopeA)).toBe(1);
+    expect(maxActiveByScope.get(scopeB)).toBe(1);
+    expect(maxTotalActive).toBeGreaterThanOrEqual(2);
+  });
+
+  it("uses guarded transitions for cancel/complete and stale continuations", async () => {
+    const { taskRun } = await createTaskRun(database.db, {
+      kind: integrationJob.name,
+      scopeKey: `${scopePrefix}:race`,
+      input: { mode: "success", delayMs: 0 },
+    });
+    await transitionTaskRun(database.db, {
+      taskRunId: taskRun.id,
+      from: ["queued"],
+      to: "running",
+      patch: { startedAt: new Date() },
+    });
+
+    const [cancelled, completed] = await Promise.all([
+      cancelTaskRun(database.db, taskRun.id),
+      transitionTaskRun(database.db, {
+        taskRunId: taskRun.id,
+        from: ["running"],
+        to: "completed",
+        patch: { completedAt: new Date() },
+      }),
+    ]);
+    expect([cancelled, completed].filter(Boolean)).toHaveLength(1);
+
+    const terminal = await getTaskRun(database.db, taskRun.id);
+    expect(["cancelled", "completed"]).toContain(terminal?.status);
+    expect(
+      await transitionTaskRun(database.db, {
+        taskRunId: taskRun.id,
+        from: ["waiting"],
+        to: "queued",
+      }),
+    ).toBeNull();
+  });
+
+  it("releases the Worker while a delayed provider poll is waiting", async () => {
+    const scopeKey = `${scopePrefix}:continuation`;
+    const deferred = await createTask(scopeKey, {
+      mode: "defer",
+      step: "submit",
+    });
+    await waitForTask(deferred.taskRun.id, ["waiting"]);
+
+    const otherTask = await createTask(scopeKey, {
+      mode: "success",
+      delayMs: 0,
+    });
+    await waitForTask(otherTask.taskRun.id, ["completed"]);
+    const completed = await waitForTask(deferred.taskRun.id, ["completed"]);
+
+    expect(completed.result).toEqual({ attempt: 1 });
+    expect(calls.get(deferred.taskRun.id)).toBe(2);
+  });
+
+  it("treats a provider webhook arriving after cancellation as a no-op", async () => {
+    const scopeKey = `${scopePrefix}:cancelled-webhook`;
+    const { taskRun } = await createTaskRun(database.db, {
+      kind: integrationJob.name,
+      scopeKey,
+      input: { mode: "defer", step: "poll" },
+    });
+    await transitionTaskRun(database.db, {
+      taskRunId: taskRun.id,
+      from: ["queued"],
+      to: "running",
+      patch: { startedAt: new Date() },
+    });
+    await transitionTaskRun(database.db, {
+      taskRunId: taskRun.id,
+      from: ["running"],
+      to: "waiting",
+    });
+    await cancelTaskRun(database.db, taskRun.id);
+
+    expect(
+      await enqueueBackgroundTaskContinuation({
+        db: database.db,
+        queue: workerA,
+        definition: integrationJob,
+        taskRunId: taskRun.id,
+        scopeKey,
+        payload: { mode: "defer", step: "poll" },
+        continuationJobId: "22222222-2222-4222-8222-222222222222",
+      }),
+    ).toBe(false);
+    expect((await getTaskRun(database.db, taskRun.id))?.status).toBe(
+      "cancelled",
+    );
+  });
+
+  it("recovers a provider submission after a crash with provider idempotency", async () => {
+    const { taskRun } = await createTaskRun(database.db, {
+      kind: integrationJob.name,
+      scopeKey: `${scopePrefix}:provider`,
+      input: {},
+    });
+    await transitionTaskRun(database.db, {
+      taskRunId: taskRun.id,
+      from: ["queued"],
+      to: "running",
+      patch: { startedAt: new Date() },
+    });
+
+    const providerJobs = new Map<string, string>();
+    await expect(
+      ensureProviderJobSubmitted({
+        db: database.db,
+        taskRunId: taskRun.id,
+        submit: async ({ idempotencyKey }) => {
+          providerJobs.set(idempotencyKey, "provider-job-1");
+          throw new Error("worker crashed before persistence");
+        },
+      }),
+    ).rejects.toThrow("worker crashed");
+
+    const providerJobId = await ensureProviderJobSubmitted({
+      db: database.db,
+      taskRunId: taskRun.id,
+      submit: async ({ idempotencyKey }) =>
+        providerJobs.get(idempotencyKey) ?? "unexpected-duplicate",
+    });
+    expect(providerJobId).toBe("provider-job-1");
+    expect((await getTaskRun(database.db, taskRun.id))?.providerJobId).toBe(
+      "provider-job-1",
+    );
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,7 @@ const customJestConfig = {
     "<rootDir>/node_modules/",
     "<rootDir>/.next/",
     "<rootDir>/e2e/",
+    "<rootDir>/integration/",
   ],
   modulePathIgnorePatterns: ["<rootDir>/.next/"],
 };

--- a/jest.jobs-integration.config.js
+++ b/jest.jobs-integration.config.js
@@ -1,0 +1,14 @@
+const nextJest = require("next/jest");
+
+const createJestConfig = nextJest({ dir: "./" });
+
+module.exports = createJestConfig({
+  testEnvironment: "node",
+  testMatch: ["<rootDir>/integration/jobs/**/*.test.ts"],
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
+  maxWorkers: 1,
+  testTimeout: 30000,
+  modulePathIgnorePatterns: ["<rootDir>/.next/"],
+});

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -784,6 +784,13 @@ const mockIsNull = jest.fn().mockImplementation(
     type: "isNull",
   }),
 );
+const mockInArray = jest
+  .fn()
+  .mockImplementation((column: unknown, values: unknown[]) => ({
+    type: "inArray",
+    column,
+    values,
+  }));
 const mockDrizzleSql = jest
   .fn()
   .mockImplementation(
@@ -800,12 +807,14 @@ jest.mock("drizzle-orm", () => ({
   and: mockAnd,
   gte: mockGte,
   isNull: mockIsNull,
+  inArray: mockInArray,
   sql: mockDrizzleSql,
 }));
 
 // Type-safe environment configuration mock
 type MockEnvironment = {
   DATABASE_URL: string;
+  JOB_DATABASE_URL?: string;
   BETTER_AUTH_SECRET: string;
   NEXT_PUBLIC_APP_URL: string;
   RESEND_API_KEY: string;
@@ -823,6 +832,8 @@ type MockEnvironment = {
   DB_IDLE_TIMEOUT: number;
   DB_MAX_LIFETIME: number;
   DB_CONNECT_TIMEOUT: number;
+  JOB_DB_POOL_SIZE: number;
+  WORKER_GRACEFUL_TIMEOUT_MS: number;
   RATE_LIMIT_IP_HEADER: string;
   UPLOAD_CLEANUP_SECRET: string;
   UPLOAD_DAILY_QUOTA_BYTES: number;
@@ -850,6 +861,8 @@ const mockEnvConfig: MockEnvironment = {
   DB_IDLE_TIMEOUT: 300,
   DB_MAX_LIFETIME: 14400,
   DB_CONNECT_TIMEOUT: 4,
+  JOB_DB_POOL_SIZE: 3,
+  WORKER_GRACEFUL_TIMEOUT_MS: 30000,
   RATE_LIMIT_IP_HEADER: "x-forwarded-for",
   UPLOAD_CLEANUP_SECRET: "mock-upload-cleanup-secret-at-least-32-chars",
   UPLOAD_DAILY_QUOTA_BYTES: 1024 * 1024 * 1024,
@@ -1050,6 +1063,8 @@ jest.mock("./env.js", () => ({
     DB_IDLE_TIMEOUT: 300,
     DB_MAX_LIFETIME: 14400,
     DB_CONNECT_TIMEOUT: 4,
+    JOB_DB_POOL_SIZE: 3,
+    WORKER_GRACEFUL_TIMEOUT_MS: 30000,
     RATE_LIMIT_IP_HEADER: "x-forwarded-for",
     UPLOAD_CLEANUP_SECRET: "mock-upload-cleanup-secret-at-least-32-chars",
     UPLOAD_DAILY_QUOTA_BYTES: 1024 * 1024 * 1024,

--- a/knip.json
+++ b/knip.json
@@ -13,5 +13,8 @@
   },
   "ignoreIssues": {
     "src/database/tables.ts": ["exports"]
+  },
+  "jest": {
+    "config": ["jest.config.js", "jest.jobs-integration.config.js"]
   }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -76,6 +76,10 @@ const nextConfig: NextConfig = {
     // Transitive ESM-only deps of `ai` that Jest must transform too.
     "@ai-sdk/gateway",
     "@workflow/serde",
+    "pg-boss",
+    "serialize-error",
+    "non-error",
+    "cron-parser",
     "@shadcn/helpers",
     "@shadcn/react",
   ],

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "engines": {
-    "node": ">=22"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "content:build": "node scripts/build-content-collections.mjs",
     "dev": "next dev",
-    "build": "next build && node scripts/prepare-standalone.mjs",
+    "build": "next build && pnpm build:worker && node scripts/prepare-standalone.mjs",
+    "build:worker": "node scripts/build-worker.mjs",
     "start": "node .next/standalone/server.js",
     "saas-cli": "node --import tsx packages/cli/src/index.ts",
     "lint": "eslint .",
@@ -21,7 +22,8 @@
     "test:e2e": "node --env-file-if-exists=.env --import tsx scripts/run-e2e.ts",
     "test:e2e:headed": "node --env-file-if-exists=.env --import tsx scripts/run-e2e.ts --headed",
     "db:generate": "drizzle-kit generate --config=src/database/config.ts",
-    "db:migrate": "drizzle-kit migrate --config=src/database/config.ts",
+    "db:migrate": "node --env-file-if-exists=.env --import tsx scripts/migrate.ts",
+    "db:migrate:app": "drizzle-kit migrate --config=src/database/config.ts",
     "db:push": "drizzle-kit push --config=src/database/config.ts",
     "db:rebaseline": "node --env-file-if-exists=.env --import tsx scripts/rebaseline-drizzle.ts",
     "prettier:check": "prettier --check --ignore-path .gitignore .",
@@ -29,7 +31,12 @@
     "analyze": "ANALYZE=true next build --webpack",
     "analyze:dev": "ANALYZE=true next dev --webpack",
     "set:admin": "node --env-file-if-exists=.env --import tsx scripts/set-admin.ts",
-    "stripe:sync-products": "node --env-file-if-exists=.env --import tsx scripts/sync-stripe-products.ts"
+    "stripe:sync-products": "node --env-file-if-exists=.env --import tsx scripts/sync-stripe-products.ts",
+    "worker:dev": "node --env-file-if-exists=.env --import tsx scripts/worker.ts",
+    "worker:start": "node dist/worker/worker.mjs",
+    "worker:smoke": "node scripts/worker-smoke.mjs",
+    "worker:shutdown-smoke": "node scripts/worker-shutdown-smoke.mjs",
+    "test:jobs:integration": "node --env-file-if-exists=.env --import tsx scripts/run-jobs-integration.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^4.0.46",
@@ -53,6 +60,8 @@
     "next-themes": "^0.4.6",
     "nextjs-toploader": "^3.9.17",
     "nuqs": "^2.8.9",
+    "pg": "^8.23.0",
+    "pg-boss": "12.27.0",
     "postgres": "^3.4.9",
     "radix-ui": "^1.6.7",
     "react": "^19.2.6",
@@ -85,9 +94,11 @@
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.20.1",
+    "@types/pg": "^8.23.1",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "drizzle-kit": "^0.31.10",
+    "esbuild": "0.25.12",
     "eslint": "^10.4.0",
     "eslint-config-next": "^16.3.0",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         version: 7.0.77(zod@4.4.3)
       better-auth:
         specifier: ^1.6.25
-        version: 1.6.25(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.29.4)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)))(mongodb@7.1.0(socks@2.8.9))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 1.6.25(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.23.1)(kysely@0.29.4)(mysql2@3.15.3)(pg@8.23.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)))(mongodb@7.1.0(socks@2.8.9))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.23.0)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -79,7 +79,7 @@ importers:
         version: 2.1.1
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.29.4)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))
+        version: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.23.1)(kysely@0.29.4)(mysql2@3.15.3)(pg@8.23.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.6)
@@ -104,6 +104,12 @@ importers:
       nuqs:
         specifier: ^2.8.9
         version: 2.8.9(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      pg:
+        specifier: ^8.23.0
+        version: 8.23.0
+      pg-boss:
+        specifier: 12.27.0
+        version: 12.27.0
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
@@ -195,6 +201,9 @@ importers:
       "@types/node":
         specifier: ^22.20.1
         version: 22.20.1
+      "@types/pg":
+        specifier: ^8.23.1
+        version: 8.23.1
       "@types/react":
         specifier: ^19.2.15
         version: 19.2.15
@@ -204,6 +213,9 @@ importers:
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
+      esbuild:
+        specifier: 0.25.12
+        version: 0.25.12
       eslint:
         specifier: ^10.4.0
         version: 10.4.0(jiti@2.7.0)
@@ -4464,6 +4476,12 @@ packages:
         integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==,
       }
 
+  "@types/pg@8.23.1":
+    resolution:
+      {
+        integrity: sha512-fKVHpikPdg4GKks3JuLEhvwSyvwzF23hnabPy6DD8ljVbC7+6J5dQzdv4arV6jqq57djnMgs1HKBxX4P8aBI3A==,
+      }
+
   "@types/react-dom@19.2.3":
     resolution:
       {
@@ -5745,6 +5763,13 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  cron-parser@5.10.0:
+    resolution:
+      {
+        integrity: sha512-izNAxJyRWUP8ljBoDSub5WyrVOUlT4SLGShswE7eoRBpp6QUsSycYxLBMJlbshgPBMcPT/nrfgjNY2918ayv2A==,
+      }
+    engines: { node: ">=18" }
 
   cross-spawn@7.0.6:
     resolution:
@@ -8648,6 +8673,13 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  luxon@3.7.2:
+    resolution:
+      {
+        integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==,
+      }
+    engines: { node: ">=12" }
+
   lz-string@1.5.0:
     resolution:
       {
@@ -9307,6 +9339,13 @@ packages:
       }
     engines: { node: ">=18" }
 
+  non-error@0.1.0:
+    resolution:
+      {
+        integrity: sha512-TMB1uHiGsHRGv1uYclfhivcnf0/PdFp2pNqRxXjncaAsjYMoisaQJI+SSZCqRq+VliwRTC8tsMQfmrWjDMhkPQ==,
+      }
+    engines: { node: ">=20" }
+
   normalize-path@3.0.0:
     resolution:
       {
@@ -9731,6 +9770,72 @@ packages:
         integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==,
       }
 
+  pg-boss@12.27.0:
+    resolution:
+      {
+        integrity: sha512-DawcUffyDVJvxGYvaoc7B+G1yY86dJtvugVYMAt+CtO6Lg+RSyQuAU7IRfNyhqi0Bo/JeaxLqhqIy5+twpmYlg==,
+      }
+    engines: { node: ">=22.12.0" }
+    hasBin: true
+
+  pg-cloudflare@1.4.0:
+    resolution:
+      {
+        integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==,
+      }
+
+  pg-connection-string@2.14.0:
+    resolution:
+      {
+        integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==,
+      }
+
+  pg-int8@1.0.1:
+    resolution:
+      {
+        integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==,
+      }
+    engines: { node: ">=4.0.0" }
+
+  pg-pool@3.14.0:
+    resolution:
+      {
+        integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==,
+      }
+    peerDependencies:
+      pg: ">=8.0"
+
+  pg-protocol@1.16.0:
+    resolution:
+      {
+        integrity: sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==,
+      }
+
+  pg-types@2.2.0:
+    resolution:
+      {
+        integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==,
+      }
+    engines: { node: ">=4" }
+
+  pg@8.23.0:
+    resolution:
+      {
+        integrity: sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==,
+      }
+    engines: { node: ">= 16.0.0" }
+    peerDependencies:
+      pg-native: ">=3.0.1"
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution:
+      {
+        integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==,
+      }
+
   picocolors@1.1.1:
     resolution:
       {
@@ -9868,6 +9973,34 @@ packages:
         integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==,
       }
     engines: { node: ^10 || ^12 || >=14 }
+
+  postgres-array@2.0.0:
+    resolution:
+      {
+        integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==,
+      }
+    engines: { node: ">=4" }
+
+  postgres-bytea@1.0.1:
+    resolution:
+      {
+        integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  postgres-date@1.0.7:
+    resolution:
+      {
+        integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  postgres-interval@1.2.0:
+    resolution:
+      {
+        integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   postgres@3.4.7:
     resolution:
@@ -10554,6 +10687,13 @@ packages:
         integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==,
       }
 
+  serialize-error@13.0.1:
+    resolution:
+      {
+        integrity: sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA==,
+      }
+    engines: { node: ">=20" }
+
   serialize-javascript@7.0.5:
     resolution:
       {
@@ -10789,6 +10929,13 @@ packages:
       {
         integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==,
       }
+
+  split2@4.2.0:
+    resolution:
+      {
+        integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==,
+      }
+    engines: { node: ">= 10.x" }
 
   sprintf-js@1.0.3:
     resolution:
@@ -11801,6 +11948,13 @@ packages:
         integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==,
       }
 
+  xtend@4.0.2:
+    resolution:
+      {
+        integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==,
+      }
+    engines: { node: ">=0.4" }
+
   y18n@5.0.8:
     resolution:
       {
@@ -12540,12 +12694,12 @@ snapshots:
     optionalDependencies:
       "@opentelemetry/api": 1.9.0
 
-  "@better-auth/drizzle-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.1))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.29.4)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)))":
+  "@better-auth/drizzle-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.1))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.23.1)(kysely@0.29.4)(mysql2@3.15.3)(pg@8.23.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)))":
     dependencies:
       "@better-auth/core": 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.1)
       "@better-auth/utils": 0.4.2
     optionalDependencies:
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.29.4)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.23.1)(kysely@0.29.4)(mysql2@3.15.3)(pg@8.23.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))
 
   "@better-auth/kysely-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.1))(@better-auth/utils@0.4.2)(kysely@0.29.4)":
     dependencies:
@@ -14782,6 +14936,12 @@ snapshots:
   "@types/parse-json@4.0.2":
     optional: true
 
+  "@types/pg@8.23.1":
+    dependencies:
+      "@types/node": 22.20.1
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
+
   "@types/react-dom@19.2.3(@types/react@19.2.15)":
     dependencies:
       "@types/react": 19.2.15
@@ -15243,10 +15403,10 @@ snapshots:
 
   baseline-browser-mapping@2.11.1: {}
 
-  better-auth@1.6.25(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.29.4)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)))(mongodb@7.1.0(socks@2.8.9))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  better-auth@1.6.25(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.23.1)(kysely@0.29.4)(mysql2@3.15.3)(pg@8.23.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)))(mongodb@7.1.0(socks@2.8.9))(mysql2@3.15.3)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.23.0)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       "@better-auth/core": 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.1)
-      "@better-auth/drizzle-adapter": 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.1))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.29.4)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)))
+      "@better-auth/drizzle-adapter": 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.1))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.23.1)(kysely@0.29.4)(mysql2@3.15.3)(pg@8.23.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)))
       "@better-auth/kysely-adapter": 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.1))(@better-auth/utils@0.4.2)(kysely@0.29.4)
       "@better-auth/memory-adapter": 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.1))(@better-auth/utils@0.4.2)
       "@better-auth/mongo-adapter": 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.1))(@better-auth/utils@0.4.2)(mongodb@7.1.0(socks@2.8.9))
@@ -15265,10 +15425,11 @@ snapshots:
     optionalDependencies:
       "@prisma/client": 7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3)
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.29.4)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.23.1)(kysely@0.29.4)(mysql2@3.15.3)(pg@8.23.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))
       mongodb: 7.1.0(socks@2.8.9)
       mysql2: 3.15.3
       next: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      pg: 8.23.0
       prisma: 7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -15543,6 +15704,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  cron-parser@5.10.0:
+    dependencies:
+      luxon: 3.7.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -15760,13 +15925,15 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.22.3
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(kysely@0.29.4)(mysql2@3.15.3)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.23.1)(kysely@0.29.4)(mysql2@3.15.3)(pg@8.23.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)):
     optionalDependencies:
       "@electric-sql/pglite": 0.3.15
       "@opentelemetry/api": 1.9.0
       "@prisma/client": 7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3)
+      "@types/pg": 8.23.1
       kysely: 0.29.4
       mysql2: 3.15.3
+      pg: 8.23.0
       postgres: 3.4.9
       prisma: 7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
 
@@ -17544,6 +17711,8 @@ snapshots:
     dependencies:
       react: 19.2.6
 
+  luxon@3.7.2: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -18094,6 +18263,8 @@ snapshots:
 
   node-releases@2.0.46: {}
 
+  non-error@0.1.0: {}
+
   normalize-path@3.0.0: {}
 
   npm-run-path@4.0.1:
@@ -18384,6 +18555,49 @@ snapshots:
   perfect-debounce@1.0.0:
     optional: true
 
+  pg-boss@12.27.0:
+    dependencies:
+      cron-parser: 5.10.0
+      pg: 8.23.0
+      serialize-error: 13.0.1
+    transitivePeerDependencies:
+      - pg-native
+
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
+
+  pg-protocol@1.16.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.23.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.23.0)
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -18446,6 +18660,16 @@ snapshots:
       nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   postgres@3.4.7:
     optional: true
@@ -18958,6 +19182,11 @@ snapshots:
   seq-queue@0.0.5:
     optional: true
 
+  serialize-error@13.0.1:
+    dependencies:
+      non-error: 0.1.0
+      type-fest: 5.8.0
+
   serialize-javascript@7.0.5: {}
 
   serve-static@2.2.1:
@@ -19184,6 +19413,8 @@ snapshots:
     dependencies:
       memory-pager: 1.5.0
     optional: true
+
+  split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
 
@@ -19832,6 +20063,8 @@ snapshots:
   xml-naming@0.3.0: {}
 
   xmlchars@2.2.0: {}
+
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 

--- a/scripts/build-worker.mjs
+++ b/scripts/build-worker.mjs
@@ -1,0 +1,32 @@
+import { mkdir } from "node:fs/promises";
+import { build } from "esbuild";
+
+await mkdir("dist/worker", { recursive: true });
+
+await build({
+  entryPoints: ["scripts/worker.ts"],
+  outfile: "dist/worker/worker.mjs",
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  target: "node22.12",
+  sourcemap: true,
+  tsconfig: "tsconfig.json",
+  banner: {
+    js: 'import { createRequire as __createRequire } from "node:module"; const require = __createRequire(import.meta.url);',
+  },
+  plugins: [
+    {
+      name: "forbid-next-server-boundaries",
+      setup(buildContext) {
+        buildContext.onResolve({ filter: /^(server-only|next\/)/ }, (args) => ({
+          errors: [
+            {
+              text: `Worker dependency ${args.path} is tied to the Next.js runtime.`,
+            },
+          ],
+        }));
+      },
+    },
+  ],
+});

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,42 @@
+import { spawn } from "node:child_process";
+import { migrateJobQueue } from "@/lib/jobs/queue";
+import { loadWorkerEnv } from "@/lib/jobs/worker-env";
+
+function run(command: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: process.env,
+      stdio: "inherit",
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} failed (${signal ?? `exit ${code}`}).`,
+        ),
+      );
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  const workerEnv = loadWorkerEnv();
+  const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+  await run(pnpmCommand, ["db:migrate:app"]);
+  await migrateJobQueue({
+    connectionString: workerEnv.JOB_DATABASE_URL,
+    poolSize: workerEnv.JOB_DB_POOL_SIZE,
+  });
+
+  console.log("Application and pg-boss migrations are up to date.");
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/run-jobs-integration.ts
+++ b/scripts/run-jobs-integration.ts
@@ -1,0 +1,54 @@
+import { spawn } from "node:child_process";
+
+function run(command: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: {
+        ...process.env,
+        DATABASE_URL: process.env.DATABASE_URL,
+        JOB_DATABASE_URL: process.env.JOB_DATABASE_URL,
+      },
+      stdio: "inherit",
+    });
+    child.once("error", reject);
+    child.once("exit", (code) =>
+      code === 0
+        ? resolve()
+        : reject(new Error(`${command} failed with exit code ${code}.`)),
+    );
+  });
+}
+
+async function main(): Promise<void> {
+  const databaseUrl =
+    process.env.JOBS_TEST_DATABASE_URL ?? process.env.E2E_DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error(
+      "JOBS_TEST_DATABASE_URL or E2E_DATABASE_URL is required for job integration tests.",
+    );
+  }
+
+  const databaseName = new URL(databaseUrl).pathname.slice(1).toLowerCase();
+  if (!/(^|[_-])(e2e|test)([_-]|$)/.test(databaseName)) {
+    throw new Error(
+      "Job integration tests require a dedicated e2e/test database.",
+    );
+  }
+
+  process.env.DATABASE_URL = databaseUrl;
+  process.env.JOB_DATABASE_URL = databaseUrl;
+  const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+  await run(pnpmCommand, ["db:migrate"]);
+  await run(pnpmCommand, [
+    "exec",
+    "jest",
+    "--config",
+    "jest.jobs-integration.config.js",
+    "--runInBand",
+  ]);
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/worker-shutdown-smoke.mjs
+++ b/scripts/worker-shutdown-smoke.mjs
@@ -1,0 +1,53 @@
+import { spawn } from "node:child_process";
+
+const databaseUrl = process.env.JOBS_TEST_DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error("JOBS_TEST_DATABASE_URL is required.");
+}
+
+const child = spawn(process.execPath, ["dist/worker/worker.mjs"], {
+  env: {
+    ...process.env,
+    DATABASE_URL: databaseUrl,
+    JOB_DATABASE_URL: databaseUrl,
+    WORKER_GRACEFUL_TIMEOUT_MS: "5000",
+  },
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+let output = "";
+let ready = false;
+const timeout = setTimeout(() => {
+  child.kill("SIGKILL");
+}, 15_000);
+
+child.stdout.on("data", (chunk) => {
+  output += chunk.toString();
+  if (!ready && output.includes('"event":"worker_ready"')) {
+    ready = true;
+    child.kill("SIGTERM");
+  }
+});
+child.stderr.on("data", (chunk) => {
+  output += chunk.toString();
+});
+
+const result = await new Promise((resolve, reject) => {
+  child.once("error", reject);
+  child.once("exit", (code, signal) => resolve({ code, signal }));
+});
+clearTimeout(timeout);
+
+if (
+  !ready ||
+  result.code !== 0 ||
+  !output.includes('"event":"shutdown"') ||
+  result.signal
+) {
+  process.stderr.write(output);
+  throw new Error(
+    `Worker graceful shutdown smoke test failed (${result.signal ?? `exit ${result.code}`}).`,
+  );
+}
+
+console.log("Worker graceful shutdown smoke test passed.");

--- a/scripts/worker-smoke.mjs
+++ b/scripts/worker-smoke.mjs
@@ -1,0 +1,22 @@
+import { spawnSync } from "node:child_process";
+
+const result = spawnSync(process.execPath, ["dist/worker/worker.mjs"], {
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    DATABASE_URL: "postgresql://worker:worker@127.0.0.1/worker_smoke",
+    WORKER_SMOKE_TEST: "1",
+  },
+});
+
+if (result.status !== 0) {
+  process.stderr.write(result.stderr);
+  process.stdout.write(result.stdout);
+  process.exit(result.status ?? 1);
+}
+
+if (!result.stdout.includes("Worker artifact smoke test passed.")) {
+  throw new Error("Worker artifact did not report a successful smoke test.");
+}
+
+process.stdout.write(result.stdout);

--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -1,0 +1,86 @@
+import { createDatabaseClient } from "@/database/client";
+import { createAiModels } from "@/lib/ai/models.node";
+import { JobQueue } from "@/lib/jobs/queue";
+import { loadWorkerEnv } from "@/lib/jobs/worker-env";
+
+async function main(): Promise<void> {
+  const workerEnv = loadWorkerEnv();
+  const database = createDatabaseClient({
+    url: workerEnv.DATABASE_URL,
+    max: workerEnv.DB_POOL_SIZE,
+    idleTimeout: workerEnv.DB_IDLE_TIMEOUT,
+    maxLifetime: workerEnv.DB_MAX_LIFETIME,
+    connectTimeout: workerEnv.DB_CONNECT_TIMEOUT,
+  });
+
+  createAiModels({
+    apiKey: workerEnv.LLM_API_KEY,
+    baseUrl: workerEnv.LLM_BASE_URL,
+    defaultModel: workerEnv.AI_DEFAULT_MODEL,
+  });
+
+  if (process.env.WORKER_SMOKE_TEST === "1") {
+    await database.close();
+    console.log("Worker artifact smoke test passed.");
+    return;
+  }
+
+  const queue = new JobQueue(
+    {
+      connectionString: workerEnv.JOB_DATABASE_URL,
+      poolSize: workerEnv.JOB_DB_POOL_SIZE,
+    },
+    { supervise: true },
+  );
+
+  try {
+    await queue.registerWorkers(database.db);
+  } catch (error) {
+    await Promise.allSettled([
+      queue.stop(workerEnv.WORKER_GRACEFUL_TIMEOUT_MS),
+      database.close(),
+    ]);
+    throw error;
+  }
+
+  let shuttingDown = false;
+  const shutdown = async (signal: NodeJS.Signals) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(
+      JSON.stringify({ component: "job-worker", event: "shutdown", signal }),
+    );
+
+    try {
+      await queue.stop(workerEnv.WORKER_GRACEFUL_TIMEOUT_MS);
+      await database.close();
+      process.exitCode = 0;
+    } catch (error) {
+      console.error(
+        JSON.stringify({
+          component: "job-worker",
+          event: "shutdown_failed",
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      );
+      process.exitCode = 1;
+    }
+  };
+
+  process.once("SIGTERM", () => void shutdown("SIGTERM"));
+  process.once("SIGINT", () => void shutdown("SIGINT"));
+  console.log(
+    JSON.stringify({ component: "job-worker", event: "worker_ready" }),
+  );
+}
+
+void main().catch((error) => {
+  console.error(
+    JSON.stringify({
+      component: "job-worker",
+      event: "worker_start_failed",
+      error: error instanceof Error ? error.message : String(error),
+    }),
+  );
+  process.exitCode = 1;
+});

--- a/src/app/api/tasks/[taskId]/cancel/route.test.ts
+++ b/src/app/api/tasks/[taskId]/cancel/route.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { NextRequest } from "next/server";
+
+const mockGetAuthSessionFromHeaders = jest.fn();
+const mockCancelOwnedBackgroundTask = jest.fn();
+
+jest.mock("@/lib/auth/session", () => ({
+  getAuthSessionFromHeaders: mockGetAuthSessionFromHeaders,
+}));
+jest.mock("@/lib/tasks/service", () => ({
+  cancelOwnedBackgroundTask: mockCancelOwnedBackgroundTask,
+}));
+jest.mock("@/lib/jobs/server", () => ({ serverJobQueue: {} }));
+
+const taskId = "11111111-1111-4111-8111-111111111111";
+const cancelledTask = {
+  id: taskId,
+  status: "cancelled",
+  createdAt: new Date("2026-08-22T12:00:00.000Z"),
+  updatedAt: new Date("2026-08-22T12:01:00.000Z"),
+  startedAt: null,
+  completedAt: new Date("2026-08-22T12:01:00.000Z"),
+};
+
+function request() {
+  return new NextRequest(`http://localhost/api/tasks/${taskId}/cancel`, {
+    method: "POST",
+  });
+}
+
+function context(id = taskId) {
+  return { params: Promise.resolve({ taskId: id }) };
+}
+
+describe("POST /api/tasks/[taskId]/cancel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthSessionFromHeaders.mockResolvedValue({ user: { id: "user-1" } });
+    mockCancelOwnedBackgroundTask.mockResolvedValue(cancelledTask);
+  });
+
+  it("cancels an owned non-terminal task", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(request(), context());
+
+    expect(response.status).toBe(200);
+    expect(mockCancelOwnedBackgroundTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskRunId: taskId,
+        scopeKey: "user:user-1",
+      }),
+    );
+  });
+
+  it("does not reveal foreign or malformed tasks", async () => {
+    mockCancelOwnedBackgroundTask.mockResolvedValueOnce(null);
+    const { POST } = await import("./route");
+    expect((await POST(request(), context())).status).toBe(404);
+    expect((await POST(request(), context("invalid"))).status).toBe(404);
+  });
+
+  it("rejects unauthenticated callers", async () => {
+    mockGetAuthSessionFromHeaders.mockResolvedValue(null);
+    const { POST } = await import("./route");
+    expect((await POST(request(), context())).status).toBe(401);
+    expect(mockCancelOwnedBackgroundTask).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/tasks/[taskId]/cancel/route.ts
+++ b/src/app/api/tasks/[taskId]/cancel/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { db } from "@/database";
+import { getAuthSessionFromHeaders } from "@/lib/auth/session";
+import { serverJobQueue } from "@/lib/jobs/server";
+import { cancelOwnedBackgroundTask } from "@/lib/tasks/service";
+import { getUserScopeKey, serializeTaskRun } from "@/lib/tasks/types";
+
+const taskRunIdSchema = z.uuid();
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ taskId: string }> },
+) {
+  const session = await getAuthSessionFromHeaders(request.headers);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const parsedId = taskRunIdSchema.safeParse((await params).taskId);
+  if (!parsedId.success) {
+    return NextResponse.json({ error: "Task not found." }, { status: 404 });
+  }
+
+  const taskRun = await cancelOwnedBackgroundTask({
+    db,
+    queue: serverJobQueue,
+    taskRunId: parsedId.data,
+    scopeKey: getUserScopeKey(session.user.id),
+  });
+  if (!taskRun) {
+    return NextResponse.json({ error: "Task not found." }, { status: 404 });
+  }
+
+  return NextResponse.json(
+    { task: serializeTaskRun(taskRun) },
+    { headers: { "Cache-Control": "private, no-store" } },
+  );
+}

--- a/src/app/api/tasks/[taskId]/route.test.ts
+++ b/src/app/api/tasks/[taskId]/route.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { NextRequest } from "next/server";
+
+const mockGetAuthSessionFromHeaders = jest.fn();
+const mockGetOwnedTaskRun = jest.fn();
+
+jest.mock("@/lib/auth/session", () => ({
+  getAuthSessionFromHeaders: mockGetAuthSessionFromHeaders,
+}));
+jest.mock("@/lib/tasks/repository", () => ({
+  getOwnedTaskRun: mockGetOwnedTaskRun,
+}));
+
+const taskId = "11111111-1111-4111-8111-111111111111";
+const taskRun = {
+  id: taskId,
+  status: "completed",
+  createdAt: new Date("2026-08-22T12:00:00.000Z"),
+  updatedAt: new Date("2026-08-22T12:01:00.000Z"),
+  startedAt: new Date("2026-08-22T12:00:01.000Z"),
+  completedAt: new Date("2026-08-22T12:01:00.000Z"),
+};
+
+function request() {
+  return new NextRequest(`http://localhost/api/tasks/${taskId}`);
+}
+
+function context(id = taskId) {
+  return { params: Promise.resolve({ taskId: id }) };
+}
+
+describe("GET /api/tasks/[taskId]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthSessionFromHeaders.mockResolvedValue({ user: { id: "user-1" } });
+    mockGetOwnedTaskRun.mockResolvedValue(taskRun);
+  });
+
+  it("returns only a task owned by the current user scope", async () => {
+    const { GET } = await import("./route");
+    const response = await GET(request(), context());
+
+    expect(response.status).toBe(200);
+    expect(mockGetOwnedTaskRun).toHaveBeenCalledWith(
+      expect.anything(),
+      taskId,
+      "user:user-1",
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      task: { id: taskId, status: "completed" },
+    });
+  });
+
+  it("does not reveal missing, foreign, or malformed tasks", async () => {
+    mockGetOwnedTaskRun.mockResolvedValueOnce(null);
+    const { GET } = await import("./route");
+    expect((await GET(request(), context())).status).toBe(404);
+    expect((await GET(request(), context("invalid"))).status).toBe(404);
+  });
+
+  it("rejects unauthenticated callers before storage access", async () => {
+    mockGetAuthSessionFromHeaders.mockResolvedValue(null);
+    const { GET } = await import("./route");
+    expect((await GET(request(), context())).status).toBe(401);
+    expect(mockGetOwnedTaskRun).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/tasks/[taskId]/route.ts
+++ b/src/app/api/tasks/[taskId]/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { db } from "@/database";
+import { getAuthSessionFromHeaders } from "@/lib/auth/session";
+import { getOwnedTaskRun } from "@/lib/tasks/repository";
+import { getUserScopeKey, serializeTaskRun } from "@/lib/tasks/types";
+
+const taskRunIdSchema = z.uuid();
+
+async function resolveOwnedTask(
+  request: NextRequest,
+  params: Promise<{ taskId: string }>,
+) {
+  const session = await getAuthSessionFromHeaders(request.headers);
+  if (!session?.user?.id) {
+    return {
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  const parsedId = taskRunIdSchema.safeParse((await params).taskId);
+  if (!parsedId.success) {
+    return {
+      response: NextResponse.json(
+        { error: "Task not found." },
+        { status: 404 },
+      ),
+    };
+  }
+
+  const scopeKey = getUserScopeKey(session.user.id);
+  const taskRun = await getOwnedTaskRun(db, parsedId.data, scopeKey);
+  if (!taskRun) {
+    return {
+      response: NextResponse.json(
+        { error: "Task not found." },
+        { status: 404 },
+      ),
+    };
+  }
+
+  return { taskRun, scopeKey };
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ taskId: string }> },
+) {
+  const resolved = await resolveOwnedTask(request, params);
+  if ("response" in resolved) return resolved.response;
+
+  return NextResponse.json(
+    { task: serializeTaskRun(resolved.taskRun) },
+    { headers: { "Cache-Control": "private, no-store" } },
+  );
+}

--- a/src/app/api/tasks/example/route.test.ts
+++ b/src/app/api/tasks/example/route.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { NextRequest } from "next/server";
+
+const mockGetAuthSessionFromHeaders = jest.fn();
+const mockReadJsonBodyWithLimit = jest.fn();
+const mockCreateBackgroundTask = jest.fn();
+class MockRequestBodyTooLargeError extends Error {}
+
+jest.mock("@/lib/auth/session", () => ({
+  getAuthSessionFromHeaders: mockGetAuthSessionFromHeaders,
+}));
+jest.mock("@/lib/http/request-body", () => ({
+  readJsonBodyWithLimit: mockReadJsonBodyWithLimit,
+  RequestBodyTooLargeError: MockRequestBodyTooLargeError,
+}));
+jest.mock("@/lib/tasks/service", () => ({
+  createBackgroundTask: mockCreateBackgroundTask,
+}));
+jest.mock("@/lib/jobs/server", () => ({ serverJobQueue: {} }));
+
+const taskId = "11111111-1111-4111-8111-111111111111";
+const taskRun = {
+  id: taskId,
+  kind: "example.process",
+  status: "queued",
+  scopeKey: "user:user-1",
+  idempotencyKey: "request-1",
+  progress: null,
+  input: { message: "hello" },
+  result: null,
+  error: null,
+  providerJobId: null,
+  startedAt: null,
+  completedAt: null,
+  createdAt: new Date("2026-08-22T12:00:00.000Z"),
+  updatedAt: new Date("2026-08-22T12:00:00.000Z"),
+};
+
+function request() {
+  return new NextRequest("http://localhost/api/tasks/example", {
+    method: "POST",
+    body: JSON.stringify({ message: "hello" }),
+  });
+}
+
+describe("POST /api/tasks/example", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthSessionFromHeaders.mockResolvedValue({ user: { id: "user-1" } });
+    mockReadJsonBodyWithLimit.mockResolvedValue({
+      message: "hello",
+      idempotencyKey: "request-1",
+    });
+    mockCreateBackgroundTask.mockResolvedValue({ taskRun, created: true });
+  });
+
+  it("creates and enqueues an owned task", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(request());
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(mockCreateBackgroundTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeKey: "user:user-1",
+        payload: { message: "hello" },
+        idempotencyKey: "request-1",
+      }),
+    );
+  });
+
+  it("returns the existing task for an idempotent request", async () => {
+    mockCreateBackgroundTask.mockResolvedValue({ taskRun, created: false });
+    const { POST } = await import("./route");
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      task: { id: taskId, status: "queued" },
+    });
+  });
+
+  it("rejects unauthenticated and invalid requests", async () => {
+    mockGetAuthSessionFromHeaders.mockResolvedValueOnce(null);
+    const { POST } = await import("./route");
+    expect((await POST(request())).status).toBe(401);
+
+    mockReadJsonBodyWithLimit.mockResolvedValueOnce({ message: "" });
+    expect((await POST(request())).status).toBe(400);
+    expect(mockCreateBackgroundTask).not.toHaveBeenCalled();
+  });
+
+  it("reports an unavailable queue without returning fake success", async () => {
+    mockCreateBackgroundTask.mockRejectedValue(new Error("queue unavailable"));
+    const { POST } = await import("./route");
+    const response = await POST(request());
+
+    expect(response.status).toBe(503);
+  });
+});

--- a/src/app/api/tasks/example/route.ts
+++ b/src/app/api/tasks/example/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { db } from "@/database";
+import { getAuthSessionFromHeaders } from "@/lib/auth/session";
+import { exampleProcessJob } from "@/lib/jobs/example";
+import { serverJobQueue } from "@/lib/jobs/server";
+import {
+  readJsonBodyWithLimit,
+  RequestBodyTooLargeError,
+} from "@/lib/http/request-body";
+import { createBackgroundTask } from "@/lib/tasks/service";
+import { getUserScopeKey, serializeTaskRun } from "@/lib/tasks/types";
+
+const requestSchema = z
+  .object({
+    message: z.string().trim().min(1).max(500),
+    idempotencyKey: z.string().trim().min(1).max(200).optional(),
+  })
+  .strict();
+const MAX_REQUEST_BYTES = 2048;
+
+export async function POST(request: NextRequest) {
+  const session = await getAuthSessionFromHeaders(request.headers);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await readJsonBodyWithLimit(request, MAX_REQUEST_BYTES);
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Invalid request." },
+      { status: error instanceof RequestBodyTooLargeError ? 413 : 400 },
+    );
+  }
+
+  const parsed = requestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request." }, { status: 400 });
+  }
+
+  try {
+    const { taskRun, created } = await createBackgroundTask({
+      db,
+      queue: serverJobQueue,
+      definition: exampleProcessJob,
+      scopeKey: getUserScopeKey(session.user.id),
+      payload: { message: parsed.data.message },
+      idempotencyKey: parsed.data.idempotencyKey,
+    });
+
+    return NextResponse.json(
+      { task: serializeTaskRun(taskRun) },
+      {
+        status: created ? 202 : 200,
+        headers: { "Cache-Control": "private, no-store" },
+      },
+    );
+  } catch (error) {
+    console.error("Failed to create background task", error);
+    return NextResponse.json(
+      { error: "Background task service is unavailable." },
+      { status: 503 },
+    );
+  }
+}

--- a/src/database/client.ts
+++ b/src/database/client.ts
@@ -1,0 +1,32 @@
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as tables from "./tables";
+
+export interface DatabaseClientOptions {
+  url: string;
+  max: number;
+  idleTimeout?: number;
+  maxLifetime?: number;
+  connectTimeout?: number;
+  debug?: boolean;
+}
+
+export function createDatabaseClient(options: DatabaseClientOptions) {
+  const sql = postgres(options.url, {
+    max: options.max,
+    idle_timeout: options.idleTimeout ?? 300,
+    max_lifetime: options.maxLifetime ?? 14_400,
+    connect_timeout: options.connectTimeout ?? 4,
+    debug: options.debug ?? false,
+    connection: { TimeZone: "UTC" },
+    onnotice: options.debug ? console.log : () => {},
+  });
+
+  return {
+    db: drizzle(sql, { schema: { ...tables } }),
+    sql,
+    close: () => sql.end({ timeout: 5 }),
+  };
+}
+
+export type AppDatabase = ReturnType<typeof createDatabaseClient>["db"];

--- a/src/database/config.test.ts
+++ b/src/database/config.test.ts
@@ -37,6 +37,7 @@ describe("database/config.ts", () => {
     expect(config).toEqual({
       dialect: "postgresql",
       schema: "./src/database/schema.ts",
+      schemaFilter: ["public"],
       out: "./src/database/migrations",
       verbose: true,
       dbCredentials: {
@@ -52,6 +53,7 @@ describe("database/config.ts", () => {
     expect(mockDefineConfig).toHaveBeenCalledWith({
       dialect: "postgresql",
       schema: "./src/database/schema.ts",
+      schemaFilter: ["public"],
       out: "./src/database/migrations",
       verbose: true,
       dbCredentials: {

--- a/src/database/config.ts
+++ b/src/database/config.ts
@@ -13,6 +13,7 @@ if (protocol !== "postgres:" && protocol !== "postgresql:") {
 export default defineConfig({
   dialect: "postgresql",
   schema: "./src/database/schema.ts",
+  schemaFilter: ["public"],
   out: "./src/database/migrations",
   verbose: true,
   dbCredentials: {

--- a/src/database/migrations.test.ts
+++ b/src/database/migrations.test.ts
@@ -71,3 +71,19 @@ describe("AI chat history migration", () => {
     expect(migration).toContain('CONSTRAINT "ai_messages_id_not_empty"');
   });
 });
+
+describe("background task migration", () => {
+  it("adds guarded product state and partial application idempotency", () => {
+    const migration = readMigration("0023_wet_serpent_society.sql");
+
+    expect(migration).toContain('CREATE TYPE "public"."task_run_status"');
+    expect(migration).toContain('CREATE TABLE "task_runs"');
+    expect(migration).toContain('"providerJobId" text');
+    expect(migration).toContain(
+      '"task_runs_scopeKey_kind_idempotencyKey_unique"',
+    );
+    expect(migration).toContain(
+      'WHERE "task_runs"."idempotencyKey" is not null',
+    );
+  });
+});

--- a/src/database/migrations/0023_wet_serpent_society.sql
+++ b/src/database/migrations/0023_wet_serpent_society.sql
@@ -1,0 +1,21 @@
+CREATE TYPE "public"."task_run_status" AS ENUM('queued', 'running', 'waiting', 'completed', 'failed', 'cancelled');--> statement-breakpoint
+CREATE TABLE "task_runs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"kind" text NOT NULL,
+	"status" "task_run_status" DEFAULT 'queued' NOT NULL,
+	"scopeKey" text NOT NULL,
+	"idempotencyKey" text,
+	"progress" jsonb,
+	"input" jsonb,
+	"result" jsonb,
+	"error" jsonb,
+	"providerJobId" text,
+	"startedAt" timestamp with time zone,
+	"completedAt" timestamp with time zone,
+	"createdAt" timestamp with time zone DEFAULT now() NOT NULL,
+	"updatedAt" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "task_runs_scopeKey_createdAt_idx" ON "task_runs" USING btree ("scopeKey","createdAt" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "task_runs_status_updatedAt_idx" ON "task_runs" USING btree ("status","updatedAt");--> statement-breakpoint
+CREATE UNIQUE INDEX "task_runs_scopeKey_kind_idempotencyKey_unique" ON "task_runs" USING btree ("scopeKey","kind","idempotencyKey") WHERE "task_runs"."idempotencyKey" is not null;

--- a/src/database/migrations/meta/0023_snapshot.json
+++ b/src/database/migrations/meta/0023_snapshot.json
@@ -1,0 +1,2190 @@
+{
+  "id": "ad016ade-bb42-4481-b904-812eca09019c",
+  "prevId": "8758ad29-f16e-4a31-8eee-01f7bc7b2c6d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_conversations": {
+      "name": "ai_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_conversations_userId_archivedAt_updatedAt_idx": {
+          "name": "ai_conversations_userId_archivedAt_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_conversations_userId_users_id_fk": {
+          "name": "ai_conversations_userId_users_id_fk",
+          "tableFrom": "ai_conversations",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_messages": {
+      "name": "ai_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "ai_message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_messages_conversationId_createdAt_idx": {
+          "name": "ai_messages_conversationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_messages_conversationId_ai_conversations_id_fk": {
+          "name": "ai_messages_conversationId_ai_conversations_id_fk",
+          "tableFrom": "ai_messages",
+          "tableTo": "ai_conversations",
+          "columnsFrom": ["conversationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ai_messages_conversationId_id_pk": {
+          "name": "ai_messages_conversationId_id_pk",
+          "columns": ["conversationId", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_messages_id_not_empty": {
+          "name": "ai_messages_id_not_empty",
+          "value": "length(\"ai_messages\".\"id\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyPrefix": {
+          "name": "keyPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastFourChars": {
+          "name": "lastFourChars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rateLimit": {
+          "name": "rateLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestCountInWindow": {
+          "name": "requestCountInWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "windowStartedAt": {
+          "name": "windowStartedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_userId_createdAt_idx": {
+          "name": "api_keys_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_keyHash_idx": {
+          "name": "api_keys_keyHash_idx",
+          "columns": [
+            {
+              "expression": "keyHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_userId_users_id_fk": {
+          "name": "api_keys_userId_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastFourChars": {
+          "name": "lastFourChars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshTokenHash": {
+          "name": "refreshTokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshExpiresAt": {
+          "name": "refreshExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceOs": {
+          "name": "deviceOs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceHostname": {
+          "name": "deviceHostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cliVersion": {
+          "name": "cliVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cli_tokens_userId_createdAt_idx": {
+          "name": "cli_tokens_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_tokens_userId_users_id_fk": {
+          "name": "cli_tokens_userId_users_id_fk",
+          "tableFrom": "cli_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_tokenHash_unique": {
+          "name": "cli_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tokenHash"]
+        },
+        "cli_tokens_refreshTokenHash_unique": {
+          "name": "cli_tokens_refreshTokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refreshTokenHash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deviceCode": {
+          "name": "deviceCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCode": {
+          "name": "userCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "lastPolledAt": {
+          "name": "lastPolledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clientName": {
+          "name": "clientName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clientVersion": {
+          "name": "clientVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceOs": {
+          "name": "deviceOs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceHostname": {
+          "name": "deviceHostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_codes_expiresAt_idx": {
+          "name": "device_codes_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_userId_users_id_fk": {
+          "name": "device_codes_userId_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_deviceCode_unique": {
+          "name": "device_codes_deviceCode_unique",
+          "nullsNotDistinct": false,
+          "columns": ["deviceCode"]
+        },
+        "device_codes_userCode_unique": {
+          "name": "device_codes_userCode_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userCode"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paymentId": {
+          "name": "paymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paymentIntentId": {
+          "name": "paymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paymentType": {
+          "name": "paymentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_userId_createdAt_idx": {
+          "name": "payments_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_status_currency_createdAt_idx": {
+          "name": "payments_status_currency_createdAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_paymentIntentId_unique": {
+          "name": "payments_paymentIntentId_unique",
+          "columns": [
+            {
+              "expression": "paymentIntentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_paymentId_userId_productId_unique": {
+          "name": "payments_paymentId_userId_productId_unique",
+          "columns": [
+            {
+              "expression": "paymentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "productId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_userId_users_id_fk": {
+          "name": "payments_userId_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payments_paymentId_unique": {
+          "name": "payments_paymentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["paymentId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_entitlements": {
+      "name": "product_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "productId": {
+          "name": "productId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourcePaymentId": {
+          "name": "sourcePaymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocationReason": {
+          "name": "revocationReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_entitlements_userId_productId_unique": {
+          "name": "product_entitlements_userId_productId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "productId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_entitlements_sourcePaymentId_unique": {
+          "name": "product_entitlements_sourcePaymentId_unique",
+          "columns": [
+            {
+              "expression": "sourcePaymentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_entitlements_userId_createdAt_idx": {
+          "name": "product_entitlements_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_entitlements_userId_users_id_fk": {
+          "name": "product_entitlements_userId_users_id_fk",
+          "tableFrom": "product_entitlements",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_entitlements_payment_owner_product_fk": {
+          "name": "product_entitlements_payment_owner_product_fk",
+          "tableFrom": "product_entitlements",
+          "tableTo": "payments",
+          "columnsFrom": ["sourcePaymentId", "userId", "productId"],
+          "columnsTo": ["paymentId", "userId", "productId"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resetAt": {
+          "name": "resetAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_resetAt_idx": {
+          "name": "rate_limit_buckets_resetAt_idx",
+          "columns": [
+            {
+              "expression": "resetAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_buckets_scope_keyHash_pk": {
+          "name": "rate_limit_buckets_scope_keyHash_pk",
+          "columns": ["scope", "keyHash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonatedBy": {
+          "name": "impersonatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "productId": {
+          "name": "productId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastWebhookCreatedAt": {
+          "name": "lastWebhookCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_userId_createdAt_idx": {
+          "name": "subscriptions_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_customerId_idx": {
+          "name": "subscriptions_customerId_idx",
+          "columns": [
+            {
+              "expression": "customerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_userId_users_id_fk": {
+          "name": "subscriptions_userId_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_subscriptionId_unique": {
+          "name": "subscriptions_subscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["subscriptionId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_runs": {
+      "name": "task_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "task_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "scopeKey": {
+          "name": "scopeKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerJobId": {
+          "name": "providerJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_runs_scopeKey_createdAt_idx": {
+          "name": "task_runs_scopeKey_createdAt_idx",
+          "columns": [
+            {
+              "expression": "scopeKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_status_updatedAt_idx": {
+          "name": "task_runs_status_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_scopeKey_kind_idempotencyKey_unique": {
+          "name": "task_runs_scopeKey_kind_idempotencyKey_unique",
+          "columns": [
+            {
+              "expression": "scopeKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotencyKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"task_runs\".\"idempotencyKey\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upload_intents": {
+      "name": "upload_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileKey": {
+          "name": "fileKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "upload_intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleteCheckedAt": {
+          "name": "deleteCheckedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanupAttempts": {
+          "name": "cleanupAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastCleanupError": {
+          "name": "lastCleanupError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upload_intents_fileKey_unique": {
+          "name": "upload_intents_fileKey_unique",
+          "columns": [
+            {
+              "expression": "fileKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upload_intents_userId_status_expiresAt_idx": {
+          "name": "upload_intents_userId_status_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upload_intents_cleanup_queue_idx": {
+          "name": "upload_intents_cleanup_queue_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cleanupAttempts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upload_intents_userId_users_id_fk": {
+          "name": "upload_intents_userId_users_id_fk",
+          "tableFrom": "upload_intents",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "upload_intents_fileSize_positive": {
+          "name": "upload_intents_fileSize_positive",
+          "value": "\"upload_intents\".\"fileSize\" > 0"
+        },
+        "upload_intents_cleanupAttempts_non_negative": {
+          "name": "upload_intents_cleanupAttempts_non_negative",
+          "value": "\"upload_intents\".\"cleanupAttempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.uploads": {
+      "name": "uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploadIntentId": {
+          "name": "uploadIntentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileKey": {
+          "name": "fileKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uploads_userId_createdAt_idx": {
+          "name": "uploads_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uploads_uploadIntentId_unique": {
+          "name": "uploads_uploadIntentId_unique",
+          "columns": [
+            {
+              "expression": "uploadIntentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uploads_fileKey_unique": {
+          "name": "uploads_fileKey_unique",
+          "columns": [
+            {
+              "expression": "fileKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploads_userId_users_id_fk": {
+          "name": "uploads_userId_users_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploads_uploadIntentId_upload_intents_id_fk": {
+          "name": "uploads_uploadIntentId_upload_intents_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "upload_intents",
+          "columnsFrom": ["uploadIntentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "uploads_fileSize_positive": {
+          "name": "uploads_fileSize_positive",
+          "value": "\"uploads\".\"fileSize\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentProviderCustomerId": {
+          "name": "paymentProviderCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_paymentProviderCustomerId_unique": {
+          "name": "users_paymentProviderCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["paymentProviderCustomerId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_events_provider_eventId_unique": {
+          "name": "webhook_events_provider_eventId_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_events_provider_idx": {
+          "name": "webhook_events_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.ai_message_role": {
+      "name": "ai_message_role",
+      "schema": "public",
+      "values": ["system", "user", "assistant"]
+    },
+    "public.task_run_status": {
+      "name": "task_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "waiting",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.upload_intent_status": {
+      "name": "upload_intent_status",
+      "schema": "public",
+      "values": ["pending", "cancelled", "cleaning", "completed"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["user", "admin", "super_admin"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1787382180262,
       "tag": "0022_repair-ai-message-order",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1787408998399,
+      "tag": "0023_wet_serpent_society",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/schema.test.ts
+++ b/src/database/schema.test.ts
@@ -19,6 +19,8 @@ import {
   aiConversations,
   aiMessages,
   aiMessageRoleEnum,
+  taskRuns,
+  taskRunStatusEnum,
 } from "./schema";
 import { Table } from "drizzle-orm/table";
 import { getTableConfig } from "drizzle-orm/pg-core";
@@ -87,6 +89,15 @@ describe("Database Schema", () => {
         "system",
         "user",
         "assistant",
+      ]);
+      expect(taskRuns).toBeDefined();
+      expect(taskRunStatusEnum.enumValues).toEqual([
+        "queued",
+        "running",
+        "waiting",
+        "completed",
+        "failed",
+        "cancelled",
       ]);
       expect(uploads).toBeDefined();
       expect(apiKeys).toBeDefined();

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -34,6 +34,15 @@ export const aiMessageRoleEnum = pgEnum("ai_message_role", [
   "assistant",
 ]);
 
+export const taskRunStatusEnum = pgEnum("task_run_status", [
+  "queued",
+  "running",
+  "waiting",
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
 export const users = pgTable("users", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
@@ -379,6 +388,50 @@ export const aiMessages = pgTable(
     conversationCreatedAtIdx: index(
       "ai_messages_conversationId_createdAt_idx",
     ).on(table.conversationId, table.createdAt),
+  }),
+);
+
+export const taskRuns = pgTable(
+  "task_runs",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    kind: text("kind").notNull(),
+    status: taskRunStatusEnum("status").notNull().default("queued"),
+    scopeKey: text("scopeKey").notNull(),
+    idempotencyKey: text("idempotencyKey"),
+    progress: jsonb("progress").$type<Record<string, unknown> | null>(),
+    input: jsonb("input").$type<unknown>(),
+    result: jsonb("result").$type<unknown>(),
+    error: jsonb("error").$type<{
+      code: string;
+      message: string;
+      retryable: boolean;
+      attempt: number;
+    } | null>(),
+    providerJobId: text("providerJobId"),
+    startedAt: timestamp("startedAt", { withTimezone: true }),
+    completedAt: timestamp("completedAt", { withTimezone: true }),
+    createdAt: timestamp("createdAt", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updatedAt", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => ({
+    scopeCreatedAtIdx: index("task_runs_scopeKey_createdAt_idx").on(
+      table.scopeKey,
+      table.createdAt.desc(),
+    ),
+    statusUpdatedAtIdx: index("task_runs_status_updatedAt_idx").on(
+      table.status,
+      table.updatedAt,
+    ),
+    scopeKindIdempotencyUnique: uniqueIndex(
+      "task_runs_scopeKey_kind_idempotencyKey_unique",
+    )
+      .on(table.scopeKey, table.kind, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} is not null`),
   }),
 );
 

--- a/src/database/tables.ts
+++ b/src/database/tables.ts
@@ -18,6 +18,8 @@ import {
   aiConversations,
   aiMessages,
   aiMessageRoleEnum,
+  taskRuns,
+  taskRunStatusEnum,
 } from "./schema";
 
 export {
@@ -40,4 +42,6 @@ export {
   aiConversations,
   aiMessages,
   aiMessageRoleEnum,
+  taskRuns,
+  taskRunStatusEnum,
 };

--- a/src/lib/ai/models.node.ts
+++ b/src/lib/ai/models.node.ts
@@ -1,0 +1,33 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import type { LanguageModel } from "ai";
+import type { GptImage1kSize } from "./image-size";
+
+export interface AiModelConfig {
+  apiKey?: string;
+  baseUrl: string;
+  defaultModel: string;
+}
+
+export function createAiModels(config: AiModelConfig) {
+  const provider = createOpenAI({
+    name: "llm",
+    baseURL: config.baseUrl,
+    apiKey: config.apiKey,
+  });
+
+  return {
+    getChatModel(): LanguageModel {
+      return provider.responses(config.defaultModel);
+    },
+    getImageGenerationTool(size: GptImage1kSize = "1024x1024") {
+      return provider.tools.imageGeneration({
+        model: "gpt-image-2",
+        quality: "low",
+        size,
+        outputFormat: "webp",
+        outputCompression: 80,
+        partialImages: 0,
+      });
+    },
+  };
+}

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -1,29 +1,15 @@
 import "server-only";
-import { createOpenAI } from "@ai-sdk/openai";
-import type { LanguageModel } from "ai";
 import env from "@/env";
-import type { GptImage1kSize } from "./image-size";
+import { createAiModels } from "./models.node";
 
 // The Responses API supports reasoning and function tools together. The base
 // URL remains configurable for gateways that implement the OpenAI Responses
 // protocol.
-const llmProvider = createOpenAI({
-  name: "llm",
-  baseURL: env.LLM_BASE_URL,
+const models = createAiModels({
   apiKey: env.LLM_API_KEY,
+  baseUrl: env.LLM_BASE_URL,
+  defaultModel: env.AI_DEFAULT_MODEL,
 });
 
-export function getChatModel(): LanguageModel {
-  return llmProvider.responses(env.AI_DEFAULT_MODEL);
-}
-
-export function getImageGenerationTool(size: GptImage1kSize = "1024x1024") {
-  return llmProvider.tools.imageGeneration({
-    model: "gpt-image-2",
-    quality: "low",
-    size,
-    outputFormat: "webp",
-    outputCompression: 80,
-    partialImages: 0,
-  });
-}
+export const getChatModel = models.getChatModel;
+export const getImageGenerationTool = models.getImageGenerationTool;

--- a/src/lib/jobs/catalog.ts
+++ b/src/lib/jobs/catalog.ts
@@ -1,0 +1,5 @@
+import { exampleProcessJob } from "./example";
+
+export const jobDefinitions = [exampleProcessJob] as const;
+
+export const deadLetterQueueName = "jobs.dead-letter";

--- a/src/lib/jobs/definition.ts
+++ b/src/lib/jobs/definition.ts
@@ -1,0 +1,79 @@
+import type { z } from "zod";
+
+export interface JobHandlerContext<Payload = unknown> {
+  taskRunId: string;
+  scopeKey: string;
+  attempt: number;
+  providerIdempotencyKey: string;
+  signal: AbortSignal;
+  isCancelled(): Promise<boolean>;
+  updateProgress(progress: Record<string, unknown>): Promise<boolean>;
+  scheduleContinuation(
+    payload: Payload,
+    startAfter: Date | number,
+  ): Promise<boolean>;
+  submitProviderJob(
+    submit: (input: { idempotencyKey: string }) => Promise<string>,
+  ): Promise<string>;
+}
+
+export interface JobDefinition<
+  Name extends string,
+  Schema extends z.ZodType,
+  Result = unknown,
+> {
+  name: Name;
+  schema: Schema;
+  handler: (
+    payload: z.infer<Schema>,
+    context: JobHandlerContext<z.infer<Schema>>,
+  ) => Promise<Result>;
+  queue: {
+    retryLimit: number;
+    retryDelay: number;
+    retryBackoff: boolean;
+    expireInSeconds: number;
+  };
+  localConcurrency: number;
+  groupConcurrency: number;
+}
+
+export function defineJob<
+  const Name extends string,
+  Schema extends z.ZodType,
+  Result = unknown,
+>(
+  name: Name,
+  schema: Schema,
+  handler: JobDefinition<Name, Schema, Result>["handler"],
+  options?: Partial<
+    Pick<
+      JobDefinition<Name, Schema, Result>,
+      "queue" | "localConcurrency" | "groupConcurrency"
+    >
+  >,
+): JobDefinition<Name, Schema, Result> {
+  return {
+    name,
+    schema,
+    handler,
+    queue: options?.queue ?? {
+      retryLimit: 3,
+      retryDelay: 2,
+      retryBackoff: true,
+      expireInSeconds: 15 * 60,
+    },
+    localConcurrency: options?.localConcurrency ?? 4,
+    groupConcurrency: options?.groupConcurrency ?? 1,
+  };
+}
+
+export class PermanentJobError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "PermanentJobError";
+    this.code = code;
+  }
+}

--- a/src/lib/jobs/example.ts
+++ b/src/lib/jobs/example.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { defineJob } from "./definition";
+
+export const exampleProcessJob = defineJob(
+  "example.process",
+  z.object({ message: z.string().trim().min(1).max(500) }).strict(),
+  async (payload, context) => {
+    if (await context.isCancelled()) {
+      return null;
+    }
+
+    await context.updateProgress({ step: "processing", percent: 50 });
+
+    if (context.signal.aborted || (await context.isCancelled())) {
+      return null;
+    }
+
+    return {
+      message: payload.message,
+      processedAt: new Date().toISOString(),
+    };
+  },
+);

--- a/src/lib/jobs/queue.ts
+++ b/src/lib/jobs/queue.ts
@@ -1,0 +1,418 @@
+import { randomUUID } from "node:crypto";
+import { PgBoss, type JobResult, type JobWithMetadata } from "pg-boss";
+import { z } from "zod";
+import type { AppDatabase } from "@/database/client";
+import {
+  getTaskRun,
+  transitionTaskRun,
+  updateTaskRunProgress,
+} from "@/lib/tasks/repository";
+import type { TaskRunError } from "@/lib/tasks/types";
+import { ensureProviderJobSubmitted } from "@/lib/tasks/provider-submission";
+import { deadLetterQueueName, jobDefinitions } from "./catalog";
+import {
+  type JobDefinition,
+  type JobHandlerContext,
+  PermanentJobError,
+} from "./definition";
+
+const envelopeSchema = z
+  .object({
+    taskRunId: z.uuid(),
+    scopeKey: z.string().min(1).max(500),
+    payload: z.unknown(),
+  })
+  .strict();
+
+type JobEnvelope = z.infer<typeof envelopeSchema>;
+
+export interface JobQueueConfig {
+  connectionString: string;
+  poolSize: number;
+  schema?: string;
+}
+
+interface EnqueueOptions {
+  startAfter?: Date | number;
+  jobId?: string;
+}
+
+function log(level: "info" | "error" | "warn", data: object): void {
+  console[level](JSON.stringify({ component: "job-worker", ...data }));
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+export class JobQueue {
+  readonly #boss: PgBoss;
+  readonly #schema: string;
+  #startPromise: Promise<PgBoss> | null = null;
+  #startAttempted = false;
+
+  constructor(
+    config: JobQueueConfig,
+    options: { migrate?: boolean; supervise?: boolean } = {},
+  ) {
+    this.#schema = config.schema ?? "pgboss";
+    this.#boss = new PgBoss({
+      connectionString: config.connectionString,
+      schema: this.#schema,
+      max: config.poolSize,
+      useListenNotify: false,
+      migrate: options.migrate ?? false,
+      createSchema: options.migrate ?? false,
+      supervise: options.supervise ?? false,
+      schedule: false,
+      persistWarnings: true,
+      warningQueueSize: 100,
+    });
+    this.#boss.on("error", (error) => {
+      log("error", { event: "queue_error", error: toError(error).message });
+    });
+    this.#boss.on("warning", (warning) => {
+      log("warn", { event: "queue_warning", warning });
+    });
+  }
+
+  async start(): Promise<PgBoss> {
+    if (!this.#startPromise) {
+      this.#startAttempted = true;
+      this.#startPromise = this.#boss.start().catch((error) => {
+        this.#startPromise = null;
+        throw error;
+      });
+    }
+    return this.#startPromise;
+  }
+
+  async enqueue<Name extends string, Schema extends z.ZodType, Result>(
+    definition: JobDefinition<Name, Schema, Result>,
+    envelope: {
+      taskRunId: string;
+      scopeKey: string;
+      payload: z.infer<Schema>;
+    },
+    options: EnqueueOptions = {},
+  ): Promise<string | null> {
+    const boss = await this.start();
+    return boss.send(definition.name, envelope, {
+      id: options.jobId ?? envelope.taskRunId,
+      singletonKey: envelope.scopeKey,
+      group: { id: envelope.scopeKey },
+      startAfter: options.startAfter,
+    });
+  }
+
+  async cancel(name: string, taskRunId: string): Promise<void> {
+    const boss = await this.start();
+    await boss.cancel(name, taskRunId);
+  }
+
+  async registerWorkers(db: AppDatabase): Promise<void> {
+    const boss = await this.start();
+
+    for (const definition of jobDefinitions) {
+      await this.registerWorker(db, definition);
+      const [stats] = await boss.getQueueStats(definition.name, {
+        force: true,
+      });
+      const { rows } = await boss.getDb().executeSql(
+        `SELECT MIN(created_on) AS "oldestCreatedOn"
+         FROM ${this.#schema}.job
+         WHERE name = $1 AND state IN ('created', 'retry')`,
+        [definition.name],
+      );
+      const oldest = rows[0]?.oldestCreatedOn
+        ? new Date(rows[0].oldestCreatedOn as string | Date)
+        : null;
+      log("info", {
+        event: "queue_ready",
+        jobName: definition.name,
+        backlog: stats?.readyCount ?? 0,
+        oldestPendingAgeSeconds: oldest
+          ? Math.max(0, Math.floor((Date.now() - oldest.getTime()) / 1000))
+          : 0,
+      });
+    }
+  }
+
+  async registerWorker<Name extends string, Schema extends z.ZodType, Result>(
+    db: AppDatabase,
+    definition: JobDefinition<Name, Schema, Result>,
+  ): Promise<void> {
+    const boss = await this.start();
+    const workOptions = {
+      batchSize: 1,
+      includeMetadata: true,
+      perJobResults: true,
+      localConcurrency: definition.localConcurrency,
+      groupConcurrency: definition.groupConcurrency,
+    } as const;
+
+    await boss.work<JobEnvelope, unknown, typeof workOptions>(
+      definition.name,
+      workOptions,
+      async (jobs) =>
+        Promise.all(jobs.map((job) => this.#executeJob(db, definition, job))),
+    );
+  }
+
+  async #executeJob<Name extends string, Schema extends z.ZodType, Result>(
+    db: AppDatabase,
+    definition: JobDefinition<Name, Schema, Result>,
+    job: JobWithMetadata<JobEnvelope>,
+  ): Promise<JobResult> {
+    const envelope = envelopeSchema.safeParse(job.data);
+    if (!envelope.success) {
+      log("error", {
+        event: "invalid_job_envelope",
+        jobName: definition.name,
+        jobId: job.id,
+        error: z.prettifyError(envelope.error),
+      });
+      return {
+        id: job.id,
+        status: "deadletter",
+        output: { code: "INVALID_JOB_ENVELOPE" },
+      };
+    }
+
+    const { taskRunId, scopeKey } = envelope.data;
+    const attempt = job.retryCount + 1;
+    let taskRun = await getTaskRun(db, taskRunId);
+
+    if (
+      !taskRun ||
+      taskRun.scopeKey !== scopeKey ||
+      taskRun.kind !== definition.name
+    ) {
+      log("error", {
+        event: "task_mismatch",
+        jobName: definition.name,
+        taskRunId,
+        scopeKey,
+        attempt,
+      });
+      return {
+        id: job.id,
+        status: "deadletter",
+        output: { code: "TASK_MISMATCH" },
+      };
+    }
+
+    if (taskRun.status === "waiting") {
+      taskRun =
+        (await transitionTaskRun(db, {
+          taskRunId,
+          from: ["waiting"],
+          to: "queued",
+        })) ?? (await getTaskRun(db, taskRunId));
+    }
+
+    if (taskRun?.status === "queued") {
+      taskRun =
+        (await transitionTaskRun(db, {
+          taskRunId,
+          from: ["queued"],
+          to: "running",
+          patch: { startedAt: taskRun.startedAt ?? new Date() },
+        })) ?? (await getTaskRun(db, taskRunId));
+    }
+
+    if (taskRun?.status !== "running") {
+      log("info", {
+        event: "terminal_task_noop",
+        jobName: definition.name,
+        taskRunId,
+        scopeKey,
+        attempt,
+        status: taskRun?.status ?? "missing",
+      });
+      return { id: job.id, status: "completed" };
+    }
+
+    const payload = definition.schema.safeParse(envelope.data.payload);
+    if (!payload.success) {
+      const error: TaskRunError = {
+        code: "INVALID_JOB_PAYLOAD",
+        message: z.prettifyError(payload.error),
+        retryable: false,
+        attempt,
+      };
+      await transitionTaskRun(db, {
+        taskRunId,
+        from: ["running"],
+        to: "failed",
+        patch: { error, completedAt: new Date() },
+      });
+      log("error", {
+        event: "invalid_job_payload",
+        jobName: definition.name,
+        taskRunId,
+        scopeKey,
+        attempt,
+        error,
+      });
+      return { id: job.id, status: "deadletter", output: error };
+    }
+
+    const context: JobHandlerContext<z.infer<Schema>> = {
+      taskRunId,
+      scopeKey,
+      attempt,
+      providerIdempotencyKey: taskRunId,
+      signal: job.signal,
+      isCancelled: async () =>
+        job.signal.aborted ||
+        (await getTaskRun(db, taskRunId))?.status === "cancelled",
+      updateProgress: async (progress) =>
+        (await updateTaskRunProgress(db, taskRunId, progress)) !== null,
+      scheduleContinuation: async (nextPayload, startAfter) => {
+        const waiting = await transitionTaskRun(db, {
+          taskRunId,
+          from: ["running"],
+          to: "waiting",
+        });
+        if (!waiting) return false;
+
+        try {
+          await this.enqueue(
+            definition,
+            { taskRunId, scopeKey, payload: nextPayload },
+            { jobId: randomUUID(), startAfter },
+          );
+          return true;
+        } catch (error) {
+          await transitionTaskRun(db, {
+            taskRunId,
+            from: ["waiting"],
+            to: "queued",
+          });
+          throw error;
+        }
+      },
+      submitProviderJob: async (submit) => {
+        try {
+          return await ensureProviderJobSubmitted({
+            db,
+            taskRunId,
+            submit,
+          });
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message ===
+              "Provider accepted the job but its id could not be persisted."
+          ) {
+            throw new PermanentJobError(
+              "PROVIDER_JOB_ID_NOT_PERSISTED",
+              error.message,
+            );
+          }
+          throw error;
+        }
+      },
+    };
+
+    log("info", {
+      event: "job_started",
+      jobName: definition.name,
+      taskRunId,
+      scopeKey,
+      attempt,
+      retryLimit: job.retryLimit,
+    });
+
+    try {
+      const result = await definition.handler(payload.data, context);
+      const completed = await transitionTaskRun(db, {
+        taskRunId,
+        from: ["running"],
+        to: "completed",
+        patch: { result, progress: null, error: null, completedAt: new Date() },
+      });
+      log("info", {
+        event: completed ? "job_completed" : "job_completion_noop",
+        jobName: definition.name,
+        taskRunId,
+        scopeKey,
+        attempt,
+      });
+      return { id: job.id, status: "completed" };
+    } catch (caught) {
+      const cause = toError(caught);
+      const permanent = cause instanceof PermanentJobError;
+      const retriesExhausted = job.retryCount >= job.retryLimit;
+      const error: TaskRunError = {
+        code: permanent ? cause.code : "JOB_HANDLER_FAILED",
+        message: permanent ? cause.message : "Background task failed.",
+        retryable: !permanent && !retriesExhausted,
+        attempt,
+      };
+
+      if (permanent || retriesExhausted) {
+        await transitionTaskRun(db, {
+          taskRunId,
+          from: ["running"],
+          to: "failed",
+          patch: { error, completedAt: new Date() },
+        });
+      }
+
+      log("error", {
+        event: permanent
+          ? "job_failed_permanently"
+          : retriesExhausted
+            ? "job_retries_exhausted"
+            : "job_retry_scheduled",
+        jobName: definition.name,
+        taskRunId,
+        scopeKey,
+        attempt,
+        retryLimit: job.retryLimit,
+        error,
+        handlerError: { name: cause.name, message: cause.message },
+      });
+      return {
+        id: job.id,
+        status: permanent ? "deadletter" : "failed",
+        output: error,
+      };
+    }
+  }
+
+  async stop(timeoutMs: number): Promise<void> {
+    if (!this.#startAttempted) return;
+    await this.#boss.stop({ close: true, graceful: true, timeout: timeoutMs });
+    this.#startPromise = null;
+    this.#startAttempted = false;
+  }
+}
+
+export async function migrateJobQueue(config: JobQueueConfig): Promise<void> {
+  const queue = new JobQueue(config, { migrate: true, supervise: true });
+  try {
+    const boss = await queue.start();
+    await boss.createQueue(deadLetterQueueName, {
+      policy: "standard",
+      retryLimit: 0,
+      deleteAfterSeconds: 30 * 24 * 60 * 60,
+    });
+
+    for (const definition of jobDefinitions) {
+      await boss.createQueue(definition.name, {
+        policy: "singleton",
+        ...definition.queue,
+        deadLetter: deadLetterQueueName,
+      });
+      await boss.updateQueue(definition.name, {
+        ...definition.queue,
+        deadLetter: deadLetterQueueName,
+      });
+    }
+  } finally {
+    await queue.stop(30_000);
+  }
+}

--- a/src/lib/jobs/server.ts
+++ b/src/lib/jobs/server.ts
@@ -1,0 +1,8 @@
+import "server-only";
+import env from "@/env";
+import { JobQueue } from "./queue";
+
+export const serverJobQueue = new JobQueue({
+  connectionString: env.JOB_DATABASE_URL ?? env.DATABASE_URL,
+  poolSize: env.JOB_DB_POOL_SIZE,
+});

--- a/src/lib/jobs/worker-env.test.ts
+++ b/src/lib/jobs/worker-env.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "@jest/globals";
+import { loadWorkerEnv } from "./worker-env";
+
+describe("worker environment", () => {
+  it("uses the application database for jobs by default", () => {
+    const env = loadWorkerEnv({
+      DATABASE_URL: "postgresql://worker:worker@localhost/app",
+    });
+
+    expect(env.JOB_DATABASE_URL).toBe(env.DATABASE_URL);
+    expect(env.DB_POOL_SIZE).toBe(5);
+    expect(env.JOB_DB_POOL_SIZE).toBe(3);
+    expect(env.WORKER_GRACEFUL_TIMEOUT_MS).toBe(30_000);
+  });
+
+  it("accepts a separate queue database and explicit pool budgets", () => {
+    const env = loadWorkerEnv({
+      DATABASE_URL: "postgresql://worker:worker@localhost/app",
+      JOB_DATABASE_URL: "postgresql://worker:worker@localhost/jobs",
+      DB_POOL_SIZE: "4",
+      JOB_DB_POOL_SIZE: "2",
+      WORKER_GRACEFUL_TIMEOUT_MS: "45000",
+    });
+
+    expect(env.JOB_DATABASE_URL).toContain("/jobs");
+    expect(env.DB_POOL_SIZE).toBe(4);
+    expect(env.JOB_DB_POOL_SIZE).toBe(2);
+    expect(env.WORKER_GRACEFUL_TIMEOUT_MS).toBe(45_000);
+  });
+
+  it("rejects non-PostgreSQL and invalid pool configuration", () => {
+    expect(() =>
+      loadWorkerEnv({ DATABASE_URL: "mysql://localhost/app" }),
+    ).toThrow("Invalid worker environment");
+    expect(() =>
+      loadWorkerEnv({
+        DATABASE_URL: "postgresql://localhost/app",
+        JOB_DB_POOL_SIZE: "0",
+      }),
+    ).toThrow("Invalid worker environment");
+  });
+});

--- a/src/lib/jobs/worker-env.ts
+++ b/src/lib/jobs/worker-env.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+const databaseUrlSchema = z
+  .url()
+  .refine(
+    (value) => ["postgres:", "postgresql:"].includes(new URL(value).protocol),
+    "must use the postgres or postgresql protocol",
+  );
+
+const workerEnvSchema = z.object({
+  DATABASE_URL: databaseUrlSchema,
+  JOB_DATABASE_URL: databaseUrlSchema.optional(),
+  DB_POOL_SIZE: z.coerce.number().int().positive().max(50).default(5),
+  DB_IDLE_TIMEOUT: z.coerce.number().int().nonnegative().default(300),
+  DB_MAX_LIFETIME: z.coerce.number().int().nonnegative().default(14_400),
+  DB_CONNECT_TIMEOUT: z.coerce.number().int().positive().max(10).default(4),
+  JOB_DB_POOL_SIZE: z.coerce.number().int().positive().max(20).default(3),
+  WORKER_GRACEFUL_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(30_000),
+  LLM_API_KEY: z.string().trim().min(1).optional(),
+  LLM_BASE_URL: z.url().default("https://api.openai.com/v1"),
+  AI_DEFAULT_MODEL: z.string().trim().min(1).default("gpt-5.6-luna"),
+});
+
+export function loadWorkerEnv(source: NodeJS.ProcessEnv = process.env) {
+  const parsed = workerEnvSchema.safeParse(source);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid worker environment: ${z.prettifyError(parsed.error)}`,
+    );
+  }
+
+  return {
+    ...parsed.data,
+    JOB_DATABASE_URL: parsed.data.JOB_DATABASE_URL ?? parsed.data.DATABASE_URL,
+  };
+}

--- a/src/lib/tasks/provider-submission.ts
+++ b/src/lib/tasks/provider-submission.ts
@@ -1,0 +1,27 @@
+import type { AppDatabase } from "@/database/client";
+import { getTaskRun, setProviderJobIdIfAbsent } from "./repository";
+
+export async function ensureProviderJobSubmitted(input: {
+  db: AppDatabase;
+  taskRunId: string;
+  submit: (input: { idempotencyKey: string }) => Promise<string>;
+}): Promise<string> {
+  const existingProviderJobId = (await getTaskRun(input.db, input.taskRunId))
+    ?.providerJobId;
+  if (existingProviderJobId) return existingProviderJobId;
+
+  const submittedId = await input.submit({
+    idempotencyKey: input.taskRunId,
+  });
+  const persistedId = await setProviderJobIdIfAbsent(
+    input.db,
+    input.taskRunId,
+    submittedId,
+  );
+  if (!persistedId) {
+    throw new Error(
+      "Provider accepted the job but its id could not be persisted.",
+    );
+  }
+  return persistedId;
+}

--- a/src/lib/tasks/repository.test.ts
+++ b/src/lib/tasks/repository.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "@jest/globals";
+import type { AppDatabase } from "@/database/client";
+import { transitionTaskRun } from "./repository";
+
+describe("task transition policy", () => {
+  const unusedDatabase = {} as AppDatabase;
+
+  it("rejects terminal-state rewrites before accessing storage", async () => {
+    await expect(
+      transitionTaskRun(unusedDatabase, {
+        taskRunId: "11111111-1111-4111-8111-111111111111",
+        from: ["completed"],
+        to: "running",
+      }),
+    ).rejects.toThrow("Invalid task transition from completed to running");
+  });
+
+  it("rejects mixed source sets containing an illegal transition", async () => {
+    await expect(
+      transitionTaskRun(unusedDatabase, {
+        taskRunId: "11111111-1111-4111-8111-111111111111",
+        from: ["queued", "running"],
+        to: "completed",
+      }),
+    ).rejects.toThrow(
+      "Invalid task transition from queued/running to completed",
+    );
+  });
+});

--- a/src/lib/tasks/repository.ts
+++ b/src/lib/tasks/repository.ts
@@ -1,0 +1,185 @@
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import type { AppDatabase } from "@/database/client";
+import { taskRuns } from "@/database/schema";
+import type { TaskRun, TaskRunError, TaskRunStatus } from "./types";
+
+interface CreateTaskRunInput {
+  kind: string;
+  scopeKey: string;
+  idempotencyKey?: string;
+  input: unknown;
+}
+
+interface TransitionPatch {
+  progress?: Record<string, unknown> | null;
+  result?: unknown;
+  error?: TaskRunError | null;
+  providerJobId?: string | null;
+  startedAt?: Date | null;
+  completedAt?: Date | null;
+}
+
+const ALLOWED_TASK_TRANSITIONS: Record<
+  TaskRunStatus,
+  readonly TaskRunStatus[]
+> = {
+  queued: ["running", "cancelled"],
+  running: ["waiting", "completed", "failed", "cancelled"],
+  waiting: ["queued", "cancelled"],
+  completed: [],
+  failed: [],
+  cancelled: [],
+};
+
+export async function createTaskRun(
+  db: AppDatabase,
+  input: CreateTaskRunInput,
+): Promise<{ taskRun: TaskRun; created: boolean }> {
+  const [created] = await db
+    .insert(taskRuns)
+    .values({
+      kind: input.kind,
+      scopeKey: input.scopeKey,
+      idempotencyKey: input.idempotencyKey,
+      input: input.input,
+    })
+    .onConflictDoNothing()
+    .returning();
+
+  if (created) {
+    return { taskRun: created, created: true };
+  }
+
+  if (!input.idempotencyKey) {
+    throw new Error("Task creation failed without an idempotency key.");
+  }
+
+  const [existing] = await db
+    .select()
+    .from(taskRuns)
+    .where(
+      and(
+        eq(taskRuns.scopeKey, input.scopeKey),
+        eq(taskRuns.kind, input.kind),
+        eq(taskRuns.idempotencyKey, input.idempotencyKey),
+      ),
+    )
+    .limit(1);
+
+  if (!existing) {
+    throw new Error("Idempotent task creation lost its winning row.");
+  }
+
+  return { taskRun: existing, created: false };
+}
+
+export async function getTaskRun(
+  db: AppDatabase,
+  taskRunId: string,
+): Promise<TaskRun | null> {
+  const [taskRun] = await db
+    .select()
+    .from(taskRuns)
+    .where(eq(taskRuns.id, taskRunId))
+    .limit(1);
+  return taskRun ?? null;
+}
+
+export async function getOwnedTaskRun(
+  db: AppDatabase,
+  taskRunId: string,
+  scopeKey: string,
+): Promise<TaskRun | null> {
+  const [taskRun] = await db
+    .select()
+    .from(taskRuns)
+    .where(and(eq(taskRuns.id, taskRunId), eq(taskRuns.scopeKey, scopeKey)))
+    .limit(1);
+  return taskRun ?? null;
+}
+
+export async function transitionTaskRun(
+  db: AppDatabase,
+  input: {
+    taskRunId: string;
+    from: readonly TaskRunStatus[];
+    to: TaskRunStatus;
+    patch?: TransitionPatch;
+  },
+): Promise<TaskRun | null> {
+  if (
+    input.from.length === 0 ||
+    input.from.some(
+      (status) => !ALLOWED_TASK_TRANSITIONS[status].includes(input.to),
+    )
+  ) {
+    throw new Error(
+      `Invalid task transition from ${input.from.join("/")} to ${input.to}.`,
+    );
+  }
+
+  const [updated] = await db
+    .update(taskRuns)
+    .set({
+      status: input.to,
+      ...input.patch,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(taskRuns.id, input.taskRunId),
+        inArray(taskRuns.status, [...input.from]),
+      ),
+    )
+    .returning();
+  return updated ?? null;
+}
+
+export async function cancelTaskRun(
+  db: AppDatabase,
+  taskRunId: string,
+): Promise<TaskRun | null> {
+  return transitionTaskRun(db, {
+    taskRunId,
+    from: ["queued", "running", "waiting"],
+    to: "cancelled",
+    patch: { completedAt: new Date() },
+  });
+}
+
+export async function updateTaskRunProgress(
+  db: AppDatabase,
+  taskRunId: string,
+  progress: Record<string, unknown>,
+): Promise<TaskRun | null> {
+  const [updated] = await db
+    .update(taskRuns)
+    .set({ progress, updatedAt: new Date() })
+    .where(and(eq(taskRuns.id, taskRunId), eq(taskRuns.status, "running")))
+    .returning();
+  return updated ?? null;
+}
+
+export async function setProviderJobIdIfAbsent(
+  db: AppDatabase,
+  taskRunId: string,
+  providerJobId: string,
+): Promise<string | null> {
+  const [updated] = await db
+    .update(taskRuns)
+    .set({ providerJobId, updatedAt: new Date() })
+    .where(
+      and(
+        eq(taskRuns.id, taskRunId),
+        inArray(taskRuns.status, ["running", "cancelled"]),
+        isNull(taskRuns.providerJobId),
+      ),
+    )
+    .returning({ providerJobId: taskRuns.providerJobId });
+
+  if (updated?.providerJobId) {
+    return updated.providerJobId;
+  }
+
+  return (await getTaskRun(db, taskRunId))?.providerJobId ?? null;
+}

--- a/src/lib/tasks/service.ts
+++ b/src/lib/tasks/service.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from "node:crypto";
+import type { z } from "zod";
+import type { AppDatabase } from "@/database/client";
+import type { JobDefinition } from "@/lib/jobs/definition";
+import type { JobQueue } from "@/lib/jobs/queue";
+import { cancelTaskRun, createTaskRun, getOwnedTaskRun } from "./repository";
+import type { TaskRun } from "./types";
+
+export async function createBackgroundTask<
+  Name extends string,
+  Schema extends z.ZodType,
+  Result,
+>(input: {
+  db: AppDatabase;
+  queue: JobQueue;
+  definition: JobDefinition<Name, Schema, Result>;
+  scopeKey: string;
+  payload: z.infer<Schema>;
+  idempotencyKey?: string;
+}): Promise<{ taskRun: TaskRun; created: boolean }> {
+  const created = await createTaskRun(input.db, {
+    kind: input.definition.name,
+    scopeKey: input.scopeKey,
+    idempotencyKey: input.idempotencyKey,
+    input: input.payload,
+  });
+
+  if (created.taskRun.status === "queued") {
+    await input.queue.enqueue(input.definition, {
+      taskRunId: created.taskRun.id,
+      scopeKey: input.scopeKey,
+      payload: input.payload,
+    });
+  }
+
+  return created;
+}
+
+export async function cancelOwnedBackgroundTask(input: {
+  db: AppDatabase;
+  queue: JobQueue;
+  taskRunId: string;
+  scopeKey: string;
+}): Promise<TaskRun | null> {
+  const owned = await getOwnedTaskRun(
+    input.db,
+    input.taskRunId,
+    input.scopeKey,
+  );
+  if (!owned) return null;
+
+  const cancelled = await cancelTaskRun(input.db, input.taskRunId);
+  if (!cancelled) return owned;
+
+  try {
+    await input.queue.cancel(owned.kind, owned.id);
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        component: "task-api",
+        event: "queue_cancel_failed",
+        taskRunId: owned.id,
+        jobName: owned.kind,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  }
+
+  return cancelled;
+}
+
+export async function enqueueBackgroundTaskContinuation<
+  Name extends string,
+  Schema extends z.ZodType,
+  Result,
+>(input: {
+  db: AppDatabase;
+  queue: JobQueue;
+  definition: JobDefinition<Name, Schema, Result>;
+  taskRunId: string;
+  scopeKey: string;
+  payload: z.infer<Schema>;
+  startAfter?: Date | number;
+  continuationJobId?: string;
+}): Promise<boolean> {
+  const taskRun = await getOwnedTaskRun(
+    input.db,
+    input.taskRunId,
+    input.scopeKey,
+  );
+  if (
+    !taskRun ||
+    taskRun.kind !== input.definition.name ||
+    taskRun.status !== "waiting"
+  ) {
+    return false;
+  }
+
+  await input.queue.enqueue(
+    input.definition,
+    {
+      taskRunId: input.taskRunId,
+      scopeKey: input.scopeKey,
+      payload: input.payload,
+    },
+    {
+      jobId: input.continuationJobId ?? randomUUID(),
+      startAfter: input.startAfter,
+    },
+  );
+  return true;
+}

--- a/src/lib/tasks/types.ts
+++ b/src/lib/tasks/types.ts
@@ -1,0 +1,31 @@
+import type { taskRuns } from "@/database/schema";
+
+export type TaskRunStatus =
+  | "queued"
+  | "running"
+  | "waiting"
+  | "completed"
+  | "failed"
+  | "cancelled";
+export type TaskRun = typeof taskRuns.$inferSelect;
+
+export interface TaskRunError {
+  code: string;
+  message: string;
+  retryable: boolean;
+  attempt: number;
+}
+
+export function getUserScopeKey(userId: string): string {
+  return `user:${userId}`;
+}
+
+export function serializeTaskRun(taskRun: TaskRun) {
+  return {
+    ...taskRun,
+    createdAt: taskRun.createdAt.toISOString(),
+    updatedAt: taskRun.updatedAt.toISOString(),
+    startedAt: taskRun.startedAt?.toISOString() ?? null,
+    completedAt: taskRun.completedAt?.toISOString() ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

- add a durable PostgreSQL-backed background job runtime with an independently built Worker, guarded task state transitions, retry/DLQ handling, scope fairness, graceful shutdown, and structured logs
- add authenticated task enqueue/query/cancel APIs with application idempotency, provider crash recovery, delayed continuations, ownership enforcement, and sanitized user-facing errors
- add database migrations, deployment/runtime configuration, operational documentation, and comprehensive unit, integration, shutdown, and E2E coverage

## Validation

- `pnpm prettier:check`
- `pnpm type-check`
- `pnpm lint`
- `pnpm dead-code:check`
- `pnpm test --runInBand` (153 suites, 1235 tests)
- `pnpm build`
- `pnpm worker:smoke`
- `JOBS_TEST_DATABASE_URL=postgresql://visoar@localhost:5432/starter_e2e pnpm test:jobs:integration` (7 tests)
- `JOBS_TEST_DATABASE_URL=postgresql://visoar@localhost:5432/starter_e2e pnpm worker:shutdown-smoke`
- `E2E_DATABASE_URL=postgresql://visoar@localhost:5432/starter_e2e pnpm test:e2e` (16 tests)
- `docker compose --env-file ../.env config --quiet`
- `git diff --check`

Docker image construction was not repeated locally because the Docker/OrbStack daemon was unavailable; the production application and standalone Worker artifacts were both built successfully with `pnpm build`.

Closes #88