### PR TITLE
chore: release v0.1.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ullrai-starter",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "engines": {


### PR DESCRIPTION
## Summary

- bump the package version to 0.1.13 for the reviewed Issue #88 production release

## Validation

- `pnpm prettier:check`
- `git diff --check`

The full Issue #88 implementation passed CI in #89.

Release tag: `release/v0.1.13`