### PR TITLE
feat(ai): saveDocument 成功后在聊天区给出文件链接

### DIFF
--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -168,6 +168,11 @@ A denied call ends up in the `output-denied` state and the model is told the use
 tools should still return a plain result object on business failures (quota exhausted, file too
 large) rather than throwing.
 
+Show the user what a write tool produced. `ToolCallRow` renders `saveDocument`'s output as a link
+to the stored file; without that the transcript reads "Used saveDocument" and the user who just
+granted permission cannot tell where the file went. Because business failures arrive on the same
+`output-available` state, `readSavedDocument` checks the shape instead of assuming it.
+
 ## Adding a skill
 
 A skill bundles a system-prompt fragment with the tools it needs, so one import gives an agent

--- a/e2e/ai-assistant.spec.ts
+++ b/e2e/ai-assistant.spec.ts
@@ -335,7 +335,11 @@ test("asks before running a write tool and resumes once approved", async ({
     {
       type: "tool-output-available",
       toolCallId: "call-1",
-      output: { fileName: "launch-plan.md", fileSize: 13, url: "https://x/y" },
+      output: {
+        fileName: "launch-plan.md",
+        fileSize: 2048,
+        url: "https://cdn.example.com/launch-plan.md",
+      },
     },
     { type: "start-step" },
     { type: "text-start", id: "t1" },
@@ -415,6 +419,11 @@ test("asks before running a write tool and resumes once approved", async ({
   await page.getByRole("button", { name: "Allow", exact: true }).click();
 
   await expect(page.getByText("Saved launch-plan.md.")).toBeVisible();
+  // The saved file has to be reachable from the transcript, not just described.
+  await expect(
+    page.getByRole("link", { name: /launch-plan\.md/ }),
+  ).toHaveAttribute("href", "https://cdn.example.com/launch-plan.md");
+  await expect(page.getByText("Saved to your files · 2 KB")).toBeVisible();
   const secondBody = await page.evaluate(
     () =>
       (window as unknown as { __chatRequestBodies: string[] })

--- a/src/app/dashboard/ai/_components/chat-panel.test.tsx
+++ b/src/app/dashboard/ai/_components/chat-panel.test.tsx
@@ -329,6 +329,94 @@ describe("ChatPanel", () => {
     expect(screen.queryByText("Running saveDocument…")).toBeNull();
   });
 
+  it("links to the file a saved document produced", () => {
+    const message: AiMessage = {
+      id: "assistant-saved",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-saveDocument",
+          toolCallId: "call-1",
+          state: "output-available",
+          input: { fileName: "launch-plan.md", content: "# Launch plan" },
+          output: {
+            fileName: "launch-plan.md",
+            fileSize: 2048,
+            url: "https://cdn.example.com/launch-plan.md",
+          },
+          approval: { id: "approval-1", approved: true },
+        },
+      ],
+    };
+
+    render(
+      <ChatPanel
+        {...handlers}
+        messages={[message]}
+        input=""
+        status="ready"
+        reasoningEffort="medium"
+        canvasCount={0}
+        canvasOpen={false}
+        conversationLoading={false}
+        imageAttachments={[]}
+        imageUploadsEnabled={false}
+        imageUploadError={false}
+        canAddImage={false}
+        onInputChange={jest.fn()}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: /launch-plan\.md/ });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://cdn.example.com/launch-plan.md",
+    );
+    expect(screen.getByText("Saved to your files · 2 KB")).toBeVisible();
+    // The generic tool row would hide where the file went.
+    expect(screen.queryByText("Used saveDocument")).toBeNull();
+  });
+
+  it("falls back to the generic row when a save reports a failure", () => {
+    const message: AiMessage = {
+      id: "assistant-quota",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-saveDocument",
+          toolCallId: "call-1",
+          state: "output-available",
+          input: { fileName: "launch-plan.md", content: "# Launch plan" },
+          output: { error: "The user's total storage quota is full." },
+          approval: { id: "approval-1", approved: true },
+        },
+      ],
+    };
+
+    render(
+      <ChatPanel
+        {...handlers}
+        messages={[message]}
+        input=""
+        status="ready"
+        reasoningEffort="medium"
+        canvasCount={0}
+        canvasOpen={false}
+        conversationLoading={false}
+        imageAttachments={[]}
+        imageUploadsEnabled={false}
+        imageUploadError={false}
+        canAddImage={false}
+        onInputChange={jest.fn()}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Used saveDocument")).toBeVisible();
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
   it("does not submit Enter while an IME composition is active", () => {
     const { input, onSubmit } = renderComposer();
 

--- a/src/app/dashboard/ai/_components/chat-panel.tsx
+++ b/src/app/dashboard/ai/_components/chat-panel.tsx
@@ -4,7 +4,9 @@ import { useEffect, useRef, useState } from "react";
 import {
   ChevronDown,
   CircleAlert,
+  ExternalLink,
   FileOutput,
+  FileText,
   History,
   ImagePlus,
   Loader2,
@@ -60,8 +62,10 @@ import {
   AI_IMAGE_INPUT_MAX_FILES,
   AI_IMAGE_INPUT_MEDIA_TYPES,
 } from "@/lib/ai/image-input";
+import { formatFileSize } from "@/lib/config/upload";
 import { useTranslation } from "@/lib/i18n/translation/client";
 import { cn } from "@/lib/utils";
+import { readSavedDocument } from "./saved-document";
 import { findActiveToolApprovalId } from "./tool-approval";
 
 interface ChatPanelProps {
@@ -281,6 +285,34 @@ function ToolCallRow({
   const isArtifact =
     part.state === "output-available" &&
     (name === "presentArtifact" || name === "generateImage");
+  const savedDocument =
+    part.state === "output-available" && name === "saveDocument"
+      ? readSavedDocument(part.output)
+      : null;
+
+  if (savedDocument) {
+    return (
+      <a
+        href={savedDocument.url}
+        target="_blank"
+        rel="noreferrer"
+        className="bg-muted/40 hover:bg-muted my-2 flex w-full items-center gap-3 border px-3 py-2 text-sm transition-colors"
+      >
+        <FileText className="text-muted-foreground size-4 shrink-0" />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate font-medium" translate="no">
+            {savedDocument.fileName}
+          </span>
+          <span className="text-muted-foreground text-xs">
+            {t("ai_chat_document_saved", {
+              size: formatFileSize(savedDocument.fileSize),
+            })}
+          </span>
+        </span>
+        <ExternalLink className="text-muted-foreground size-4 shrink-0" />
+      </a>
+    );
+  }
 
   if (isArtifact) {
     return (

--- a/src/app/dashboard/ai/_components/saved-document.test.ts
+++ b/src/app/dashboard/ai/_components/saved-document.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "@jest/globals";
+import { readSavedDocument } from "./saved-document";
+
+describe("readSavedDocument", () => {
+  it("reads a successful save", () => {
+    expect(
+      readSavedDocument({
+        fileName: "launch-plan.md",
+        fileSize: 13,
+        url: "https://cdn.example.com/launch-plan.md",
+      }),
+    ).toEqual({
+      fileName: "launch-plan.md",
+      fileSize: 13,
+      url: "https://cdn.example.com/launch-plan.md",
+    });
+  });
+
+  it("ignores a reported failure", () => {
+    // The tool returns business failures as a successful output, so a quota
+    // error must not render as a saved file.
+    expect(
+      readSavedDocument({ error: "The user's total storage quota is full." }),
+    ).toBeNull();
+  });
+
+  it("rejects a URL that is not HTTP(S)", () => {
+    expect(
+      readSavedDocument({
+        fileName: "launch-plan.md",
+        fileSize: 13,
+        url: "javascript:alert(1)",
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["a missing file name", { fileSize: 13, url: "https://x/y" }],
+    ["an empty file name", { fileName: "", fileSize: 13, url: "https://x/y" }],
+    [
+      "a non-numeric size",
+      { fileName: "a.md", fileSize: "13", url: "https://x/y" },
+    ],
+    ["a malformed URL", { fileName: "a.md", fileSize: 13, url: "not-a-url" }],
+    ["a non-object output", "saved"],
+  ])("returns nothing for %s", (_label, output) => {
+    expect(readSavedDocument(output)).toBeNull();
+  });
+});

--- a/src/app/dashboard/ai/_components/saved-document.ts
+++ b/src/app/dashboard/ai/_components/saved-document.ts
@@ -1,0 +1,41 @@
+export interface SavedDocument {
+  fileName: string;
+  fileSize: number;
+  url: string;
+}
+
+/**
+ * Reads the file a successful `saveDocument` call produced.
+ *
+ * The tool reports business failures as `{ error }` on the same successful
+ * output, so the shape has to be checked rather than assumed.
+ */
+export function readSavedDocument(output: unknown): SavedDocument | null {
+  if (typeof output !== "object" || output === null) {
+    return null;
+  }
+
+  const { fileName, fileSize, url } = output as Record<string, unknown>;
+  if (
+    typeof fileName !== "string" ||
+    fileName.length === 0 ||
+    typeof fileSize !== "number" ||
+    !Number.isFinite(fileSize) ||
+    typeof url !== "string"
+  ) {
+    return null;
+  }
+
+  // The URL is rendered as a link, so anything but HTTP(S) is dropped rather
+  // than trusted: `javascript:` in an href would execute on click.
+  try {
+    const { protocol } = new URL(url);
+    if (protocol !== "https:" && protocol !== "http:") {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  return { fileName, fileSize, url };
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1035,6 +1035,7 @@
   "ai_chat_message_actions": "Message actions",
   "ai_chat_artifact_ready": "Document ready in canvas",
   "ai_chat_image_ready": "Image ready in canvas",
+  "ai_chat_document_saved": "Saved to your files · {size}",
   "ai_chat_disclaimer": "AI can make mistakes. Check important information.",
   "ai_history_title": "Chat history",
   "ai_history_archived_title": "Archived chats",

--- a/src/messages/zh-Hans.json
+++ b/src/messages/zh-Hans.json
@@ -1035,6 +1035,7 @@
   "ai_chat_message_actions": "消息操作",
   "ai_chat_artifact_ready": "文档已在画布中生成",
   "ai_chat_image_ready": "图片已在画布中生成",
+  "ai_chat_document_saved": "已存入你的文件 · {size}",
   "ai_chat_disclaimer": "AI 可能会出错，请核对重要信息。",
   "ai_history_title": "聊天记录",
   "ai_history_archived_title": "已归档对话",


### PR DESCRIPTION
Closes #103。

## 做了什么

`saveDocument` 成功后，聊天区渲染一行文件卡片：文件名、大小、指向 R2 对象的外链。此前它和 `getCurrentTime` 这类只读工具长得一模一样，只有一行「已调用 saveDocument」——用户刚为一个写操作点了「允许」，却看不到文件叫什么、存到哪、怎么打开。

**没有走 canvas。** canvas 服务的是「模型生成、尚未落地」的内容（`presentArtifact` / `generateImage`），而 `saveDocument` 的产物已经是用户文件库里的一个真实对象，它需要的是一个能点开的链接，不是一个预览面板。

## `readSavedDocument` 为什么要校验形状

两个原因，都不是防御性编程的客套话：

1. **配额不足、文件过大这类业务失败，是以 `{ error }` 挂在同一个 `output-available` 状态上返回的**（工具不抛异常，好让模型能把原因讲给用户）。直接取 `output.fileName` 会把一次失败渲染成一个文件名为 `undefined` 的卡片。
2. **`url` 会进 `href`**。它来自工具输出，虽然当前由 `buildR2PublicUrl` 生成，但解析器不该依赖调用方的善意——`javascript:` 协议在 `href` 里是会执行的。所以非 HTTP(S) 一律丢弃。

## 验证

- `pnpm lint` / `type-check` / `dead-code:check` / `build` / `prettier:check` 通过
- `pnpm test` 158 suites / 1270 tests 全绿（新增 10 条：解析器的 6 个边界 + 渲染文件行 + 失败时回落到通用行）
- `pnpm test:e2e` 17/17 通过，审批用例末尾补了对链接 `href` 和大小文案的断言

**未覆盖**：E2E 的 `tool-output-available` 是 stub 出来的，服务端真实写入 R2 后再渲染这条链路没有端到端覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)