### PR TITLE
feat(ai): 持久化 token 用量并新增 lessons-learned 文档

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ This file is the single source of truth for repository-specific agent instructio
 - Check existing patterns before adding new abstractions.
 - Keep user-visible behavior complete. Do not leave mock data, placeholder flows, or half-finished paths.
 - When documentation in this file conflicts with the codebase, verify the codebase and update the documentation to match reality.
+- Read `docs/lessons-learned.md` before non-trivial work. It records counter-intuitive failures this repository has actually hit, which is exactly where prior knowledge tends to be wrong. Add an entry whenever you lose time to a surprise.
 
 ## 2. Development Commands
 

--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -17,6 +17,7 @@ src/lib/ai/
 ├── chat-attachments.ts    # Ownership and media validation for reference images
 ├── generated-image-storage.ts # Generated-image persistence through R2
 ├── response-chain.ts      # User-bound signed handles for previous_response_id
+├── usage.ts               # Per-turn token accounting into ai_usage_events
 ├── context.ts             # AgentContext: per-request session data for tools
 ├── tools/                 # One file per tool
 │   ├── index.ts           # Tool registry: name → factory, plus buildTools()
@@ -208,6 +209,28 @@ The dashboard page at `/dashboard/ai` follows the AI Elements conversation, reas
 prompt-input, tool-status, and artifact patterns while reusing this repository's shadcn primitives
 and design tokens. Wide desktop layouts add persistent history beside the split Chat + Canvas
 workspace; narrower screens open history and Canvas in independent full-height sheets.
+
+## Usage accounting
+
+Every completed assistant turn writes one `ai_usage_events` row: the user, conversation, message,
+agent, model, reasoning effort, token counts, finish reason, and duration. This is the data layer
+for cost attribution, quotas, and usage-based billing — request-count rate limiting cannot express
+that a `high` reasoning turn with image generation costs orders of magnitude more than a lookup.
+
+Two details are easy to get wrong:
+
+- **Usage does not reach `onEnd`.** The AI SDK's stream-end event carries no token counts. They
+  arrive on stream parts, so `src/app/api/chat/route.ts` captures `totalUsage` from the `finish`
+  part and `response.modelId` from `finish-step` into closure variables, then writes one row from
+  `onEnd`. Do not put usage into the `messageMetadata` return value — that is sent to the client.
+- **Aborted turns still cost money.** Tokens spent before a client disconnects are billed, so
+  those turns are recorded too, flagged with `aborted`. Dropping them understates cost precisely
+  where runs are most expensive.
+
+Token columns are nullable throughout. A provider that reports no cache tokens is not the same as
+one reporting zero, and `extractUsageTotals` in `src/lib/ai/usage.ts` preserves that distinction
+rather than defaulting to `0`. Accounting failures are logged and swallowed: a bookkeeping error
+must never cost the user their reply.
 
 ## Testing
 

--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -215,22 +215,29 @@ workspace; narrower screens open history and Canvas in independent full-height s
 Every completed assistant turn writes one `ai_usage_events` row: the user, conversation, message,
 agent, model, reasoning effort, token counts, finish reason, and duration. This is the data layer
 for cost attribution, quotas, and usage-based billing — request-count rate limiting cannot express
-that a `high` reasoning turn with image generation costs orders of magnitude more than a lookup.
+that a `high` reasoning turn costs far more than a lookup.
 
 Two details are easy to get wrong:
 
-- **Usage does not reach `onEnd`.** The AI SDK's stream-end event carries no token counts. They
-  arrive on stream parts, so `src/app/api/chat/route.ts` captures `totalUsage` from the `finish`
-  part and `response.modelId` from `finish-step` into closure variables, then writes one row from
-  `onEnd`. Do not put usage into the `messageMetadata` return value — that is sent to the client.
-- **Aborted turns still cost money.** Tokens spent before a client disconnects are billed, so
-  those turns are recorded too, flagged with `aborted`. Dropping them understates cost precisely
-  where runs are most expensive.
+- **Usage does not reach `onEnd`.** The AI SDK's stream-end event carries `finishReason` but no
+  token counts. Those arrive on stream parts, so `src/app/api/chat/route.ts` captures `totalUsage`
+  from the `finish` part and `response.modelId` from `finish-step` into closure variables, then
+  writes one row from `onEnd`. Do not put usage into the `messageMetadata` return value — that is
+  sent to the client.
+- **The row counts language-model tokens only.** `generateImage` runs as a provider-executed tool,
+  and its image tokens never appear in `LanguageModelUsage`. Image spend is billed but not captured
+  here; costing that feature needs a separate source.
+
+The `model` column records the model that served the final step. That is accurate only while a
+single chat model serves the whole loop, which is today's configuration; introducing per-step model
+selection would require per-step rows instead of one row per turn.
 
 Token columns are nullable throughout. A provider that reports no cache tokens is not the same as
 one reporting zero, and `extractUsageTotals` in `src/lib/ai/usage.ts` preserves that distinction
 rather than defaulting to `0`. Accounting failures are logged and swallowed: a bookkeeping error
-must never cost the user their reply.
+must never cost the user their reply. `messageId` carries no foreign key, and regenerating a turn
+overwrites the message row while leaving a usage row per attempt — sum by user or conversation, not
+by message.
 
 ## Testing
 

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -1,0 +1,70 @@
+# Lessons Learned
+
+违反直觉的事实,每条都来自真实踩过的坑。
+
+与 `AGENTS.md` 的分工:`AGENTS.md` 写「必须怎么做」的规则,本文件写「为什么这么做会炸」。规则留在 `AGENTS.md`,不要迁移过来。
+
+## 写入规范
+
+- 只写真实踩过的坑。没踩过的推测和最佳实践复述不要进。
+- 每条写清**现象 → 原因 → 正确做法**。只写「不要用 X」而不写为什么,下次仍然会有人踩。
+- 一条一个坑,按主题分节即可,不做分类学。
+- 过期即删。框架升级后不再成立的条目直接移除,不留考古层。
+
+---
+
+## 数据库
+
+### 新增表必须同时登记到 `src/database/tables.ts`
+
+**现象**:在 `src/database/schema.ts` 加了一张表之后,`pnpm type-check` 在**完全无关**的 `src/lib/billing/stripe/webhook.ts` 报错,信息是 `Property 'xxx' is missing in type 'ExtractTablesWithRelations<...>'`,长达数十行且不指向真正的问题点。
+
+**原因**:`src/database/index.ts` 的 `drizzle(sql, { schema: { ...tables } })` 用的是 `./tables`——一份**手工维护的再导出白名单**,而 `src/lib/database/subscription.ts` 的 `Tx` 类型引用的是 `./schema` 全量。两者不一致时,`db.transaction()` 的回调参数类型与 `Tx` 不兼容,错误在最先使用 `Tx` 的文件爆出来。
+
+**正确做法**:改 `schema.ts` 加表后,立刻在 `tables.ts` 的 import 和 export 两处都加上。报错位置与真实原因无关,不要在 `webhook.ts` 里找问题。
+
+---
+
+## AI
+
+### `onEnd` 回调不携带 token 用量
+
+**现象**:想在 `createAgentUIStreamResponse` 的 `onEnd` 里记录用量,但事件对象上找不到 usage 字段。
+
+**原因**:`ai@7` 的 `UIMessageStreamOnEndCallback` 事件只有 `{ messages, isContinuation, isAborted, responseMessage, finishReason }`。用量在流的 part 上,不在结束回调里。
+
+**正确做法**:用 `messageMetadata` 回调捕获——`part.type === "finish"` 带整轮的 `totalUsage`,`part.type === "finish-step"` 带单步的 `usage` 和 `response.modelId`(provider 实际使用的模型,比读配置准确)。捕获到闭包变量,由 `onEnd` 统一落库。
+
+注意 `messageMetadata` 的返回值会发给客户端,用量数据不要放进返回值。参见 #92。
+
+### 中止的回合同样消耗 token
+
+**现象**:用户关闭页面后统计出的 AI 成本低于账单。
+
+**原因**:只在正常完成时记账。但流被中止时,已经产生的 token 早已计费。
+
+**正确做法**:`onEnd` 的 `isAborted` 为 `true` 时照样记一条,用单独的列标记。丢弃这些记录会让成本统计在最贵的场景下系统性偏低。
+
+---
+
+## Next.js
+
+### 本项目的 Next.js 与训练数据不符
+
+**现象**:按记忆写 App Router 代码,遇到 API 签名或文件约定对不上。
+
+**原因**:Next.js 16 有 breaking changes,模型的先验知识往往停留在更早的版本。
+
+**正确做法**:动手前先读 `node_modules/next/dist/docs/` 里的相关指南(从 `AGENTS.md` 所在目录解析)。这条也由 `next dev` 自动写进 `CLAUDE.md` 底部。
+
+---
+
+## 工具链
+
+### 让 agent 跑验证前,先让它读项目脚本
+
+**现象**:agent 自行执行 `npx tsc`、`eslint .` 之类的通用命令,得出「没有错误」或一堆假错误的结论。
+
+**原因**:这些命令绕过了项目实际的配置——本仓库的 `pnpm type-check` 会先构建 content collections 并生成路由类型,`pnpm lint` 有专门的 ESLint 配置,直接跑通用命令得到的结果不可信。
+
+**正确做法**:验证前先读 `AGENTS.md` 第 2 节和 `package.json` 的 scripts,只用其中列出的命令。

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -33,17 +33,25 @@
 
 **原因**:`ai@7` 的 `UIMessageStreamOnEndCallback` 事件只有 `{ messages, isContinuation, isAborted, responseMessage, finishReason }`。用量在流的 part 上,不在结束回调里。
 
-**正确做法**:用 `messageMetadata` 回调捕获——`part.type === "finish"` 带整轮的 `totalUsage`,`part.type === "finish-step"` 带单步的 `usage` 和 `response.modelId`(provider 实际使用的模型,比读配置准确)。捕获到闭包变量,由 `onEnd` 统一落库。
+**正确做法**:用 `messageMetadata` 回调捕获——`part.type === "finish"` 带整轮的 `totalUsage`,`part.type === "finish-step"` 带 `response.modelId`(provider 实际使用的模型,比读配置准确)。捕获到闭包变量,由 `onEnd` 统一落库。
 
-注意 `messageMetadata` 的返回值会发给客户端,用量数据不要放进返回值。参见 #92。
+注意两点:`messageMetadata` 的返回值会发给客户端,用量数据不要放进返回值;另外 `finishReason` 本来就在 `onEnd` 事件上,不要跟着一起用闭包捕获。参见 #92。
 
-### 中止的回合同样消耗 token
+### `onEnd` 的 `isAborted` 在本项目恒为 `false`
 
-**现象**:用户关闭页面后统计出的 AI 成本低于账单。
+**现象**:按 `isAborted` 给用量记录加了「已中止」标记,写了测试也过了,但线上永远不会出现这个值。
 
-**原因**:只在正常完成时记账。但流被中止时,已经产生的 token 早已计费。
+**原因**:`isAborted` 只在流里出现 `abort` chunk 时才为真,而该 chunk 只在 `abortSignal.aborted` 时产生。我们调用 `createAgentUIStreamResponse` 时既没传 `abortSignal` 也没配 `timeout`,并且 `consumeSseStream` 还刻意让浏览器断开后继续消费。测试之所以通过,是因为它直接手工调用 `onEnd({ isAborted: true })`,绕过了真实流程。
 
-**正确做法**:`onEnd` 的 `isAborted` 为 `true` 时照样记一条,用单独的列标记。丢弃这些记录会让成本统计在最贵的场景下系统性偏低。
+**正确做法**:`isAborted` 有意义的前提是先接上 `abortSignal`。在此之前不要为它建列、建分支。判断一个回调字段是否可达,要沿 SDK 的 runtime 反查它的触发条件,而不是看类型签名上有没有。
+
+### 手工调用回调的单测证明不了该路径可达
+
+**现象**:测试绿的功能上线后从不触发。
+
+**原因**:mock 掉 SDK 后直接调用 `onEnd`/`messageMetadata` 并自行构造入参,测的是「给定这个输入,函数怎么做」,而非「这个输入真的会出现」。
+
+**正确做法**:这类测试仍然值得写,但新增依赖 SDK 回调字段的分支时,额外确认一次该字段在本项目配置下的可达性。
 
 ---
 

--- a/src/app/api/chat/route.test.ts
+++ b/src/app/api/chat/route.test.ts
@@ -324,10 +324,7 @@ describe("/api/chat", () => {
 
     const [streamArgs] = mockCreateAgentUIStreamResponse.mock.calls[0] as [
       {
-        onEnd: (options: {
-          responseMessage: unknown;
-          isAborted: boolean;
-        }) => Promise<void>;
+        onEnd: (options: { responseMessage: unknown }) => Promise<void>;
       },
     ];
     const responseMessage = {
@@ -335,7 +332,7 @@ describe("/api/chat", () => {
       role: "assistant",
       parts: [{ type: "text", text: "Hello" }],
     };
-    await streamArgs.onEnd({ responseMessage, isAborted: false });
+    await streamArgs.onEnd({ responseMessage });
 
     expect(mockPersistGeneratedImages).toHaveBeenCalledWith({
       message: responseMessage,
@@ -356,7 +353,7 @@ describe("/api/chat", () => {
         messageMetadata: (options: { part: unknown }) => unknown;
         onEnd: (options: {
           responseMessage: unknown;
-          isAborted: boolean;
+          finishReason: string;
         }) => Promise<void>;
       },
     ];
@@ -369,12 +366,10 @@ describe("/api/chat", () => {
         response: { id: "resp_new", modelId: "gpt-5.6-luna" },
       },
     });
-    streamArgs.messageMetadata({
-      part: { type: "finish", totalUsage, finishReason: "stop" },
-    });
+    streamArgs.messageMetadata({ part: { type: "finish", totalUsage } });
     await streamArgs.onEnd({
       responseMessage: { id: "assistant-1", role: "assistant", parts: [] },
-      isAborted: false,
+      finishReason: "stop",
     });
 
     expect(mockExtractUsageTotals).toHaveBeenCalledWith(totalUsage);
@@ -387,7 +382,6 @@ describe("/api/chat", () => {
         model: "gpt-5.6-luna",
         reasoningEffort: "low",
         finishReason: "stop",
-        aborted: false,
         inputTokens: 11,
         outputTokens: 22,
         totalTokens: 33,
@@ -395,26 +389,25 @@ describe("/api/chat", () => {
     );
   });
 
-  it("still records usage when the turn was aborted", async () => {
+  it("falls back to a sentinel when the provider reports no model", async () => {
     await postChat();
 
     const [streamArgs] = mockCreateAgentUIStreamResponse.mock.calls[0] as [
       {
         onEnd: (options: {
           responseMessage: unknown;
-          isAborted: boolean;
+          finishReason: string;
         }) => Promise<void>;
       },
     ];
-    // Tokens are spent whether or not the client stayed connected; skipping
-    // aborted turns would understate cost.
+    // Unattributable spend must stay visible in aggregates, not vanish.
     await streamArgs.onEnd({
       responseMessage: { id: "assistant-1", role: "assistant", parts: [] },
-      isAborted: true,
+      finishReason: "stop",
     });
 
     expect(mockRecordAiUsageEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ aborted: true, model: "unreported" }),
+      expect.objectContaining({ model: "unreported" }),
     );
   });
 
@@ -426,7 +419,7 @@ describe("/api/chat", () => {
       {
         onEnd: (options: {
           responseMessage: unknown;
-          isAborted: boolean;
+          finishReason: string;
         }) => Promise<void>;
       },
     ];
@@ -434,7 +427,7 @@ describe("/api/chat", () => {
     await expect(
       streamArgs.onEnd({
         responseMessage: { id: "assistant-1", role: "assistant", parts: [] },
-        isAborted: false,
+        finishReason: "stop",
       }),
     ).resolves.toBeUndefined();
     expect(mockSaveAiMessages).toHaveBeenCalled();

--- a/src/app/api/chat/route.test.ts
+++ b/src/app/api/chat/route.test.ts
@@ -13,6 +13,8 @@ const mockRequireAiConversation = jest.fn();
 const mockRequireOwnedAiImageAttachments = jest.fn();
 const mockSaveAiMessages = jest.fn();
 const mockPersistGeneratedImages = jest.fn();
+const mockExtractUsageTotals = jest.fn();
+const mockRecordAiUsageEvent = jest.fn();
 
 const siteConfig = {
   features: { emailAuth: true, billing: true, uploads: true, ai: true },
@@ -68,6 +70,12 @@ jest.mock("@/lib/ai/generated-image-storage", () => ({
   persistGeneratedImages: mockPersistGeneratedImages,
 }));
 
+jest.mock("@/lib/ai/usage", () => ({
+  AI_MODEL_UNREPORTED: "unreported",
+  extractUsageTotals: mockExtractUsageTotals,
+  recordAiUsageEvent: mockRecordAiUsageEvent,
+}));
+
 const session = {
   user: {
     id: "user-1",
@@ -118,6 +126,12 @@ describe("/api/chat", () => {
     mockPersistGeneratedImages.mockImplementation(
       ({ message }: { message: unknown }) => Promise.resolve(message),
     );
+    mockExtractUsageTotals.mockReturnValue({
+      inputTokens: 11,
+      outputTokens: 22,
+      totalTokens: 33,
+    });
+    mockRecordAiUsageEvent.mockResolvedValue(undefined);
     mockCreateAgentUIStreamResponse.mockResolvedValue(
       new Response("stream", { status: 200 }),
     );
@@ -310,7 +324,10 @@ describe("/api/chat", () => {
 
     const [streamArgs] = mockCreateAgentUIStreamResponse.mock.calls[0] as [
       {
-        onEnd: (options: { responseMessage: unknown }) => Promise<void>;
+        onEnd: (options: {
+          responseMessage: unknown;
+          isAborted: boolean;
+        }) => Promise<void>;
       },
     ];
     const responseMessage = {
@@ -318,7 +335,7 @@ describe("/api/chat", () => {
       role: "assistant",
       parts: [{ type: "text", text: "Hello" }],
     };
-    await streamArgs.onEnd({ responseMessage });
+    await streamArgs.onEnd({ responseMessage, isAborted: false });
 
     expect(mockPersistGeneratedImages).toHaveBeenCalledWith({
       message: responseMessage,
@@ -329,6 +346,98 @@ describe("/api/chat", () => {
       userId: "user-1",
       messages: [responseMessage],
     });
+  });
+
+  it("records token usage for a completed turn", async () => {
+    await postChat();
+
+    const [streamArgs] = mockCreateAgentUIStreamResponse.mock.calls[0] as [
+      {
+        messageMetadata: (options: { part: unknown }) => unknown;
+        onEnd: (options: {
+          responseMessage: unknown;
+          isAborted: boolean;
+        }) => Promise<void>;
+      },
+    ];
+    const totalUsage = { inputTokens: 11, outputTokens: 22, totalTokens: 33 };
+
+    // The model is reported per step, the totals only on the final part.
+    streamArgs.messageMetadata({
+      part: {
+        type: "finish-step",
+        response: { id: "resp_new", modelId: "gpt-5.6-luna" },
+      },
+    });
+    streamArgs.messageMetadata({
+      part: { type: "finish", totalUsage, finishReason: "stop" },
+    });
+    await streamArgs.onEnd({
+      responseMessage: { id: "assistant-1", role: "assistant", parts: [] },
+      isAborted: false,
+    });
+
+    expect(mockExtractUsageTotals).toHaveBeenCalledWith(totalUsage);
+    expect(mockRecordAiUsageEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        conversationId,
+        messageId: "assistant-1",
+        agentId: "assistant",
+        model: "gpt-5.6-luna",
+        reasoningEffort: "low",
+        finishReason: "stop",
+        aborted: false,
+        inputTokens: 11,
+        outputTokens: 22,
+        totalTokens: 33,
+      }),
+    );
+  });
+
+  it("still records usage when the turn was aborted", async () => {
+    await postChat();
+
+    const [streamArgs] = mockCreateAgentUIStreamResponse.mock.calls[0] as [
+      {
+        onEnd: (options: {
+          responseMessage: unknown;
+          isAborted: boolean;
+        }) => Promise<void>;
+      },
+    ];
+    // Tokens are spent whether or not the client stayed connected; skipping
+    // aborted turns would understate cost.
+    await streamArgs.onEnd({
+      responseMessage: { id: "assistant-1", role: "assistant", parts: [] },
+      isAborted: true,
+    });
+
+    expect(mockRecordAiUsageEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ aborted: true, model: "unreported" }),
+    );
+  });
+
+  it("does not fail the turn when usage accounting throws", async () => {
+    mockRecordAiUsageEvent.mockRejectedValue(new Error("usage insert failed"));
+    await postChat();
+
+    const [streamArgs] = mockCreateAgentUIStreamResponse.mock.calls[0] as [
+      {
+        onEnd: (options: {
+          responseMessage: unknown;
+          isAborted: boolean;
+        }) => Promise<void>;
+      },
+    ];
+
+    await expect(
+      streamArgs.onEnd({
+        responseMessage: { id: "assistant-1", role: "assistant", parts: [] },
+        isAborted: false,
+      }),
+    ).resolves.toBeUndefined();
+    expect(mockSaveAiMessages).toHaveBeenCalled();
   });
 
   it("keeps consuming the response when the browser disconnects", async () => {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -201,12 +201,11 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    // `onEnd` does not carry usage, so the metadata callback captures it here:
-    // `finish` reports the turn total and `finish-step` the model that actually
-    // served it. Both are read back once the stream ends.
+    // `onEnd` carries `finishReason` but no token counts, so the metadata
+    // callback captures what it lacks: `finish` reports the turn total and
+    // `finish-step` the model that actually served it.
     const startedAt = Date.now();
     let usage: LanguageModelUsage | undefined;
-    let finishReason: string | undefined;
     let responseModelId: string | undefined;
 
     const response = await createAgentUIStreamResponse({
@@ -221,7 +220,7 @@ export async function POST(request: NextRequest) {
             console.error("AI chat background stream error:", error);
           },
         }),
-      onEnd: async ({ responseMessage, isAborted }) => {
+      onEnd: async ({ responseMessage, finishReason }) => {
         const message = await persistGeneratedImages({
           message: responseMessage as AiMessage,
           userId: session.user.id,
@@ -232,19 +231,19 @@ export async function POST(request: NextRequest) {
           messages: [message],
         });
 
-        // Accounting must never cost the user their reply. Tokens are spent
-        // even on an aborted turn, so those are recorded too: skipping them
-        // would understate cost exactly when a run is most expensive.
+        // Accounting must never cost the user their reply.
         try {
           await recordAiUsageEvent({
             userId: session.user.id,
             conversationId: parsed.data.conversationId,
             messageId: message.id,
             agentId: parsed.data.agentId,
+            // The turn total spans every step. Attributing it to one model id
+            // holds only while a single chat model serves the whole loop; per-
+            // step model selection would need per-step rows instead.
             model: responseModelId ?? AI_MODEL_UNREPORTED,
             reasoningEffort: parsed.data.reasoningEffort,
             finishReason,
-            aborted: isAborted,
             durationMs: Date.now() - startedAt,
             ...extractUsageTotals(usage),
           });
@@ -255,7 +254,6 @@ export async function POST(request: NextRequest) {
       messageMetadata: ({ part }) => {
         if (part.type === "finish") {
           usage = part.totalUsage;
-          finishReason = part.finishReason;
           return undefined;
         }
         if (part.type !== "finish-step") return undefined;

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -5,6 +5,7 @@ import {
   createAgentUIStreamResponse,
   generateId,
   validateUIMessages,
+  type LanguageModelUsage,
 } from "ai";
 import { createAgent, isAgentId } from "@/lib/ai/agents";
 import {
@@ -27,6 +28,11 @@ import {
   createResponseHandle,
   readResponseHandle,
 } from "@/lib/ai/response-chain";
+import {
+  AI_MODEL_UNREPORTED,
+  extractUsageTotals,
+  recordAiUsageEvent,
+} from "@/lib/ai/usage";
 import { getAuthSessionFromHeaders } from "@/lib/auth/session";
 import { SITE_CONFIG } from "@/lib/config/site";
 import {
@@ -195,6 +201,14 @@ export async function POST(request: NextRequest) {
   }
 
   try {
+    // `onEnd` does not carry usage, so the metadata callback captures it here:
+    // `finish` reports the turn total and `finish-step` the model that actually
+    // served it. Both are read back once the stream ends.
+    const startedAt = Date.now();
+    let usage: LanguageModelUsage | undefined;
+    let finishReason: string | undefined;
+    let responseModelId: string | undefined;
+
     const response = await createAgentUIStreamResponse({
       agent,
       uiMessages: validatedMessages,
@@ -207,7 +221,7 @@ export async function POST(request: NextRequest) {
             console.error("AI chat background stream error:", error);
           },
         }),
-      onEnd: async ({ responseMessage }) => {
+      onEnd: async ({ responseMessage, isAborted }) => {
         const message = await persistGeneratedImages({
           message: responseMessage as AiMessage,
           userId: session.user.id,
@@ -217,16 +231,42 @@ export async function POST(request: NextRequest) {
           userId: session.user.id,
           messages: [message],
         });
+
+        // Accounting must never cost the user their reply. Tokens are spent
+        // even on an aborted turn, so those are recorded too: skipping them
+        // would understate cost exactly when a run is most expensive.
+        try {
+          await recordAiUsageEvent({
+            userId: session.user.id,
+            conversationId: parsed.data.conversationId,
+            messageId: message.id,
+            agentId: parsed.data.agentId,
+            model: responseModelId ?? AI_MODEL_UNREPORTED,
+            reasoningEffort: parsed.data.reasoningEffort,
+            finishReason,
+            aborted: isAborted,
+            durationMs: Date.now() - startedAt,
+            ...extractUsageTotals(usage),
+          });
+        } catch (error) {
+          console.error("AI chat usage could not be recorded:", error);
+        }
       },
-      messageMetadata: ({ part }) =>
-        part.type === "finish-step"
-          ? {
-              responseHandle: createResponseHandle(
-                part.response.id,
-                session.user.id,
-              ),
-            }
-          : undefined,
+      messageMetadata: ({ part }) => {
+        if (part.type === "finish") {
+          usage = part.totalUsage;
+          finishReason = part.finishReason;
+          return undefined;
+        }
+        if (part.type !== "finish-step") return undefined;
+        responseModelId = part.response.modelId;
+        return {
+          responseHandle: createResponseHandle(
+            part.response.id,
+            session.user.id,
+          ),
+        };
+      },
       onError: (error) => {
         console.error("AI chat stream error:", error);
         // Keep provider error details out of the client stream.

--- a/src/database/migrations/0024_icy_crystal.sql
+++ b/src/database/migrations/0024_icy_crystal.sql
@@ -13,7 +13,6 @@ CREATE TABLE "ai_usage_events" (
 	"reasoningTokens" integer,
 	"totalTokens" integer,
 	"finishReason" text,
-	"aborted" boolean DEFAULT false NOT NULL,
 	"durationMs" integer,
 	"createdAt" timestamp with time zone DEFAULT now() NOT NULL
 );

--- a/src/database/migrations/0024_slim_rockslide.sql
+++ b/src/database/migrations/0024_slim_rockslide.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "ai_usage_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"userId" text NOT NULL,
+	"conversationId" uuid NOT NULL,
+	"messageId" text NOT NULL,
+	"agentId" text NOT NULL,
+	"model" text NOT NULL,
+	"reasoningEffort" text NOT NULL,
+	"inputTokens" integer,
+	"cacheReadTokens" integer,
+	"cacheWriteTokens" integer,
+	"outputTokens" integer,
+	"reasoningTokens" integer,
+	"totalTokens" integer,
+	"finishReason" text,
+	"aborted" boolean DEFAULT false NOT NULL,
+	"durationMs" integer,
+	"createdAt" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "ai_usage_events" ADD CONSTRAINT "ai_usage_events_userId_users_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ai_usage_events" ADD CONSTRAINT "ai_usage_events_conversationId_ai_conversations_id_fk" FOREIGN KEY ("conversationId") REFERENCES "public"."ai_conversations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "ai_usage_events_userId_createdAt_idx" ON "ai_usage_events" USING btree ("userId","createdAt" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "ai_usage_events_conversationId_idx" ON "ai_usage_events" USING btree ("conversationId");

--- a/src/database/migrations/meta/0024_snapshot.json
+++ b/src/database/migrations/meta/0024_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "c866b4b8-6849-4a11-babf-276e074a78bb",
+  "id": "0febbc88-2fa4-4bdb-8d6e-f0eced542f89",
   "prevId": "ad016ade-bb42-4481-b904-812eca09019c",
   "version": "7",
   "dialect": "postgresql",
@@ -392,13 +392,6 @@
           "type": "text",
           "primaryKey": false,
           "notNull": false
-        },
-        "aborted": {
-          "name": "aborted",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
         },
         "durationMs": {
           "name": "durationMs",

--- a/src/database/migrations/meta/0024_snapshot.json
+++ b/src/database/migrations/meta/0024_snapshot.json
@@ -1,0 +1,2364 @@
+{
+  "id": "c866b4b8-6849-4a11-babf-276e074a78bb",
+  "prevId": "ad016ade-bb42-4481-b904-812eca09019c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "accounts_userId_idx": {
+          "name": "accounts_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_conversations": {
+      "name": "ai_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_conversations_userId_archivedAt_updatedAt_idx": {
+          "name": "ai_conversations_userId_archivedAt_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_conversations_userId_users_id_fk": {
+          "name": "ai_conversations_userId_users_id_fk",
+          "tableFrom": "ai_conversations",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_messages": {
+      "name": "ai_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "ai_message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_messages_conversationId_createdAt_idx": {
+          "name": "ai_messages_conversationId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_messages_conversationId_ai_conversations_id_fk": {
+          "name": "ai_messages_conversationId_ai_conversations_id_fk",
+          "tableFrom": "ai_messages",
+          "tableTo": "ai_conversations",
+          "columnsFrom": ["conversationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ai_messages_conversationId_id_pk": {
+          "name": "ai_messages_conversationId_id_pk",
+          "columns": ["conversationId", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_messages_id_not_empty": {
+          "name": "ai_messages_id_not_empty",
+          "value": "length(\"ai_messages\".\"id\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_events": {
+      "name": "ai_usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoningEffort": {
+          "name": "reasoningEffort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputTokens": {
+          "name": "inputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cacheReadTokens": {
+          "name": "cacheReadTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cacheWriteTokens": {
+          "name": "cacheWriteTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputTokens": {
+          "name": "outputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoningTokens": {
+          "name": "reasoningTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finishReason": {
+          "name": "finishReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aborted": {
+          "name": "aborted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_usage_events_userId_createdAt_idx": {
+          "name": "ai_usage_events_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_events_conversationId_idx": {
+          "name": "ai_usage_events_conversationId_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_usage_events_userId_users_id_fk": {
+          "name": "ai_usage_events_userId_users_id_fk",
+          "tableFrom": "ai_usage_events",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_usage_events_conversationId_ai_conversations_id_fk": {
+          "name": "ai_usage_events_conversationId_ai_conversations_id_fk",
+          "tableFrom": "ai_usage_events",
+          "tableTo": "ai_conversations",
+          "columnsFrom": ["conversationId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyPrefix": {
+          "name": "keyPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastFourChars": {
+          "name": "lastFourChars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rateLimit": {
+          "name": "rateLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestCountInWindow": {
+          "name": "requestCountInWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "windowStartedAt": {
+          "name": "windowStartedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_userId_createdAt_idx": {
+          "name": "api_keys_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_keyHash_idx": {
+          "name": "api_keys_keyHash_idx",
+          "columns": [
+            {
+              "expression": "keyHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_userId_users_id_fk": {
+          "name": "api_keys_userId_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastFourChars": {
+          "name": "lastFourChars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshTokenHash": {
+          "name": "refreshTokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshExpiresAt": {
+          "name": "refreshExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceOs": {
+          "name": "deviceOs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceHostname": {
+          "name": "deviceHostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cliVersion": {
+          "name": "cliVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cli_tokens_userId_createdAt_idx": {
+          "name": "cli_tokens_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_tokens_userId_users_id_fk": {
+          "name": "cli_tokens_userId_users_id_fk",
+          "tableFrom": "cli_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_tokenHash_unique": {
+          "name": "cli_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tokenHash"]
+        },
+        "cli_tokens_refreshTokenHash_unique": {
+          "name": "cli_tokens_refreshTokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refreshTokenHash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deviceCode": {
+          "name": "deviceCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCode": {
+          "name": "userCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "lastPolledAt": {
+          "name": "lastPolledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clientName": {
+          "name": "clientName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clientVersion": {
+          "name": "clientVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceOs": {
+          "name": "deviceOs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceHostname": {
+          "name": "deviceHostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_codes_expiresAt_idx": {
+          "name": "device_codes_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_userId_users_id_fk": {
+          "name": "device_codes_userId_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_deviceCode_unique": {
+          "name": "device_codes_deviceCode_unique",
+          "nullsNotDistinct": false,
+          "columns": ["deviceCode"]
+        },
+        "device_codes_userCode_unique": {
+          "name": "device_codes_userCode_unique",
+          "nullsNotDistinct": false,
+          "columns": ["userCode"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "productId": {
+          "name": "productId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paymentId": {
+          "name": "paymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paymentIntentId": {
+          "name": "paymentIntentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paymentType": {
+          "name": "paymentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_userId_createdAt_idx": {
+          "name": "payments_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_status_currency_createdAt_idx": {
+          "name": "payments_status_currency_createdAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "currency",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_paymentIntentId_unique": {
+          "name": "payments_paymentIntentId_unique",
+          "columns": [
+            {
+              "expression": "paymentIntentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_paymentId_userId_productId_unique": {
+          "name": "payments_paymentId_userId_productId_unique",
+          "columns": [
+            {
+              "expression": "paymentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "productId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_userId_users_id_fk": {
+          "name": "payments_userId_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payments_paymentId_unique": {
+          "name": "payments_paymentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["paymentId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_entitlements": {
+      "name": "product_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "productId": {
+          "name": "productId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourcePaymentId": {
+          "name": "sourcePaymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocationReason": {
+          "name": "revocationReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_entitlements_userId_productId_unique": {
+          "name": "product_entitlements_userId_productId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "productId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_entitlements_sourcePaymentId_unique": {
+          "name": "product_entitlements_sourcePaymentId_unique",
+          "columns": [
+            {
+              "expression": "sourcePaymentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "product_entitlements_userId_createdAt_idx": {
+          "name": "product_entitlements_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_entitlements_userId_users_id_fk": {
+          "name": "product_entitlements_userId_users_id_fk",
+          "tableFrom": "product_entitlements",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_entitlements_payment_owner_product_fk": {
+          "name": "product_entitlements_payment_owner_product_fk",
+          "tableFrom": "product_entitlements",
+          "tableTo": "payments",
+          "columnsFrom": ["sourcePaymentId", "userId", "productId"],
+          "columnsTo": ["paymentId", "userId", "productId"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resetAt": {
+          "name": "resetAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_resetAt_idx": {
+          "name": "rate_limit_buckets_resetAt_idx",
+          "columns": [
+            {
+              "expression": "resetAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_buckets_scope_keyHash_pk": {
+          "name": "rate_limit_buckets_scope_keyHash_pk",
+          "columns": ["scope", "keyHash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonatedBy": {
+          "name": "impersonatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_userId_idx": {
+          "name": "sessions_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "productId": {
+          "name": "productId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastWebhookCreatedAt": {
+          "name": "lastWebhookCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_userId_createdAt_idx": {
+          "name": "subscriptions_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_customerId_idx": {
+          "name": "subscriptions_customerId_idx",
+          "columns": [
+            {
+              "expression": "customerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_userId_users_id_fk": {
+          "name": "subscriptions_userId_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_subscriptionId_unique": {
+          "name": "subscriptions_subscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["subscriptionId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_runs": {
+      "name": "task_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "task_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "scopeKey": {
+          "name": "scopeKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerJobId": {
+          "name": "providerJobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_runs_scopeKey_createdAt_idx": {
+          "name": "task_runs_scopeKey_createdAt_idx",
+          "columns": [
+            {
+              "expression": "scopeKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_status_updatedAt_idx": {
+          "name": "task_runs_status_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_scopeKey_kind_idempotencyKey_unique": {
+          "name": "task_runs_scopeKey_kind_idempotencyKey_unique",
+          "columns": [
+            {
+              "expression": "scopeKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotencyKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"task_runs\".\"idempotencyKey\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upload_intents": {
+      "name": "upload_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileKey": {
+          "name": "fileKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "upload_intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleteCheckedAt": {
+          "name": "deleteCheckedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanupAttempts": {
+          "name": "cleanupAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastCleanupError": {
+          "name": "lastCleanupError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upload_intents_fileKey_unique": {
+          "name": "upload_intents_fileKey_unique",
+          "columns": [
+            {
+              "expression": "fileKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upload_intents_userId_status_expiresAt_idx": {
+          "name": "upload_intents_userId_status_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upload_intents_cleanup_queue_idx": {
+          "name": "upload_intents_cleanup_queue_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cleanupAttempts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upload_intents_userId_users_id_fk": {
+          "name": "upload_intents_userId_users_id_fk",
+          "tableFrom": "upload_intents",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "upload_intents_fileSize_positive": {
+          "name": "upload_intents_fileSize_positive",
+          "value": "\"upload_intents\".\"fileSize\" > 0"
+        },
+        "upload_intents_cleanupAttempts_non_negative": {
+          "name": "upload_intents_cleanupAttempts_non_negative",
+          "value": "\"upload_intents\".\"cleanupAttempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.uploads": {
+      "name": "uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploadIntentId": {
+          "name": "uploadIntentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileKey": {
+          "name": "fileKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uploads_userId_createdAt_idx": {
+          "name": "uploads_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uploads_uploadIntentId_unique": {
+          "name": "uploads_uploadIntentId_unique",
+          "columns": [
+            {
+              "expression": "uploadIntentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uploads_fileKey_unique": {
+          "name": "uploads_fileKey_unique",
+          "columns": [
+            {
+              "expression": "fileKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploads_userId_users_id_fk": {
+          "name": "uploads_userId_users_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploads_uploadIntentId_upload_intents_id_fk": {
+          "name": "uploads_uploadIntentId_upload_intents_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "upload_intents",
+          "columnsFrom": ["uploadIntentId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "uploads_fileSize_positive": {
+          "name": "uploads_fileSize_positive",
+          "value": "\"uploads\".\"fileSize\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentProviderCustomerId": {
+          "name": "paymentProviderCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_paymentProviderCustomerId_unique": {
+          "name": "users_paymentProviderCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["paymentProviderCustomerId"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_events_provider_eventId_unique": {
+          "name": "webhook_events_provider_eventId_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_events_provider_idx": {
+          "name": "webhook_events_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.ai_message_role": {
+      "name": "ai_message_role",
+      "schema": "public",
+      "values": ["system", "user", "assistant"]
+    },
+    "public.task_run_status": {
+      "name": "task_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "waiting",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.upload_intent_status": {
+      "name": "upload_intent_status",
+      "schema": "public",
+      "values": ["pending", "cancelled", "cleaning", "completed"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["user", "admin", "super_admin"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1787408998399,
       "tag": "0023_wet_serpent_society",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1787458028543,
+      "tag": "0024_slim_rockslide",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -173,8 +173,8 @@
     {
       "idx": 24,
       "version": "7",
-      "when": 1787458028543,
-      "tag": "0024_slim_rockslide",
+      "when": 1787461190942,
+      "tag": "0024_icy_crystal",
       "breakpoints": true
     }
   ]

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -417,7 +417,6 @@ export const aiUsageEvents = pgTable(
     reasoningTokens: integer("reasoningTokens"),
     totalTokens: integer("totalTokens"),
     finishReason: text("finishReason"),
-    aborted: boolean("aborted").notNull().default(false),
     durationMs: integer("durationMs"),
     createdAt: timestamp("createdAt", { withTimezone: true })
       .notNull()

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -391,6 +391,49 @@ export const aiMessages = pgTable(
   }),
 );
 
+/**
+ * One row per completed assistant turn. Token columns stay nullable because a
+ * provider may omit any of them; storing 0 for "unknown" would silently
+ * understate cost once these rows drive billing or quota decisions.
+ */
+export const aiUsageEvents = pgTable(
+  "ai_usage_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: text("userId")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    conversationId: uuid("conversationId")
+      .notNull()
+      .references(() => aiConversations.id, { onDelete: "cascade" }),
+    messageId: text("messageId").notNull(),
+    agentId: text("agentId").notNull(),
+    model: text("model").notNull(),
+    reasoningEffort: text("reasoningEffort").notNull(),
+    inputTokens: integer("inputTokens"),
+    cacheReadTokens: integer("cacheReadTokens"),
+    cacheWriteTokens: integer("cacheWriteTokens"),
+    outputTokens: integer("outputTokens"),
+    reasoningTokens: integer("reasoningTokens"),
+    totalTokens: integer("totalTokens"),
+    finishReason: text("finishReason"),
+    aborted: boolean("aborted").notNull().default(false),
+    durationMs: integer("durationMs"),
+    createdAt: timestamp("createdAt", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => ({
+    userCreatedAtIdx: index("ai_usage_events_userId_createdAt_idx").on(
+      table.userId,
+      table.createdAt.desc(),
+    ),
+    conversationIdx: index("ai_usage_events_conversationId_idx").on(
+      table.conversationId,
+    ),
+  }),
+);
+
 export const taskRuns = pgTable(
   "task_runs",
   {

--- a/src/database/tables.ts
+++ b/src/database/tables.ts
@@ -18,6 +18,7 @@ import {
   aiConversations,
   aiMessages,
   aiMessageRoleEnum,
+  aiUsageEvents,
   taskRuns,
   taskRunStatusEnum,
 } from "./schema";
@@ -42,6 +43,7 @@ export {
   aiConversations,
   aiMessages,
   aiMessageRoleEnum,
+  aiUsageEvents,
   taskRuns,
   taskRunStatusEnum,
 };

--- a/src/lib/ai/usage.test.ts
+++ b/src/lib/ai/usage.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "@jest/globals";
+import type { LanguageModelUsage } from "ai";
+import { extractUsageTotals } from "./usage";
+
+function usage(overrides: Partial<LanguageModelUsage>): LanguageModelUsage {
+  return {
+    inputTokens: undefined,
+    inputTokenDetails: {
+      noCacheTokens: undefined,
+      cacheReadTokens: undefined,
+      cacheWriteTokens: undefined,
+    },
+    outputTokens: undefined,
+    outputTokenDetails: {
+      textTokens: undefined,
+      reasoningTokens: undefined,
+    },
+    totalTokens: undefined,
+    ...overrides,
+  } as LanguageModelUsage;
+}
+
+describe("extractUsageTotals", () => {
+  it("flattens the nested provider shape into persisted columns", () => {
+    expect(
+      extractUsageTotals(
+        usage({
+          inputTokens: 100,
+          inputTokenDetails: {
+            noCacheTokens: 60,
+            cacheReadTokens: 30,
+            cacheWriteTokens: 10,
+          },
+          outputTokens: 50,
+          outputTokenDetails: { textTokens: 20, reasoningTokens: 30 },
+          totalTokens: 150,
+        }),
+      ),
+    ).toEqual({
+      inputTokens: 100,
+      cacheReadTokens: 30,
+      cacheWriteTokens: 10,
+      outputTokens: 50,
+      reasoningTokens: 30,
+      totalTokens: 150,
+    });
+  });
+
+  it("keeps unreported fields undefined instead of defaulting to zero", () => {
+    // A provider that reports no cache tokens is not the same as one that
+    // reports zero; collapsing the two would understate cost silently.
+    expect(extractUsageTotals(usage({ inputTokens: 7 }))).toEqual({
+      inputTokens: 7,
+      cacheReadTokens: undefined,
+      cacheWriteTokens: undefined,
+      outputTokens: undefined,
+      reasoningTokens: undefined,
+      totalTokens: undefined,
+    });
+  });
+
+  it("returns an all-undefined record when usage is missing entirely", () => {
+    expect(extractUsageTotals(undefined)).toEqual({
+      inputTokens: undefined,
+      cacheReadTokens: undefined,
+      cacheWriteTokens: undefined,
+      outputTokens: undefined,
+      reasoningTokens: undefined,
+      totalTokens: undefined,
+    });
+  });
+
+  it("drops non-finite counts that an integer column cannot hold", () => {
+    expect(
+      extractUsageTotals(
+        usage({
+          inputTokens: Number.NaN,
+          outputTokens: Number.POSITIVE_INFINITY,
+        }),
+      ),
+    ).toMatchObject({ inputTokens: undefined, outputTokens: undefined });
+  });
+
+  it("normalizes fractional and negative counts", () => {
+    expect(
+      extractUsageTotals(usage({ inputTokens: 10.6, outputTokens: -5 })),
+    ).toMatchObject({ inputTokens: 11, outputTokens: 0 });
+  });
+});

--- a/src/lib/ai/usage.test.ts
+++ b/src/lib/ai/usage.test.ts
@@ -81,9 +81,9 @@ describe("extractUsageTotals", () => {
     ).toMatchObject({ inputTokens: undefined, outputTokens: undefined });
   });
 
-  it("normalizes fractional and negative counts", () => {
+  it("normalizes fractional counts and rejects negative ones", () => {
     expect(
       extractUsageTotals(usage({ inputTokens: 10.6, outputTokens: -5 })),
-    ).toMatchObject({ inputTokens: 11, outputTokens: 0 });
+    ).toMatchObject({ inputTokens: 11, outputTokens: undefined });
   });
 });

--- a/src/lib/ai/usage.ts
+++ b/src/lib/ai/usage.ts
@@ -35,14 +35,17 @@ export interface AiUsageEventInput extends AiUsageTotals {
   model: string;
   reasoningEffort: ReasoningEffort;
   finishReason?: string;
-  aborted: boolean;
   durationMs?: number;
 }
 
-/** Keeps a non-finite value (NaN, Infinity) from reaching an integer column. */
+/**
+ * Rejects anything an integer token column cannot honestly hold. A negative or
+ * non-finite count is corrupt rather than zero, and this module treats absent
+ * as absent — see `AiUsageTotals` for why 0 is not a safe stand-in.
+ */
 function toTokenCount(value: number | undefined): number | undefined {
-  return typeof value === "number" && Number.isFinite(value)
-    ? Math.max(0, Math.round(value))
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.round(value)
     : undefined;
 }
 
@@ -77,7 +80,6 @@ export async function recordAiUsageEvent(
     reasoningTokens: event.reasoningTokens,
     totalTokens: event.totalTokens,
     finishReason: event.finishReason,
-    aborted: event.aborted,
     durationMs: event.durationMs,
   });
 }

--- a/src/lib/ai/usage.ts
+++ b/src/lib/ai/usage.ts
@@ -1,0 +1,83 @@
+import "server-only";
+
+import type { LanguageModelUsage } from "ai";
+import { db } from "@/database";
+import { aiUsageEvents } from "@/database/schema";
+import type { ReasoningEffort } from "./reasoning";
+
+/**
+ * Stand-in for `model` when the provider omits `response.modelId`. A sentinel
+ * keeps the column NOT NULL and makes unattributable spend visible in
+ * aggregates instead of hiding it behind an empty string.
+ */
+export const AI_MODEL_UNREPORTED = "unreported";
+
+/**
+ * Token counts for one assistant turn. Every field is optional because the
+ * SDK types each of them as `number | undefined`: a provider may report only
+ * a subset. Absent stays absent all the way to the database — see the note on
+ * `aiUsageEvents` for why 0 is not an acceptable stand-in.
+ */
+export interface AiUsageTotals {
+  inputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  outputTokens?: number;
+  reasoningTokens?: number;
+  totalTokens?: number;
+}
+
+export interface AiUsageEventInput extends AiUsageTotals {
+  userId: string;
+  conversationId: string;
+  messageId: string;
+  agentId: string;
+  model: string;
+  reasoningEffort: ReasoningEffort;
+  finishReason?: string;
+  aborted: boolean;
+  durationMs?: number;
+}
+
+/** Keeps a non-finite value (NaN, Infinity) from reaching an integer column. */
+function toTokenCount(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, Math.round(value))
+    : undefined;
+}
+
+/** Flattens the SDK's nested usage shape into the columns we persist. */
+export function extractUsageTotals(
+  usage: LanguageModelUsage | undefined,
+): AiUsageTotals {
+  return {
+    inputTokens: toTokenCount(usage?.inputTokens),
+    cacheReadTokens: toTokenCount(usage?.inputTokenDetails?.cacheReadTokens),
+    cacheWriteTokens: toTokenCount(usage?.inputTokenDetails?.cacheWriteTokens),
+    outputTokens: toTokenCount(usage?.outputTokens),
+    reasoningTokens: toTokenCount(usage?.outputTokenDetails?.reasoningTokens),
+    totalTokens: toTokenCount(usage?.totalTokens),
+  };
+}
+
+export async function recordAiUsageEvent(
+  event: AiUsageEventInput,
+): Promise<void> {
+  await db.insert(aiUsageEvents).values({
+    userId: event.userId,
+    conversationId: event.conversationId,
+    messageId: event.messageId,
+    agentId: event.agentId,
+    model: event.model,
+    reasoningEffort: event.reasoningEffort,
+    inputTokens: event.inputTokens,
+    cacheReadTokens: event.cacheReadTokens,
+    cacheWriteTokens: event.cacheWriteTokens,
+    outputTokens: event.outputTokens,
+    reasoningTokens: event.reasoningTokens,
+    totalTokens: event.totalTokens,
+    finishReason: event.finishReason,
+    aborted: event.aborted,
+    durationMs: event.durationMs,
+  });
+}


### PR DESCRIPTION
调研 [vercel-labs/open-agents](https://github.com/vercel-labs/open-agents) 后落地的两项改进。

Closes #92
Closes #94

## 1. AI token 用量记账 (#92)

此前 `POST /api/chat` 的 `onEnd` 只保存消息,**token 用量完全没有落库**。对一个卖订阅的产品来说,这意味着没有成本归因、无法做配额、无法按量计费——唯一的护栏是「30 次 / 10 分钟」的请求数限流,而一次 `high` reasoning + 图片生成的成本可能是简单问答的几十倍。

新增 `ai_usage_events` 表,每轮助手响应写入一行:用户、会话、消息、agent、模型、reasoning effort、token 数、finish reason、耗时。

### 两个容易踩错的点

**用量不在 `onEnd` 里。** `ai@7` 的 `UIMessageStreamOnEndCallback` 事件只有 `{ messages, isContinuation, isAborted, responseMessage, finishReason }`,不含 usage。改由已有的 `messageMetadata` 回调捕获——`finish` part 带整轮 `totalUsage`,`finish-step` 带 `response.modelId`(provider 实际使用的模型,比读配置准确)。捕获到闭包变量,由 `onEnd` 统一写库。

用量**不进** `messageMetadata` 的返回值——那是要发给客户端的。

**只统计语言模型 token。** `generateImage` 是 provider-executed tool,其 token 不进 `LanguageModelUsage`,图像成本需另找来源。`model` 列记录最后一步的模型,仅在单模型配置下准确。

### 设计取舍

- **token 列全部可空。** SDK 把每个字段都标注为 `number | undefined`——provider 未上报和上报为 0 是两回事。用 `0` 冒充「未知」会让后续核算悄悄偏低。
- **记账失败不影响用户。** try/catch + `console.error`,与既有 `persistGeneratedImages` 的容错风格一致。对话本身的优先级高于账本。
- **`model` 用 `unreported` 哨兵值**而非空串,让不可归因的花费在聚合里可见。

范围限定在**只记账、不执行配额**——先有数据,再谈策略。成本金额换算(需模型价目表)和用量看板未包含。

## 2. `docs/lessons-learned.md` (#94)

open-agents 信息密度最高的文件是 `docs/agents/lessons-learned.md`(114 条),被其 `AGENTS.md` 引用,即每次 agent 运行前都会读到。

我们有规则(`AGENTS.md`)但没有踩坑记录。两者性质不同:规则回答「应该怎么做」,教训回答「这么做会炸」。后者对 agent 辅助开发价值更高,因为模型的先验知识往往正好站在错误的一边。

首批四条全部来自本仓库真实经历,其中一条就是本次开发中踩到的:

> **新增表必须同时登记到 `src/database/tables.ts`**
> 在 `schema.ts` 加表后,`pnpm type-check` 会在**完全无关**的 `src/lib/billing/stripe/webhook.ts` 报几十行类型错误。原因是 `db` 实例用的是手工维护的 `./tables` 白名单,而 `Tx` 类型引用 `./schema` 全量,两者不一致时错误在最先使用 `Tx` 的文件爆出来。

`AGENTS.md` 加了一行引用,并明确分工:规则留在 `AGENTS.md`,不迁移。

## 文档

`docs/ai-agent.md` 新增「Usage accounting」小节并更新架构树,保持文档与代码一致(AGENTS.md §1)。

## 验证

| 检查 | 结果 |
| :--- | :--- |
| `pnpm lint` | ✅ |
| `pnpm type-check` | ✅ |
| `pnpm prettier:check` | ✅ |
| `pnpm dead-code:check` | ✅ |
| `pnpm test` | ✅ 154 suites / 1243 tests |
| `pnpm build` | ✅ 含 worker 产物 |

新增测试:`src/lib/ai/usage.test.ts`(5 例,覆盖 `undefined` 保留、非有限值、小数归一化与负值拒绝),`route.test.ts` 补 3 例(正常记账、模型缺失回退哨兵值、记账抛错不影响回复)。

迁移 `0024_slim_rockslide.sql` 已提交,只新增一张表,无破坏性变更。按 AGENTS.md §8 用 `db:generate` 生成,未使用 `db:push`。

## 未包含

本地未跑 E2E——本次无用户可见流程变更,`e2e/ai-assistant.spec.ts` 覆盖的页面与拒绝路径均未触及。CI 的 `validate` job 已对 `saas_e2e` 库跑完整套 E2E 并通过,同时校验了迁移历史无漂移(`db:generate` 后 diff 为空)并实跑了 `db:migrate`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review 后的修正 (dd97991)

独立审查发现并已修掉三处:

1. **`aborted` 列不可达,已移除。** `isAborted` 只在流中出现 abort chunk 时为真,而该 chunk 只在 `abortSignal.aborted` 时产生——我们既没传 `abortSignal` 也没配 `timeout`,且 `consumeSseStream` 刻意让浏览器断开后继续消费。原测试直接手工调用 `onEnd({ isAborted: true })` 才通过,证明不了路径可达。
2. **`finishReason` 本就在 `onEnd` 事件上**,不必用闭包从 `finish` part 捕获。
3. **`toTokenCount` 把负数压成 0**,与本模块「0 不能冒充未知」的策略自相矛盾,改为 `undefined`。

文档同步修正:`lessons-learned.md` 里「中止的回合同样消耗 token」并非真实经历,违反了本文件自身在同一 PR 中定下的写入规范,已删除,替换为这次真实踩到的两条。迁移 0024 尚未合入 main,直接重新生成而非追加 drop column。
