### PR TITLE
feat: establish UllrAI design system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This file is the single source of truth for repository-specific agent instructio
 - Prefer simple modules, low cyclomatic complexity, and reusable logic.
 - Check existing patterns before adding new abstractions.
 - Keep user-visible behavior complete. Do not leave mock data, placeholder flows, or half-finished paths.
+- Read `design.md` before user-facing design or UI work. It is the repository's visual and interaction source of truth.
 - When documentation in this file conflicts with the codebase, verify the codebase and update the documentation to match reality.
 - Read `docs/lessons-learned.md` before non-trivial work. It records counter-intuitive failures this repository has actually hit, which is exactly where prior knowledge tends to be wrong. Add an entry whenever you lose time to a surprise.
 

--- a/design.md
+++ b/design.md
@@ -1,0 +1,333 @@
+---
+name: ullrai-design-guidelines
+description: "Design and implementation rules for UllrAI SaaS Starter surfaces. Use for every user-facing page, component, email, and generated product UI."
+---
+
+# Design UllrAI surfaces with clarity and edge
+
+This document is the design source of truth for the repository. It adapts the
+decision-first structure, typographic discipline, shared grid, restraint, and
+accessibility standards of [Vercel's design guidance](https://vercel.com/design.md)
+to UllrAI's actual product. It does not copy Vercel's monochrome brand or
+product chrome.
+
+UllrAI should feel precise, direct, technical, and ready for production. The
+visual signature is a cool indigo primary, square geometry, visible structure,
+and compact evidence-led composition. Confidence comes from clear hierarchy and
+working product states, not decoration.
+
+## Protect these priorities
+
+When requirements compete, protect them in this order:
+
+1. Preserve user data, meaning, permissions, localization, and task accuracy.
+2. Make the user's goal, current state, and next action immediately clear.
+3. Preserve the repository's framework, semantic containers, tokens, and UI
+   primitives.
+4. Maintain UllrAI authorship through indigo, square geometry, strong type, and
+   disciplined borders.
+5. Refine responsive behavior, accessibility, and details without weakening
+   the hierarchy.
+
+## Brand character
+
+- **Square and engineered.** The default radius is zero. Controls, panels,
+  cards, code blocks, previews, badges, and menus use square corners.
+- **Indigo, not monochrome.** Keep the existing `primary` indigo as the main
+  action and emphasis color. Never replace it with Vercel black.
+- **Calm, not sterile.** Use indigo and measured contrast to establish a focal
+  point. Supporting surfaces stay quiet.
+- **Direct, not promotional.** Prefer concrete outcomes and real capabilities
+  over hype, generic praise, or invented certainty.
+- **Structured, not boxed.** Use spacing, alignment, and dividers before adding
+  another container.
+
+The following shapes are intentional exceptions to square geometry because the
+shape carries meaning: avatars, status dots, switch tracks and thumbs, loading
+spinners, chart points, and circular icon-only controls whose hit area remains
+clear. A badge, tab, card, input, dialog, or ordinary button is not an exception.
+
+## Color and tokens
+
+`styles/theme.css` owns all application color, radius, shadow, and typography
+tokens. Components consume semantic tokens instead of literal colors.
+
+- `background` is the continuous page canvas.
+- `card` is a neutral grouped surface, not a default wrapper for every section.
+- `muted` supports secondary regions and passive states.
+- `primary` is reserved for the primary action, selected state, focus, key link,
+  or the single strongest visual anchor in a section.
+- `destructive` communicates destructive or failed states only.
+- `border` separates real regions. Stronger hierarchy uses a two-pixel border,
+  not a soft shadow.
+- Chart colors encode distinct series or states and must never be the only cue.
+
+Both light and dark themes must preserve the same hierarchy. Do not introduce a
+third page-local palette or hardcoded product color. Black media scrims are
+allowed only when necessary to keep text or controls readable over an image or
+video.
+
+## Depth and boundaries
+
+The default surface is flat. Cards and inputs do not receive ambient shadows.
+Use borders, background contrast, and whitespace first.
+
+Hard offset shadows may be used for one deliberately elevated or illustrative
+object, such as the homepage product preview. Floating overlays may use one
+small hard shadow to separate them from the page. Do not use blur-heavy shadows,
+glows, glass effects, backdrop blur, or nested elevation.
+
+Every border must explain a boundary, selection, warning, table row, or control.
+If removing a border does not reduce comprehension, remove it.
+
+## Typography
+
+Inter is the Latin interface and reading typeface; Simplified Chinese uses the
+platform sans-serif fallback. JetBrains Mono is reserved for commands, paths,
+code, tokens, timestamps, identifiers, and aligned technical values. Do not set
+ordinary prices, dates, labels, or prose in monospace.
+
+Use the existing Tailwind type scale. Do not add arbitrary font sizes when a
+named scale step works.
+
+- One page-defining `h1` establishes the first read.
+- Section headings state a concrete question, capability, or outcome.
+- Body copy uses regular weight and a comfortable line height.
+- Labels are sentence case. Do not use all-caps, wide tracking, decorative
+  eyebrows, or numbered section ornaments.
+- Equivalent peers use identical size, weight, leading, and numeric treatment.
+- Reading prose should remain near 60–68 characters per line.
+- Large text should wrap intentionally. Fix copy or measure before shrinking it.
+
+Use full sentences rather than concatenated fragments. User-visible copy must
+live in both locale catalogs and follow the repository's `next-intl` rules.
+
+## Grid, containers, and spacing
+
+Use the semantic containers in `src/components/layout/page-container.tsx`:
+
+- `ShellContainer` for global chrome and wide product compositions.
+- `SectionContainer` for standard marketing sections and page bodies.
+- `ReadingContainer` for articles and legal content.
+- `CompactContainer` for authentication forms.
+- `FocusContainer` for status pages and bounded single-task flows.
+
+Full-bleed background and content width are separate decisions. A full-width
+section still places its content in a semantic container.
+
+Use a shared edge and a stable reading path. Desktop compositions may use 12
+columns, tablet 6, and mobile 4. Major comparisons, admin tables, charts, upload
+workbenches, and AI canvases may use the full available width. Prose should not.
+
+Spacing communicates relationships:
+
+- Heading to its first paragraph is close.
+- Items inside a component use compact gaps.
+- Peer groups use consistent gaps and aligned internal rows.
+- A new section receives clearly more space than a new paragraph.
+- One parent owns each gap; avoid stacked margins from both parent and child.
+
+Avoid equal card grids when the content is not truly peer information. Let the
+decisive capability or action take more space when it matters.
+
+## Composition
+
+The first viewport must reveal what the surface is for, what state it is in, and
+what the user can do next. It should not be a ceremonial title followed by a
+generic card grid.
+
+Choose geometry before components:
+
+- Comparison: aligned rows or columns on the same visual basis.
+- Process or dependency: sequence and connection.
+- Magnitude or rank: aligned position or length on one declared scale.
+- Exact lookup: semantic table.
+- One conclusion: concise prose beside or above its evidence.
+- One task: make the working form, editor, uploader, or calculator the focal
+  object.
+
+Every major section should add a new answer. Do not repeat the same feature,
+recommendation, or value in a badge, title, card, and conclusion.
+
+## Component rules
+
+### Buttons and links
+
+- One primary button per local decision group.
+- Secondary actions use outline or ghost treatment.
+- Link styling stays visibly link-like; do not turn every link into a button.
+- Labels start with a clear verb when the action is not obvious.
+- Icon-only controls require an accessible name and a familiar icon.
+- Hover and active states change color, border, or position by at most a small
+  deliberate amount. Never bounce or dramatically scale controls.
+
+### Cards and panels
+
+- Use a card only for a real grouped object, selectable option, or bounded task.
+- Cards are flat by default and never nest decorative cards.
+- Align title, description, values, and actions across peer cards.
+- A selected or recommended card uses a stronger border and an explicit text
+  label. Do not rely on color or shadow alone.
+
+### Badges and status
+
+- Badges communicate status, category, or a compact count.
+- They are rectangular, sentence case, and quiet unless the state is critical.
+- Do not use a badge as a decorative eyebrow above every title.
+- Pair status color with text or an icon.
+
+### Forms
+
+- Use native semantics, persistent visible labels, and clear units.
+- Help text appears only when it prevents an error or explains a constraint.
+- Preserve invalid values so users can correct them.
+- Place the error next to the field and summarize it when the form is long.
+- Focus is always visible. Disabled and loading states must remain legible.
+- Inputs, selects, textareas, checkboxes, and tab controls use square geometry.
+  Switches retain their standard track shape.
+
+### Dialogs, menus, sheets, and tooltips
+
+- Use overlays only when the task should interrupt or remain in context.
+- Titles describe the decision or task, not the component type.
+- Keep motion short and functional, and respect reduced-motion settings.
+- Portaled surfaces use the same tokens and square geometry as the page.
+- Tooltips supplement a visible control; they never contain required
+  instructions.
+
+### Tables and data
+
+- Use semantic `table`, header, body, row, and caption structure.
+- Left-align text and right-align numeric columns, including their headers.
+- Use tabular numerals for aligned values.
+- Keep units, periods, bases, filters, and totals next to the data they qualify.
+- Tables own the available evidence width and may scroll locally on narrow
+  screens. Do not shrink labels to unreadable text.
+- Charts use a shared scale, direct labels when possible, and a text alternative.
+
+### Empty, loading, success, and error states
+
+- Empty states explain why the area is empty and offer one useful next action.
+- Skeletons preserve the final layout and do not pulse indefinitely.
+- Success states confirm what changed and where the result lives.
+- Error states explain the recovery action without exposing raw provider errors.
+- Never ship fake success, placeholder data, or dead-end controls.
+
+## Surface-specific guidance
+
+### Marketing
+
+Lead with the product outcome and working proof. The homepage may keep its hard
+offset product preview as the signature composition. Supporting sections use
+fewer cards, left-aligned editorial headings, and indigo only for the strongest
+anchor. Avoid gradients, decorative grid backgrounds, glass headers, floating
+badges, and repetitive centered section intros.
+
+### Authentication and status flows
+
+Keep the form or status card as the only focal object. Global navigation is
+minimal. Background decoration must not compete with labels, validation, or the
+next action.
+
+### Dashboard and settings
+
+The persistent sidebar establishes navigation. Page headers align titles,
+descriptions, and actions to the same grid. Prefer section dividers and full-
+width task surfaces to a collection of elevated cards. Dense operational views
+prioritize scan speed, table alignment, state clarity, and keyboard access.
+
+### Billing and pricing
+
+Put payment mode and billing period controls before the tiers. Compare tiers on
+the same basis, align prices and included features, and label the recommendation
+in text. Price is proportional hierarchy, not a decorative monospace billboard.
+Explain renewal timing and the checkout transition before the primary action.
+
+### Blog and legal content
+
+Use `ReadingContainer` and the shared Markdown styles. Images are evidence or
+content, not decoration. Captions, dates, and authorship remain subordinate but
+readable. Headings follow a strict order and tables preserve lookup width.
+
+### Uploads and media
+
+The drop zone is a task surface, not a decorative dashed card. Show accepted
+formats and limits before selection, expose progress and cancellation, and keep
+file identity visible. Rounded media is not part of the product language;
+previews use square crops unless the source itself is circular.
+
+### AI chat and canvas
+
+Chat remains the conversational path and Canvas the work surface. User messages
+may use a muted bounded block; assistant content stays unboxed. The composer is
+always reachable. Tool approval, reasoning, attachments, and generated
+artifacts must expose their state in text and remain usable on mobile.
+
+### Email
+
+Match the same indigo, square geometry, direct hierarchy, and sentence-case
+copy, while using email-safe inline styles. Do not rely on dark mode or complex
+layout for comprehension.
+
+## Accessibility and responsive behavior
+
+- Use landmarks, one descriptive `h1`, ordered headings, native controls, and
+  semantic tables.
+- Provide a skip link on global application shells when repeated navigation
+  precedes the main content.
+- Meet WCAG AA contrast. Color is never the only state cue.
+- Keep targets at least 40 CSS pixels where the layout allows; never make the
+  only target smaller than 32 pixels.
+- Preserve source order as reading order.
+- Reflow before shrinking. Grid and flex children use `min-width: 0` where
+  content could overflow.
+- Do not hide page overflow to conceal a layout problem.
+- Test keyboard navigation, visible focus, zoom/reflow, light and dark themes,
+  and reduced motion.
+
+## Motion
+
+Default to stillness. Motion may explain a state change, preserve continuity,
+or confirm an action. Do not use decorative pinging, auto-scrolling marquees,
+typing cursors, bounce, parallax, hover image movement, or scroll-reveal effects.
+The complete experience must work with reduced motion.
+
+## Hard rejects
+
+Do not ship:
+
+- decorative gradients, glows, blobs, grid textures, glass, or backdrop blur;
+- soft ambient shadows on ordinary cards, inputs, buttons, or panels;
+- pill-shaped metadata, ordinary labels, or tabs;
+- all-caps labels, wide letter spacing, or decorative eyebrows;
+- a generic centered hero followed by interchangeable card grids;
+- icons in colored tiles when a text label is clearer;
+- nested cards, borders used to repair weak hierarchy, or color without meaning;
+- arbitrary font sizes, tiny muted copy, or mismatched peer typography;
+- fake screenshots, placeholder flows, stock decoration, or unsupported claims;
+- visible controls that do not work.
+
+## Implementation and review
+
+Before adding a new visual pattern, check the relevant implementation in
+`src/components`, `styles/theme.css`, `styles/globals.css`, and this file. Reuse
+an existing semantic container and UI primitive before creating a new one.
+
+Review every meaningful UI change in this order:
+
+1. **First read:** purpose, state, and next action are obvious.
+2. **Hierarchy:** one focal object leads; supporting content is quieter.
+3. **Alignment:** shared edges, baselines, peer rows, and actions line up.
+4. **Restraint:** remove any surface, border, badge, icon, or copy that adds no
+   meaning or affordance.
+5. **States:** loading, empty, error, success, disabled, selected, and destructive
+   states are complete.
+6. **Access:** semantics, focus, labels, contrast, target size, and reading order
+   are sound.
+7. **Themes and reflow:** light, dark, desktop, and narrow layouts preserve the
+   same hierarchy without overflow.
+8. **Localization:** English and Simplified Chinese stay in parity and do not
+   mix languages within one shipped view.
+
+The target is UllrAI judgment: strong structure, square geometry, indigo
+authorship, real product states, and unusually low friction.

--- a/src/app/(auth)/_components/auth-shell.test.tsx
+++ b/src/app/(auth)/_components/auth-shell.test.tsx
@@ -46,7 +46,6 @@ describe("AuthShell", () => {
       "flex-col",
       "items-center",
       "justify-center",
-      "overflow-hidden",
       "bg-background",
     );
 
@@ -86,7 +85,7 @@ describe("AuthShell", () => {
     expect(logoContainer).toHaveAttribute("href", "/");
   });
 
-  it("renders background patterns", () => {
+  it("keeps the authentication background undecorated", () => {
     render(
       <AuthShell>
         <div>Content</div>
@@ -95,11 +94,10 @@ describe("AuthShell", () => {
 
     const mainElement = screen.getByRole("main");
 
-    // Check if background pattern container exists
     const backgroundContainer = mainElement.querySelector(
       ".absolute.inset-0.-z-10",
     );
-    expect(backgroundContainer).toBeInTheDocument();
+    expect(backgroundContainer).not.toBeInTheDocument();
   });
 
   it("renders children in the correct container", () => {

--- a/src/app/(auth)/_components/auth-shell.tsx
+++ b/src/app/(auth)/_components/auth-shell.tsx
@@ -4,7 +4,6 @@ import { Logo } from "@/components/logo";
 import { LocalizedLink as Link } from "@/components/localized-link";
 import { CompactContainer } from "@/components/layout/page-container";
 import { Button } from "@/components/ui/button";
-import { BackgroundPattern } from "@/components/ui/background-pattern";
 import { APP_NAME } from "@/lib/config/constants";
 import { useTranslation } from "@/lib/i18n/translation/client";
 
@@ -12,8 +11,7 @@ export function AuthShell({ children }: { children: React.ReactNode }) {
   const { t } = useTranslation();
 
   return (
-    <main className="bg-background relative flex min-h-screen flex-col items-center justify-center overflow-hidden">
-      <BackgroundPattern />
+    <main className="bg-background relative flex min-h-screen flex-col items-center justify-center">
       <div className="absolute top-6 left-6">
         <Button asChild variant="ghost" size="sm">
           <Link href="/" className="flex items-center gap-2">

--- a/src/app/(pages)/about/page.tsx
+++ b/src/app/(pages)/about/page.tsx
@@ -81,7 +81,7 @@ export default function AboutPage({
         <PageIntro
           className="mb-20"
           badge={
-            <Badge className="border-border bg-background/50 inline-flex items-center border px-3 py-1 text-sm backdrop-blur-sm">
+            <Badge className="border-border bg-background inline-flex items-center border px-3 py-1 text-sm">
               <Info className="text-muted-foreground mr-2 h-3 w-3" />
               <span className="text-muted-foreground font-mono">
                 {t("about_readme_md")}
@@ -103,9 +103,9 @@ export default function AboutPage({
           </PageSectionHeading>
 
           <div className="grid gap-6 md:grid-cols-3">
-            <Card className="shadow-sm">
+            <Card>
               <CardHeader>
-                <div className="bg-primary/10 text-primary border-primary/20 mb-4 flex h-12 w-12 items-center justify-center border">
+                <div className="text-primary mb-4 flex h-12 w-12 items-center">
                   <Zap className="h-6 w-6" />
                 </div>
                 <CardTitle>{t("about_practical_workflow_speed")}</CardTitle>
@@ -115,9 +115,9 @@ export default function AboutPage({
               </CardHeader>
             </Card>
 
-            <Card className="shadow-sm">
+            <Card>
               <CardHeader>
-                <div className="bg-primary/10 text-primary border-primary/20 mb-4 flex h-12 w-12 items-center justify-center border">
+                <div className="text-primary mb-4 flex h-12 w-12 items-center">
                   <Shield className="h-6 w-6" />
                 </div>
                 <CardTitle>{t("about_security_boundaries")}</CardTitle>
@@ -127,9 +127,9 @@ export default function AboutPage({
               </CardHeader>
             </Card>
 
-            <Card className="shadow-sm">
+            <Card>
               <CardHeader>
-                <div className="bg-primary/10 text-primary border-primary/20 mb-4 flex h-12 w-12 items-center justify-center border">
+                <div className="text-primary mb-4 flex h-12 w-12 items-center">
                   <Users className="h-6 w-6" />
                 </div>
                 <CardTitle>{t("about_maintainable_defaults")}</CardTitle>
@@ -145,7 +145,7 @@ export default function AboutPage({
           </PageSectionHeading>
 
           <div className="grid gap-6 md:grid-cols-3">
-            <Card className="shadow-sm">
+            <Card>
               <CardHeader>
                 <CardTitle>{t("about_real_checkout_flow")}</CardTitle>
                 <CardDescription>
@@ -154,7 +154,7 @@ export default function AboutPage({
               </CardHeader>
             </Card>
 
-            <Card className="shadow-sm">
+            <Card>
               <CardHeader>
                 <CardTitle>{t("about_protected_app_routes")}</CardTitle>
                 <CardDescription>
@@ -163,7 +163,7 @@ export default function AboutPage({
               </CardHeader>
             </Card>
 
-            <Card className="shadow-sm">
+            <Card>
               <CardHeader>
                 <CardTitle>{t("about_repository_content")}</CardTitle>
                 <CardDescription>
@@ -182,7 +182,7 @@ export default function AboutPage({
           </PageSectionHeading>
 
           <div className="grid gap-6 md:grid-cols-2">
-            <Card className="shadow-sm">
+            <Card>
               <CardHeader>
                 <CardTitle>{t("about_code_over_claims")}</CardTitle>
                 <CardDescription>
@@ -191,7 +191,7 @@ export default function AboutPage({
               </CardHeader>
             </Card>
 
-            <Card className="shadow-sm">
+            <Card>
               <CardHeader>
                 <CardTitle>{t("about_small_reviewable_changes")}</CardTitle>
                 <CardDescription>
@@ -212,7 +212,7 @@ export default function AboutPage({
             <PageIntroDescription className="mb-8 text-lg">
               {t("about_build_saas_product_works_well")}
             </PageIntroDescription>
-            <div className="flex flex-wrap justify-center gap-4">
+            <div className="flex flex-wrap gap-4">
               {SITE_CONFIG.features.billing && (
                 <Button asChild size="lg">
                   <Link href="/pricing" locale={locale}>

--- a/src/app/(pages)/blog/not-found.tsx
+++ b/src/app/(pages)/blog/not-found.tsx
@@ -2,7 +2,6 @@ import { Home, ArrowLeft, Sparkles } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { BackgroundPattern } from "@/components/ui/background-pattern";
 import { ReadingContainer } from "@/components/layout/page-container";
 import { SOURCE_LOCALE } from "@/lib/config/i18n";
 import { getStaticTranslations } from "@/lib/i18n/translation/static";
@@ -10,12 +9,10 @@ import { getStaticTranslations } from "@/lib/i18n/translation/static";
 export default function PagesNotFound() {
   const { t } = getStaticTranslations(SOURCE_LOCALE);
   return (
-    <div className="bg-background relative flex min-h-[60vh] flex-col items-center justify-center overflow-hidden py-16">
-      <BackgroundPattern />
-
+    <div className="bg-background flex min-h-[60vh] flex-col items-center justify-center py-16">
       <ReadingContainer className="relative text-center">
         {/* Status Badge */}
-        <Badge className="border-border bg-background/50 mb-8 inline-flex items-center border px-3 py-1 text-sm backdrop-blur-sm">
+        <Badge className="border-border bg-background mb-8 inline-flex items-center border px-3 py-1 text-sm">
           <Sparkles className="text-muted-foreground mr-2 h-3 w-3" />
           <span className="text-muted-foreground font-mono">
             {t("blog_error_404")}

--- a/src/app/(pages)/blog/page.tsx
+++ b/src/app/(pages)/blog/page.tsx
@@ -2,7 +2,6 @@ import { getServerTranslations } from "@/lib/i18n/translation/server";
 import { getStaticTranslations } from "@/lib/i18n/translation/static";
 import { Sparkles, BookOpen } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { BackgroundPattern } from "@/components/ui/background-pattern";
 import { BlogPostCard } from "@/components/blog/blog-post-card";
 import {
   ReadingContainer,
@@ -80,12 +79,10 @@ export function BlogPageContent({ locale }: { locale: SupportedLocale }) {
   return (
     <>
       {/* Hero Section */}
-      <section className="bg-muted/40 relative overflow-hidden py-16 sm:py-20 lg:py-24">
-        <BackgroundPattern />
-
+      <section className="bg-muted/40 border-border border-b py-16 sm:py-20 lg:py-24">
         <ReadingContainer>
-          <div className="text-center">
-            <Badge className="border-border bg-background/50 mb-4 inline-flex items-center border px-3 py-1 text-sm backdrop-blur-sm sm:mb-6">
+          <div className="max-w-3xl">
+            <Badge className="border-border bg-background mb-4 inline-flex items-center border px-3 py-1 text-sm sm:mb-6">
               <Sparkles className="text-muted-foreground mr-2 h-3 w-3" />
               <span className="text-muted-foreground font-mono">
                 {t("blog_index")}
@@ -106,7 +103,7 @@ export function BlogPageContent({ locale }: { locale: SupportedLocale }) {
         <SectionContainer>
           {sortedPosts.length === 0 ? (
             <div className="py-16 text-center sm:py-20">
-              <div className="bg-muted mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full sm:h-20 sm:w-20">
+              <div className="bg-muted mx-auto mb-6 flex h-16 w-16 items-center justify-center border sm:h-20 sm:w-20">
                 <BookOpen className="text-muted-foreground h-8 w-8 sm:h-10 sm:w-10" />
               </div>
               <h2 className="text-foreground mb-4 text-xl font-semibold sm:text-2xl">
@@ -121,7 +118,7 @@ export function BlogPageContent({ locale }: { locale: SupportedLocale }) {
               {/* Featured Posts */}
               {featuredPosts.length > 0 && (
                 <section>
-                  <div className="mb-6 text-center sm:mb-8">
+                  <div className="mb-6 max-w-2xl sm:mb-8">
                     <h2 className="text-foreground mb-2 text-2xl font-bold tracking-tight sm:text-3xl">
                       {t("blog_featured_posts")}
                     </h2>
@@ -139,7 +136,7 @@ export function BlogPageContent({ locale }: { locale: SupportedLocale }) {
               {regularPosts.length > 0 && (
                 <section>
                   {featuredPosts.length > 0 && (
-                    <div className="mb-6 text-center sm:mb-8">
+                    <div className="mb-6 max-w-2xl sm:mb-8">
                       <h2 className="text-foreground mb-2 text-2xl font-bold tracking-tight sm:text-3xl">
                         {t("blog_all_posts")}
                       </h2>

--- a/src/app/(pages)/contact/contact-methods.tsx
+++ b/src/app/(pages)/contact/contact-methods.tsx
@@ -60,27 +60,20 @@ export function ContactMethods({
         return (
           <Card
             key={method.href}
-            className="group shadow-sm transition-all hover:shadow-md"
+            className="hover:border-primary transition-colors"
           >
             <CardHeader>
-              <div className="bg-primary/10 text-primary border-primary/20 mb-4 flex h-12 w-12 items-center justify-center border transition-transform group-hover:scale-110">
+              <div className="text-primary mb-4 flex h-12 w-12 items-center">
                 <Icon className="h-6 w-6" />
               </div>
               <CardTitle className="text-lg">{method.title}</CardTitle>
-              <p className="text-muted-foreground font-mono text-[10px] uppercase">
-                {method.label}
-              </p>
+              <p className="text-muted-foreground text-xs">{method.label}</p>
             </CardHeader>
             <CardContent>
               <p className="text-muted-foreground mb-4 text-sm">
                 {method.description}
               </p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="w-full shadow-xs"
-                asChild
-              >
+              <Button variant="outline" size="sm" className="w-full" asChild>
                 <a
                   href={method.href}
                   className="block font-mono text-xs"

--- a/src/app/(pages)/contact/page.tsx
+++ b/src/app/(pages)/contact/page.tsx
@@ -70,7 +70,7 @@ export default function ContactPage({
         <PageIntro
           className="mb-20"
           badge={
-            <Badge className="border-border bg-background/50 inline-flex items-center border px-3 py-1 text-sm backdrop-blur-sm">
+            <Badge className="border-border bg-background inline-flex items-center border px-3 py-1 text-sm">
               <Mail className="text-muted-foreground mr-2 h-3 w-3" />
               <span className="text-muted-foreground font-mono">
                 {t("contact_md")}
@@ -98,7 +98,7 @@ export default function ContactPage({
           </PageSectionHeading>
 
           <div className="grid gap-6 md:grid-cols-2">
-            <Card className="shadow-sm">
+            <Card>
               <CardHeader>
                 <CardTitle>{t("contact_standard_support")}</CardTitle>
                 <CardDescription>
@@ -133,7 +133,7 @@ export default function ContactPage({
               </CardContent>
             </Card>
 
-            <Card className="shadow-sm">
+            <Card>
               <CardHeader>
                 <CardTitle>{t("contact_premium_support")}</CardTitle>
                 <CardDescription>
@@ -178,7 +178,7 @@ export default function ContactPage({
           </PageSectionHeading>
 
           <div className="grid gap-6 md:grid-cols-2">
-            <Card className="shadow-sm">
+            <Card>
               <CardHeader>
                 <CardTitle className="text-lg">
                   {t("contact_what_average_response_time")}
@@ -191,7 +191,7 @@ export default function ContactPage({
               </CardContent>
             </Card>
 
-            <Card className="shadow-sm">
+            <Card>
               <CardHeader>
                 <CardTitle className="text-lg">
                   {t("contact_do_you_offer_enterprise_support")}
@@ -204,7 +204,7 @@ export default function ContactPage({
               </CardContent>
             </Card>
 
-            <Card className="shadow-sm">
+            <Card>
               <CardHeader>
                 <CardTitle className="text-lg">
                   {t("contact_can_i_schedule_demo")}
@@ -219,7 +219,7 @@ export default function ContactPage({
               </CardContent>
             </Card>
 
-            <Card className="shadow-sm">
+            <Card>
               <CardHeader>
                 <CardTitle className="text-lg">
                   {t("contact_where_can_i_find_documentation")}
@@ -253,7 +253,7 @@ export default function ContactPage({
           </PageSectionHeading>
 
           <div className="grid gap-4 md:grid-cols-3">
-            <Card className="shadow-sm transition-all hover:shadow-md">
+            <Card className="hover:border-primary transition-colors">
               <CardHeader>
                 <CardTitle className="text-base">
                   {t("contact_documentation")}
@@ -271,7 +271,7 @@ export default function ContactPage({
               </CardContent>
             </Card>
 
-            <Card className="shadow-sm transition-all hover:shadow-md">
+            <Card className="hover:border-primary transition-colors">
               <CardHeader>
                 <CardTitle className="text-base">
                   {t("contact_community_forum")}
@@ -293,7 +293,7 @@ export default function ContactPage({
               </CardContent>
             </Card>
 
-            <Card className="shadow-sm transition-all hover:shadow-md">
+            <Card className="hover:border-primary transition-colors">
               <CardHeader>
                 <CardTitle className="text-base">
                   {t("contact_release_notes")}
@@ -329,7 +329,7 @@ export default function ContactPage({
                 COMPANY_NAME,
               })}
             </PageIntroDescription>
-            <div className="flex flex-wrap justify-center gap-4">
+            <div className="flex flex-wrap gap-4">
               {SITE_CONFIG.features.billing && (
                 <Button asChild size="lg">
                   <Link href="/pricing" locale={locale}>

--- a/src/app/(pages)/features/page.tsx
+++ b/src/app/(pages)/features/page.tsx
@@ -68,7 +68,7 @@ export default function FeaturesPage({
         <PageIntro
           className="mb-20"
           badge={
-            <Badge className="border-border bg-background/50 inline-flex items-center border px-3 py-1 text-sm backdrop-blur-sm">
+            <Badge className="border-border bg-background inline-flex items-center border px-3 py-1 text-sm">
               <Package2 className="text-muted-foreground mr-2 h-3 w-3" />
               <span className="text-muted-foreground font-mono">
                 {t("features_starter_scope")}

--- a/src/app/(pages)/layout.test.tsx
+++ b/src/app/(pages)/layout.test.tsx
@@ -39,6 +39,11 @@ describe("PagesLayout", () => {
 
     const main = screen.getByRole("main");
     expect(main).toHaveClass("flex-1");
+    expect(main).toHaveAttribute("id", "main-content");
     expect(main).toContainElement(screen.getByTestId("layout-child"));
+
+    expect(
+      screen.getByRole("link", { name: "Skip to main content" }),
+    ).toHaveAttribute("href", "#main-content");
   });
 });

--- a/src/app/(pages)/payment-status/_components/payment-status-content.tsx
+++ b/src/app/(pages)/payment-status/_components/payment-status-content.tsx
@@ -270,13 +270,7 @@ export function PaymentStatusContent() {
   // Show loading state while checking status
   if (isLoading || status === null) {
     return (
-      <section className="bg-background relative flex min-h-screen items-center justify-center overflow-hidden">
-        {/* Background Pattern */}
-        <div className="absolute inset-0 -z-10">
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(120,119,198,0.03),transparent_50%)]" />
-          <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--border))_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--border))_1px,transparent_1px)] bg-[size:4rem_4rem] opacity-20" />
-        </div>
-
+      <section className="bg-background flex min-h-screen items-center justify-center">
         <FocusContainer className="relative">
           <Card className="w-full text-center">
             <CardContent className="pt-6">
@@ -309,13 +303,7 @@ export function PaymentStatusContent() {
   }
   const config = getStatusConfig(status, paymentMode, t);
   return (
-    <section className="bg-background relative flex min-h-screen items-center justify-center overflow-hidden">
-      {/* Background Pattern */}
-      <div className="absolute inset-0 -z-10">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(120,119,198,0.03),transparent_50%)]" />
-        <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--border))_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--border))_1px,transparent_1px)] bg-[size:4rem_4rem] opacity-20" />
-      </div>
-
+    <section className="bg-background flex min-h-screen items-center justify-center">
       <FocusContainer className="relative">
         {/* Status Badge */}
         <div className="mb-8 text-center">

--- a/src/app/(pages)/payment-status/page.tsx
+++ b/src/app/(pages)/payment-status/page.tsx
@@ -12,19 +12,13 @@ import { notFound } from "next/navigation";
 function PaymentStatusSkeleton({ locale }: { locale: SupportedLocale }) {
   const { t } = getStaticTranslations(locale);
   return (
-    <section className="bg-background relative flex min-h-screen items-center justify-center overflow-hidden">
-      {/* Background Pattern */}
-      <div className="absolute inset-0 -z-10">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(120,119,198,0.03),transparent_50%)]" />
-        <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--border))_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--border))_1px,transparent_1px)] bg-[size:4rem_4rem] opacity-20" />
-      </div>
-
+    <section className="bg-background flex min-h-screen items-center justify-center">
       <SectionContainer className="relative">
         {/* Status Badge Skeleton */}
         <div className="mb-8 text-center">
           <Badge
             variant="outline"
-            className="border-border bg-background/50 text-muted-foreground inline-flex items-center border px-3 py-1 font-mono text-sm backdrop-blur-sm"
+            className="border-border bg-background text-muted-foreground inline-flex items-center border px-3 py-1 text-sm"
           >
             <Clock className="mr-2 h-3 w-3" />
             {t("billing_loading_status")}

--- a/src/app/(pages)/pricing/page.tsx
+++ b/src/app/(pages)/pricing/page.tsx
@@ -113,7 +113,7 @@ export default function PricingPage({
       <PageIntro
         className="mb-20"
         badge={
-          <Badge className="border-border bg-background/50 inline-flex items-center border px-3 py-1 text-sm backdrop-blur-sm">
+          <Badge className="border-border bg-background inline-flex items-center border px-3 py-1 text-sm">
             <Boxes className="text-muted-foreground mr-2 h-3 w-3" />
             <span className="text-muted-foreground font-mono">
               {t("pricing_starter_pricing")}
@@ -124,7 +124,7 @@ export default function PricingPage({
         <PageIntroHeading>
           {t("pricing_simple_transparent_pricing")}
         </PageIntroHeading>
-        <PageIntroDescription className="mx-auto max-w-3xl">
+        <PageIntroDescription>
           {t("pricing_choose_plan_fits_you_no_hidden")}
         </PageIntroDescription>
       </PageIntro>
@@ -142,9 +142,9 @@ export default function PricingPage({
           {includedCards.map((item) => {
             const Icon = item.icon;
             return (
-              <Card key={item.id} className="shadow-sm">
+              <Card key={item.id}>
                 <CardHeader>
-                  <div className="bg-primary/10 text-primary border-primary/20 mb-4 flex h-12 w-12 items-center justify-center border">
+                  <div className="text-primary mb-4 flex h-12 w-12 items-center">
                     <Icon className="h-6 w-6" />
                   </div>
                   <CardTitle>{item.title}</CardTitle>
@@ -161,7 +161,7 @@ export default function PricingPage({
       </div>
 
       <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-        <Card className="shadow-sm">
+        <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Info className="text-primary h-5 w-5" />
@@ -178,17 +178,17 @@ export default function PricingPage({
           </CardContent>
         </Card>
 
-        <Card className="shadow-sm">
+        <Card>
           <CardHeader>
             <CardTitle>{t("pricing_current_payment_provider")}</CardTitle>
             <CardDescription>{t("pricing_checkout_routes")}</CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
             <div className="border-border bg-muted/30 border p-5">
-              <p className="text-muted-foreground text-sm uppercase">
+              <p className="text-muted-foreground text-sm">
                 {t("pricing_provider")}
               </p>
-              <p className="text-foreground mt-2 font-mono text-2xl font-bold uppercase">
+              <p className="text-foreground mt-2 text-2xl font-bold">
                 {PAYMENT_PROVIDER}
               </p>
             </div>

--- a/src/app/(pages)/privacy/page.tsx
+++ b/src/app/(pages)/privacy/page.tsx
@@ -120,7 +120,7 @@ export default function PrivacyPage({
         <PageIntro
           className="mb-12"
           badge={
-            <Badge className="border-border bg-background/50 inline-flex items-center border px-3 py-1 text-sm backdrop-blur-sm">
+            <Badge className="border-border bg-background inline-flex items-center border px-3 py-1 text-sm">
               <Shield className="text-muted-foreground mr-2 h-3 w-3" />
               <span className="text-muted-foreground font-mono">
                 {t("legal_privacy_md")}

--- a/src/app/(pages)/terms/page.tsx
+++ b/src/app/(pages)/terms/page.tsx
@@ -149,7 +149,7 @@ export default function TermsPage({
         <PageIntro
           className="mb-12"
           badge={
-            <Badge className="border-border bg-background/50 inline-flex items-center border px-3 py-1 text-sm backdrop-blur-sm">
+            <Badge className="border-border bg-background inline-flex items-center border px-3 py-1 text-sm">
               <FileText className="text-muted-foreground mr-2 h-3 w-3" />
               <span className="text-muted-foreground font-mono">
                 {t("legal_terms_md")}

--- a/src/app/dashboard/admin/_components/recent-users-chart.tsx
+++ b/src/app/dashboard/admin/_components/recent-users-chart.tsx
@@ -59,10 +59,10 @@ export function RecentUsersChart({ chartData }: RecentUsersChartProps) {
           content={({ active, payload, label }) => {
             if (active && payload && payload.length) {
               return (
-                <div className="bg-background rounded-lg border p-2 shadow-sm">
+                <div className="bg-background border p-2">
                   <div className="grid grid-cols-2 gap-2">
                     <div className="flex flex-col">
-                      <span className="text-muted-foreground text-[0.70rem] uppercase">
+                      <span className="text-muted-foreground text-xs">
                         Date
                       </span>
                       <span className="text-muted-foreground font-bold">
@@ -70,7 +70,7 @@ export function RecentUsersChart({ chartData }: RecentUsersChartProps) {
                       </span>
                     </div>
                     <div className="flex flex-col">
-                      <span className="text-muted-foreground text-[0.70rem] uppercase">
+                      <span className="text-muted-foreground text-xs">
                         New Users
                       </span>
                       <span className="font-bold">{payload[0].value}</span>

--- a/src/app/dashboard/admin/_components/revenue-chart.tsx
+++ b/src/app/dashboard/admin/_components/revenue-chart.tsx
@@ -80,15 +80,15 @@ export function RevenueChart({ chartData }: RevenueChartProps) {
           content={({ active, payload, label }) => {
             if (active && payload && payload.length) {
               return (
-                <div className="bg-background rounded-lg border p-2 shadow-sm">
+                <div className="bg-background border p-2">
                   <div className="grid grid-cols-1 gap-2">
                     <div className="flex flex-col">
-                      <span className="text-muted-foreground text-[0.70rem] uppercase">
+                      <span className="text-muted-foreground text-xs">
                         {label}
                       </span>
                     </div>
                     <div className="flex flex-col">
-                      <span className="text-muted-foreground text-[0.70rem] uppercase">
+                      <span className="text-muted-foreground text-xs">
                         {t("admin_settled_usd_revenue")}
                       </span>
                       <span className="font-bold">
@@ -96,7 +96,7 @@ export function RevenueChart({ chartData }: RevenueChartProps) {
                       </span>
                     </div>
                     <div className="flex flex-col">
-                      <span className="text-muted-foreground text-[0.70rem] uppercase">
+                      <span className="text-muted-foreground text-xs">
                         {t("admin_payments_label")}
                       </span>
                       <span className="text-muted-foreground font-bold">

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -10,6 +10,8 @@ import {
 } from "@/components/layout/app-document";
 import { getRequestLocale } from "@/lib/i18n/server-locale";
 import { loadMessages } from "@/lib/i18n/messages";
+import { getServerTranslations } from "@/lib/i18n/translation/server";
+import { SkipLink } from "@/components/layout/skip-link";
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
@@ -40,10 +42,12 @@ export default async function AppLayout({ children }: DashboardLayoutProps) {
     sidebarCookie === undefined ? true : sidebarCookie === "true";
   const locale = await getRequestLocale();
   const messages = await loadMessages(locale);
+  const { t } = await getServerTranslations({ locale });
 
   return (
     <AppDocument locale={locale} messages={messages}>
       <AppProviders>
+        <SkipLink label={t("common_skip_to_content")} />
         <SidebarProvider
           defaultOpen={defaultSidebarOpen}
           style={
@@ -55,7 +59,9 @@ export default async function AppLayout({ children }: DashboardLayoutProps) {
           <Suspense fallback={<div className="bg-sidebar w-14" />}>
             <AppSidebar variant="inset" />
           </Suspense>
-          <SidebarInset className="flex flex-col">{children}</SidebarInset>
+          <SidebarInset id="main-content" className="flex flex-col">
+            {children}
+          </SidebarInset>
         </SidebarProvider>
       </AppProviders>
     </AppDocument>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -159,7 +159,7 @@ export default async function HomeRoute() {
       description={<>{t("dashboard_account_summary")}</>}
     >
       <div className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
-        <Card className="shadow-sm">
+        <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <UserCircle2 className="text-primary h-5 w-5" />
@@ -170,7 +170,7 @@ export default async function HomeRoute() {
           <CardContent className="grid gap-4 md:grid-cols-3">
             {SITE_CONFIG.features.billing && (
               <div className="border-border space-y-2 border p-4">
-                <p className="text-muted-foreground text-xs uppercase">
+                <p className="text-muted-foreground text-xs">
                   {t("dashboard_plan")}
                 </p>
                 <p className="text-lg font-semibold">{subscriptionLabel}</p>
@@ -195,7 +195,7 @@ export default async function HomeRoute() {
             )}
             {SITE_CONFIG.features.uploads && (
               <div className="border-border space-y-2 border p-4">
-                <p className="text-muted-foreground text-xs uppercase">
+                <p className="text-muted-foreground text-xs">
                   {t("dashboard_uploads")}
                 </p>
                 <p className="text-lg font-semibold">{uploadedFileCount}</p>
@@ -208,7 +208,7 @@ export default async function HomeRoute() {
             )}
             {SITE_CONFIG.features.billing && (
               <div className="border-border space-y-2 border p-4">
-                <p className="text-muted-foreground text-xs uppercase">
+                <p className="text-muted-foreground text-xs">
                   {t("dashboard_payments")}
                 </p>
                 <p className="text-lg font-semibold">{paymentCount}</p>
@@ -228,7 +228,7 @@ export default async function HomeRoute() {
           </CardContent>
         </Card>
 
-        <Card className="shadow-sm">
+        <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <ShieldCheck className="text-primary h-5 w-5" />
@@ -255,7 +255,7 @@ export default async function HomeRoute() {
       </div>
 
       <div className="grid gap-4 lg:grid-cols-[1fr_0.9fr]">
-        <Card className="shadow-sm">
+        <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Sparkles className="text-primary h-5 w-5" />
@@ -288,7 +288,7 @@ export default async function HomeRoute() {
         </Card>
 
         {SITE_CONFIG.features.billing && (
-          <Card className="shadow-sm">
+          <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <CreditCard className="text-primary h-5 w-5" />

--- a/src/app/dashboard/settings/_components/appearance-page.tsx
+++ b/src/app/dashboard/settings/_components/appearance-page.tsx
@@ -119,7 +119,7 @@ export function AppearancePage() {
             {themes.map((themeOption) => (
               <div
                 key={themeOption.value}
-                className="cursor-pointer transition-all hover:scale-105"
+                className="cursor-pointer"
                 onClick={() => setTheme(themeOption.value)}
               >
                 <ThemeCard

--- a/src/app/dashboard/settings/_components/developer-access-card.tsx
+++ b/src/app/dashboard/settings/_components/developer-access-card.tsx
@@ -15,7 +15,7 @@ export function DeveloperAccessCard() {
     <Card>
       <CardHeader>
         <div className="flex items-start gap-3">
-          <div className="bg-primary/10 text-primary rounded-lg p-2">
+          <div className="text-primary">
             <KeyRound className="h-5 w-5" />
           </div>
           <div className="space-y-1.5">

--- a/src/app/dashboard/upload/_components/upload-workbench.tsx
+++ b/src/app/dashboard/upload/_components/upload-workbench.tsx
@@ -308,7 +308,7 @@ export function UploadWorkbench() {
         {capabilityCards.map((card) => {
           const Icon = card.icon;
           return (
-            <Card key={card.id} className="shadow-sm">
+            <Card key={card.id}>
               <CardHeader className="space-y-3">
                 <div className="text-primary">
                   <Icon className="h-5 w-5" />
@@ -324,7 +324,7 @@ export function UploadWorkbench() {
       </section>
 
       <section className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
-        <Card className="shadow-sm">
+        <Card>
           <CardHeader>
             <CardTitle>{t("uploads_default_uploader_demos")}</CardTitle>
             <CardDescription>
@@ -367,7 +367,7 @@ export function UploadWorkbench() {
           </CardContent>
         </Card>
 
-        <Card className="shadow-sm">
+        <Card>
           <CardHeader>
             <CardTitle>{t("uploads_headless_example")}</CardTitle>
             <CardDescription>
@@ -388,7 +388,7 @@ export function UploadWorkbench() {
         </Card>
       </section>
 
-      <Card className="shadow-sm">
+      <Card>
         <CardHeader>
           <div className="flex items-center gap-2">
             <Server className="text-primary h-5 w-5" />

--- a/src/components/app-providers.tsx
+++ b/src/components/app-providers.tsx
@@ -20,7 +20,7 @@ export function AppProviders({ children }: AppProvidersProps) {
         disableTransitionOnChange
       >
         <TooltipProvider>
-          <NextTopLoader color="hsl(var(--primary))" showSpinner={false} />
+          <NextTopLoader color="var(--primary)" showSpinner={false} />
           {children}
           <Toaster />
         </TooltipProvider>

--- a/src/components/auth/auth-form-base.tsx
+++ b/src/components/auth/auth-form-base.tsx
@@ -9,7 +9,6 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 import { LocalizedLink as Link } from "@/components/localized-link";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -21,7 +20,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { toast } from "sonner";
-import { Loader2, Sparkles, ArrowRight } from "lucide-react";
+import { Loader2, ArrowRight } from "lucide-react";
 import { SocialLoginButtons } from "@/components/auth/social-login-buttons";
 import type { SocialProvider } from "@/lib/auth/providers";
 import { ReactNode } from "react";
@@ -41,7 +40,6 @@ interface AuthFormField<T extends FieldValues> {
 interface AuthFormConfig {
   title: ReactNode;
   description: ReactNode;
-  badgeText: ReactNode;
   submitButtonText: ReactNode;
   magicLinkLoadingText: ReactNode;
   submitIcon: React.ComponentType<{
@@ -88,21 +86,10 @@ export function AuthFormBase<T extends FieldValues>({
     }
   };
   return (
-    <Card className="bg-background/80 w-full shadow-lg backdrop-blur-sm">
+    <Card className="bg-background w-full border-2">
       <CardHeader className="space-y-4">
-        {/* Welcome Badge */}
-        <div className="flex justify-center">
-          <Badge
-            variant="secondary"
-            className="bg-primary/10 text-primary border-primary/20"
-          >
-            <Sparkles className="mr-1 h-3 w-3" />
-            {config.badgeText}
-          </Badge>
-        </div>
-
         <div className="space-y-2 text-center">
-          <CardTitle className="from-foreground to-foreground/70 bg-gradient-to-r bg-clip-text text-2xl font-bold text-transparent md:text-3xl">
+          <CardTitle className="text-foreground text-2xl font-bold md:text-3xl">
             {config.title}
           </CardTitle>
           <CardDescription className="text-muted-foreground text-sm md:text-base">
@@ -137,7 +124,7 @@ export function AuthFormBase<T extends FieldValues>({
                     <div className="absolute inset-0 flex items-center">
                       <span className="border-border w-full border-t" />
                     </div>
-                    <div className="relative flex justify-center text-xs uppercase">
+                    <div className="relative flex justify-center text-xs">
                       <span className="bg-background text-muted-foreground px-3 font-medium">
                         {t("auth_continue_magic_link")}
                       </span>
@@ -168,7 +155,7 @@ export function AuthFormBase<T extends FieldValues>({
                               type={field.type || "text"}
                               {...formField}
                               disabled={isPending}
-                              className="focus:border-primary/50 h-12 border-2 pl-10 shadow-sm transition-all focus:translate-x-[1px] focus:translate-y-[1px] focus:shadow-none"
+                              className="focus:border-primary h-12 border-2 pl-10"
                             />
                           </div>
                         </FormControl>
@@ -183,7 +170,7 @@ export function AuthFormBase<T extends FieldValues>({
               <Button
                 type="submit"
                 disabled={isPending}
-                className="from-primary to-primary/90 hover:from-primary/90 hover:to-primary text-primary-foreground h-12 w-full cursor-pointer bg-gradient-to-r font-medium shadow transition-all duration-200 hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-sm active:translate-x-[4px] active:translate-y-[4px] active:shadow-none"
+                className="text-primary-foreground h-12 w-full cursor-pointer font-medium"
               >
                 {isMagicLinkPending ? (
                   <span className="flex items-center gap-2">

--- a/src/components/auth/link-sent-card.tsx
+++ b/src/components/auth/link-sent-card.tsx
@@ -20,9 +20,9 @@ export function LinkSentCard({
 }: LinkSentCardProps) {
   const { t } = useTranslation();
   return (
-    <Card className="bg-muted/30 w-full shadow-md backdrop-blur-sm">
+    <Card className="bg-background w-full border-2">
       <CardHeader className="text-center">
-        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-50">
+        <div className="mx-auto flex h-16 w-16 items-center justify-center border bg-green-50">
           <CheckCircle className="h-8 w-8 text-green-500" />
         </div>
         <CardTitle className="text-xl font-semibold tracking-tight">

--- a/src/components/blog/blog-post-card.tsx
+++ b/src/components/blog/blog-post-card.tsx
@@ -47,10 +47,10 @@ export function BlogPostCard({
   const isFeatured = variant === "featured";
   const hasImage = !!heroImage;
   const cardClasses = cn(
-    "group overflow-hidden backdrop-blur-sm transition-all duration-300",
+    "group overflow-hidden transition-colors duration-200",
     isFeatured
-      ? "bg-background/50 hover:bg-background/80 border-primary/20 border hover:shadow-xl"
-      : "border-border bg-background/50 hover:bg-background/80 hover:shadow-lg",
+      ? "bg-background border-primary border-2"
+      : "border-border bg-background hover:border-primary",
     className,
   );
   const imageHeight = isFeatured ? "h-64 lg:h-80" : "h-48";
@@ -68,7 +68,7 @@ export function BlogPostCard({
             src={heroImage}
             alt={title}
             fill
-            className="object-cover transition-transform duration-300 group-hover:scale-105"
+            className="object-cover"
             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           />
           <div className="absolute inset-0 bg-linear-to-t from-black/60 via-transparent to-transparent" />
@@ -78,7 +78,7 @@ export function BlogPostCard({
             {featured ? (
               <Badge
                 variant="default"
-                className="bg-primary/90 text-primary-foreground border-primary/20 hover:bg-primary backdrop-blur-sm transition-colors"
+                className="bg-primary text-primary-foreground border-primary"
               >
                 <Sparkles className="mr-1 h-3 w-3" />
                 {t("blog_featured")}
@@ -86,7 +86,7 @@ export function BlogPostCard({
             ) : (
               <Badge
                 variant="secondary"
-                className="bg-background/90 text-foreground border-border hover:bg-background backdrop-blur-sm transition-colors"
+                className="bg-background text-foreground border-border"
               >
                 {t("blog_article")}
               </Badge>
@@ -154,15 +154,10 @@ export function BlogPostCard({
 
         <Link
           href={postHref}
-          className="text-primary hover:text-primary/80 inline-flex items-center gap-2 font-medium transition-all duration-200 group-hover:gap-3"
+          className="text-primary hover:text-primary/80 inline-flex items-center gap-2 font-medium underline-offset-4 hover:underline"
         >
           {readMoreText}
-          <span
-            className="transition-transform group-hover:translate-x-1"
-            translate="no"
-          >
-            →
-          </span>
+          <span translate="no">→</span>
         </Link>
       </CardContent>
     </Card>

--- a/src/components/blog/blog-post-header.tsx
+++ b/src/components/blog/blog-post-header.tsx
@@ -1,7 +1,6 @@
 import { getStaticTranslations } from "@/lib/i18n/translation/static";
 import type { ReactNode } from "react";
 import { Button } from "@/components/ui/button";
-import { BackgroundPattern } from "@/components/ui/background-pattern";
 import { Badge } from "@/components/ui/badge";
 import { ReadingContainer } from "@/components/layout/page-container";
 import { BlogPostMeta } from "./blog-post-meta";
@@ -62,7 +61,7 @@ export function BlogPostHeader({
               <Button
                 variant="ghost"
                 asChild
-                className="bg-background/80 hover:bg-background/90 backdrop-blur-sm transition-colors"
+                className="bg-background/90 hover:bg-background transition-colors"
               >
                 <Link href={backHref}>
                   <ArrowLeft className="mr-2 h-4 w-4" />
@@ -125,9 +124,7 @@ export function BlogPostHeader({
 
   // Non-hero image layout
   return (
-    <section className="bg-background relative overflow-hidden">
-      <BackgroundPattern />
-
+    <section className="bg-background">
       <div className="py-6 md:py-12">
         <ReadingContainer>
           {/* Back button */}
@@ -146,7 +143,7 @@ export function BlogPostHeader({
           </div>
 
           {/* Article header */}
-          <header className="text-center">
+          <header>
             <BlogPostMeta
               publishedDate={publishedDate}
               updatedDate={updatedDate}

--- a/src/components/blog/blog-post-meta.tsx
+++ b/src/components/blog/blog-post-meta.tsx
@@ -37,10 +37,10 @@ export function BlogPostMeta({
   const badgeVariant = featured ? "default" : "secondary";
   const isCenter = className?.includes("justify-center");
   const featuredBadgeClasses = isOverlay
-    ? "bg-primary/90 text-primary-foreground border-primary/20 backdrop-blur-sm"
+    ? "bg-primary text-primary-foreground border-primary"
     : "bg-primary/10 text-primary border-primary/20";
   const articleBadgeClasses = isOverlay
-    ? "bg-background/90 text-foreground border-border backdrop-blur-sm"
+    ? "bg-background text-foreground border-border"
     : "bg-muted/50 text-muted-foreground border-muted";
   const intlLocale = resolveIntlLocale(supportedLocale);
   const formattedUpdatedDate = updatedDate

--- a/src/components/forms/auth-form.tsx
+++ b/src/components/forms/auth-form.tsx
@@ -109,11 +109,6 @@ export function AuthForm({
     ) : (
       <>{t("auth_oauth_signup_description")}</>
     ),
-    badgeText: isLogin ? (
-      <>{t("auth_welcome_back")}</>
-    ) : (
-      <>{t("auth_get_started")}</>
-    ),
     submitButtonText: isLogin ? (
       <>{t("auth_send_magic_link")}</>
     ) : (

--- a/src/components/homepage/call-to-action.tsx
+++ b/src/components/homepage/call-to-action.tsx
@@ -36,7 +36,7 @@ export function CallToAction({
           </div>
 
           <div className="mx-auto mt-10 max-w-3xl space-y-6">
-            <p className="text-primary text-xs font-bold tracking-[0.2em] uppercase">
+            <p className="text-primary text-sm font-semibold">
               <>{t("home_ship_foundation_first")}</>
             </p>
             <h2 className="text-foreground text-4xl font-bold tracking-tight sm:text-5xl">
@@ -60,12 +60,12 @@ export function CallToAction({
             {SITE_CONFIG.features.billing && (
               <Button
                 size="lg"
-                className="group h-14 px-10 text-base font-bold shadow-lg transition-all hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-md active:translate-x-[4px] active:translate-y-[4px]"
+                className="h-14 border-2 px-10 text-base font-bold"
                 asChild
               >
                 <Link href="/pricing" locale={locale}>
                   <>{t("home_view_pricing")}</>
-                  <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
+                  <ArrowRight className="ml-2 h-4 w-4" />
                 </Link>
               </Button>
             )}

--- a/src/components/homepage/features.tsx
+++ b/src/components/homepage/features.tsx
@@ -37,10 +37,10 @@ function FeatureCard({
   };
 }) {
   return (
-    <Card className="group border-border bg-card hover:border-primary h-full border p-6 transition-all">
+    <Card className="border-border bg-card hover:border-primary h-full border p-6 transition-colors">
       <div className="space-y-4">
         <div className="flex items-center justify-between gap-4">
-          <div className="bg-secondary text-primary border-border group-hover:border-primary group-hover:bg-primary group-hover:text-primary-foreground flex h-12 w-12 items-center justify-center border transition-colors">
+          <div className="text-primary flex h-12 w-12 items-center">
             <Icon className="h-6 w-6" />
           </div>
           <Badge variant="outline" className="border-border font-mono text-xs">
@@ -194,8 +194,8 @@ export function Features({
       className="bg-background border-border border-b py-24"
     >
       <SectionContainer>
-        <div className="mx-auto mb-16 max-w-2xl text-center">
-          <Badge className="border-border bg-background/50 mb-4 inline-flex items-center border px-3 py-1 text-sm backdrop-blur-sm">
+        <div className="mb-16 max-w-2xl">
+          <Badge className="border-border bg-background mb-4 inline-flex items-center border px-3 py-1 text-sm">
             <Package2 className="text-muted-foreground mr-2 h-3 w-3" />
             <span className="text-muted-foreground font-mono">
               {t("home_included_modules")}
@@ -229,7 +229,7 @@ export function Features({
               <div className="text-foreground text-4xl font-bold tracking-tighter">
                 {stat.value}
               </div>
-              <div className="text-muted-foreground mt-2 text-sm tracking-widest uppercase">
+              <div className="text-muted-foreground mt-2 text-sm">
                 {stat.label}
               </div>
             </div>

--- a/src/components/homepage/footer.tsx
+++ b/src/components/homepage/footer.tsx
@@ -215,7 +215,7 @@ export function Footer({
                     <a
                       key={social.name}
                       href={social.href}
-                      className="border-border bg-background text-muted-foreground hover:text-foreground hover:border-border/80 flex h-9 w-9 items-center justify-center rounded-lg border transition-colors"
+                      className="border-border bg-background text-muted-foreground hover:text-foreground hover:border-primary flex h-9 w-9 items-center justify-center border transition-colors"
                       target="_blank"
                       rel="noopener noreferrer"
                       aria-label={social.name}

--- a/src/components/homepage/header.tsx
+++ b/src/components/homepage/header.tsx
@@ -52,7 +52,7 @@ export function Header({
   ].filter((item) => SITE_CONFIG.features.billing || item.id !== "nav-pricing");
 
   return (
-    <header className="border-border/40 bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 w-full border-b backdrop-blur">
+    <header className="border-border bg-background sticky top-0 z-50 w-full border-b">
       <ShellContainer>
         <div className="flex h-16 items-center justify-between">
           <Link href={homeHref} className="flex items-center gap-2">

--- a/src/components/homepage/hero.tsx
+++ b/src/components/homepage/hero.tsx
@@ -27,10 +27,7 @@ export function Hero({
                 variant="outline"
                 className="border-primary/30 bg-primary/5 text-primary hover:bg-primary/10 mb-4 inline-flex cursor-default items-center gap-2 border px-4 py-2 font-mono text-sm font-bold transition-colors"
               >
-                <span className="relative flex h-2 w-2">
-                  <span className="bg-primary absolute inline-flex h-full w-full animate-ping rounded-full opacity-75"></span>
-                  <span className="bg-primary relative inline-flex h-2 w-2 rounded-full"></span>
-                </span>
+                <span className="bg-primary h-2 w-2 rounded-full" />
                 <>{t("home_open_source_agent_ready")}</>
               </Badge>
             </div>
@@ -38,7 +35,7 @@ export function Hero({
             {/* Massive Headline */}
             <h1 className="text-foreground mb-6 text-5xl leading-[0.9] font-black tracking-tighter sm:text-6xl lg:text-7xl xl:text-8xl">
               <span className="block">{t("home_ship")}</span>
-              <span className="from-foreground to-foreground/50 block bg-gradient-to-b bg-clip-text pr-1 text-transparent">
+              <span className="text-primary block pr-1">
                 {t("home_micro_saas")}
               </span>
             </h1>
@@ -52,7 +49,7 @@ export function Hero({
             <div className="flex flex-col gap-4 sm:flex-row lg:gap-6">
               <Button
                 size="lg"
-                className="bg-primary text-primary-foreground hover:bg-primary/90 h-14 px-10 text-base font-bold shadow-md transition-all hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-lg active:translate-x-[8px] active:translate-y-[8px] lg:h-16 lg:px-12 lg:text-lg"
+                className="bg-primary text-primary-foreground hover:bg-primary/90 h-14 border-2 px-10 text-base font-bold lg:h-16 lg:px-12 lg:text-lg"
                 asChild
               >
                 <Link
@@ -186,7 +183,7 @@ export function Hero({
                 {/* Right: What's Included */}
                 <div className="bg-secondary/5 flex flex-col p-6 text-left sm:p-8 lg:col-span-5">
                   <div className="mb-6 space-y-2">
-                    <div className="text-muted-foreground text-xs font-bold tracking-widest uppercase">
+                    <div className="text-muted-foreground text-xs font-semibold">
                       <>{t("home_whats_included")}</>
                     </div>
                     <div className="flex items-center gap-2">

--- a/src/components/homepage/other-products.tsx
+++ b/src/components/homepage/other-products.tsx
@@ -87,12 +87,12 @@ export function OtherProducts({
             return (
               <Card
                 key={product.id}
-                className="group border-border bg-card hover:border-primary relative h-full border p-6 transition-all hover:shadow-[4px_4px_0px_0px_var(--border)]"
+                className="group border-border bg-card hover:border-primary relative h-full border p-6 transition-colors"
               >
                 <CardContent className="p-0">
                   <div className="flex items-start justify-between">
                     <div className="flex items-center gap-3">
-                      <div className="bg-secondary text-primary border-border group-hover:bg-primary group-hover:text-primary-foreground flex h-10 w-10 items-center justify-center border transition-colors">
+                      <div className="text-primary flex h-10 w-10 items-center">
                         <IconComponent className="h-5 w-5" />
                       </div>
                       <div className="flex-1">

--- a/src/components/homepage/product-proof.tsx
+++ b/src/components/homepage/product-proof.tsx
@@ -66,7 +66,7 @@ export function ProductProof({
               return (
                 <Card key={point.id} className="h-full">
                   <CardContent className="pt-6">
-                    <div className="bg-primary/10 text-primary flex h-10 w-10 items-center justify-center rounded-lg">
+                    <div className="text-primary flex h-10 w-10 items-center">
                       <Icon className="h-5 w-5" aria-hidden="true" />
                     </div>
                     <h3 className="text-foreground mt-5 font-semibold">

--- a/src/components/layout/marketing-chrome.tsx
+++ b/src/components/layout/marketing-chrome.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from "react";
 import { Footer } from "@/components/homepage/footer";
 import { Header } from "@/components/homepage/header";
 import { SOURCE_LOCALE, type SupportedLocale } from "@/lib/config/i18n";
+import { getStaticTranslations } from "@/lib/i18n/translation/static";
+import { SkipLink } from "./skip-link";
 
 export function MarketingChrome({
   children,
@@ -11,10 +13,15 @@ export function MarketingChrome({
   children: ReactNode;
   locale?: SupportedLocale;
 }) {
+  const { t } = getStaticTranslations(locale);
+
   return (
     <div className="flex min-h-screen flex-col">
+      <SkipLink label={t("common_skip_to_content")} />
       <Header locale={locale} />
-      <main className="flex-1">{children}</main>
+      <main id="main-content" className="flex-1">
+        {children}
+      </main>
       <Footer locale={locale} />
     </div>
   );

--- a/src/components/layout/marketing-page-shell.tsx
+++ b/src/components/layout/marketing-page-shell.tsx
@@ -1,5 +1,4 @@
 import type { ComponentPropsWithoutRef } from "react";
-import { BackgroundPattern } from "@/components/ui/background-pattern";
 import { cn } from "@/lib/utils";
 import { SectionContainer } from "./page-container";
 
@@ -17,9 +16,8 @@ export function MarketingPageShell({
 }: MarketingPageShellProps) {
   return (
     <section className={cn("flex min-h-screen flex-col", className)} {...props}>
-      <div className="bg-background relative grow overflow-hidden">
-        <BackgroundPattern />
-        <div className={cn("relative py-16", contentClassName)}>
+      <div className="bg-background grow">
+        <div className={cn("py-16", contentClassName)}>
           <SectionContainer className={containerClassName}>
             {children}
           </SectionContainer>

--- a/src/components/layout/page-intro.tsx
+++ b/src/components/layout/page-intro.tsx
@@ -12,10 +12,7 @@ export function PageIntro({
   ...props
 }: PageIntroProps) {
   return (
-    <header
-      className={cn("mx-auto max-w-3xl text-center", className)}
-      {...props}
-    >
+    <header className={cn("max-w-3xl text-left", className)} {...props}>
       {badge ? <div className="mb-6">{badge}</div> : null}
       {children}
     </header>
@@ -32,7 +29,7 @@ export function PageIntroHeading({
   return (
     <Component
       className={cn(
-        "text-foreground mb-6 text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl",
+        "text-foreground mb-5 text-4xl font-bold tracking-tight text-balance sm:text-5xl",
         className,
       )}
       {...props}
@@ -45,7 +42,10 @@ export function PageIntroDescription(props: ComponentPropsWithoutRef<"p">) {
 
   return (
     <p
-      className={cn("text-muted-foreground text-xl leading-relaxed", className)}
+      className={cn(
+        "text-muted-foreground max-w-2xl text-lg leading-8",
+        className,
+      )}
       {...rest}
     />
   );

--- a/src/components/layout/skip-link.tsx
+++ b/src/components/layout/skip-link.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib/utils";
+
+export function SkipLink({
+  label,
+  className,
+}: {
+  label: string;
+  className?: string;
+}) {
+  return (
+    <a
+      href="#main-content"
+      className={cn(
+        "bg-background text-foreground focus:ring-ring fixed top-3 left-3 z-[100] -translate-y-20 border px-4 py-2 text-sm font-medium focus:translate-y-0 focus:ring-2 focus:outline-none",
+        className,
+      )}
+    >
+      {label}
+    </a>
+  );
+}

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -23,8 +23,8 @@ export function Logo({
   const baseClasses = "flex items-center justify-center";
 
   const variantClasses = {
-    default: "h-full w-full rounded-lg bg-primary p-2.5",
-    minimal: "h-full w-full rounded-md bg-primary/10 p-2",
+    default: "h-full w-full bg-primary p-2.5",
+    minimal: "h-full w-full bg-primary/10 p-2",
     "icon-only": "h-full w-full",
   };
 

--- a/src/components/not-found-content.tsx
+++ b/src/components/not-found-content.tsx
@@ -3,7 +3,6 @@
 import { ArrowLeft, Home, Sparkles } from "lucide-react";
 
 import { LocalizedLink as Link } from "@/components/localized-link";
-import { BackgroundPattern } from "@/components/ui/background-pattern";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "@/lib/i18n/translation/client";
@@ -12,10 +11,9 @@ export function NotFoundContent() {
   const { t } = useTranslation();
 
   return (
-    <main className="bg-background relative flex min-h-screen flex-col items-center justify-center overflow-hidden">
-      <BackgroundPattern />
+    <main className="bg-background flex min-h-screen flex-col items-center justify-center">
       <div className="relative mx-auto w-full max-w-2xl px-6 text-center">
-        <Badge className="border-border bg-background/50 mb-8 inline-flex items-center border px-3 py-1 text-sm backdrop-blur-sm">
+        <Badge className="border-border bg-background mb-8 inline-flex items-center border px-3 py-1 text-sm">
           <Sparkles className="text-muted-foreground mr-2 h-3 w-3" />
           <span className="text-muted-foreground font-mono">
             {t("common_error_404")}

--- a/src/components/payment-options.tsx
+++ b/src/components/payment-options.tsx
@@ -118,7 +118,7 @@ function TierActionGetLabel({ tierName }: { tierName: string }) {
   return (
     <>
       {t("billing_get_tier", {
-        expression0: tierName.toUpperCase(),
+        expression0: tierName,
       })}
     </>
   );
@@ -398,14 +398,14 @@ export function PricingSection({ className }: { className?: string }) {
           <TabsList className="bg-muted/50 grid h-11 w-full grid-cols-2 p-1">
             <TabsTrigger
               value="subscription"
-              className="data-[state=active]:bg-background flex items-center gap-2 text-sm font-medium transition-all data-[state=active]:shadow-sm"
+              className="data-[state=active]:border-primary data-[state=active]:bg-background flex items-center gap-2 text-sm font-medium"
             >
               <Calendar className="h-4 w-4" />
               <PaymentModeLabel mode="subscription" />
             </TabsTrigger>
             <TabsTrigger
               value="one_time"
-              className="data-[state=active]:bg-background flex items-center gap-2 text-sm font-medium transition-all data-[state=active]:shadow-sm"
+              className="data-[state=active]:border-primary data-[state=active]:bg-background flex items-center gap-2 text-sm font-medium"
             >
               <CreditCard className="h-4 w-4" />
               <PaymentModeLabel mode="one_time" />
@@ -422,7 +422,7 @@ export function PricingSection({ className }: { className?: string }) {
               className={cn(
                 "cursor-pointer rounded-sm px-4 py-1.5 text-sm font-medium transition-all select-none",
                 billingCycle === "monthly"
-                  ? "bg-background text-foreground shadow-sm"
+                  ? "border-primary bg-background text-foreground"
                   : "text-muted-foreground hover:text-foreground",
               )}
             >
@@ -441,7 +441,7 @@ export function PricingSection({ className }: { className?: string }) {
               className={cn(
                 "cursor-pointer rounded-sm px-4 py-1.5 text-sm font-medium transition-all select-none",
                 billingCycle === "yearly"
-                  ? "bg-background text-foreground shadow-sm"
+                  ? "border-primary bg-background text-foreground"
                   : "text-muted-foreground hover:text-foreground",
               )}
             >
@@ -483,13 +483,13 @@ export function PricingSection({ className }: { className?: string }) {
               className={cn(
                 "relative flex flex-col transition-all duration-300",
                 tier.isPopular
-                  ? "border-primary ring-primary/20 shadow-lg ring-1"
-                  : "hover:border-primary/50 shadow-sm hover:shadow-md",
+                  ? "border-primary border-2"
+                  : "hover:border-primary/50",
               )}
             >
               {tier.isPopular && (
                 <div className="absolute -top-3 left-1/2 z-10 -translate-x-1/2">
-                  <Badge className="bg-primary text-primary-foreground hover:bg-primary px-3 py-1 text-xs font-bold uppercase shadow-sm">
+                  <Badge className="bg-primary text-primary-foreground hover:bg-primary px-3 py-1 text-xs font-semibold">
                     <TierBadgeLabel badge="recommended" />
                   </Badge>
                 </div>
@@ -504,7 +504,7 @@ export function PricingSection({ className }: { className?: string }) {
                 </CardDescription>
                 <div className="mt-6 space-y-2">
                   <div className="flex items-baseline justify-center gap-1">
-                    <span className="text-foreground font-mono text-4xl font-bold tracking-tight">
+                    <span className="text-foreground text-4xl font-bold tracking-tight tabular-nums">
                       {paymentMode === "one_time"
                         ? formatPrice(price, intlLocale, tier.currency)
                         : billingCycle === "monthly"
@@ -522,7 +522,7 @@ export function PricingSection({ className }: { className?: string }) {
                     )}
                   </div>
                   <div className="flex h-5 items-center justify-center">
-                    <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                    <p className="text-muted-foreground text-xs font-medium">
                       <TierBillingLabel
                         billingCycle={billingCycle}
                         paymentMode={paymentMode}
@@ -574,9 +574,9 @@ export function PricingSection({ className }: { className?: string }) {
                 ) : (
                   <Button
                     className={cn(
-                      "h-11 w-full font-bold shadow-sm transition-all",
+                      "h-11 w-full font-bold",
                       tier.isPopular
-                        ? "bg-primary text-primary-foreground hover:bg-primary/90 shadow-md"
+                        ? "bg-primary text-primary-foreground hover:bg-primary/90"
                         : "bg-background hover:bg-accent hover:text-accent-foreground border",
                     )}
                     onClick={() =>
@@ -588,14 +588,14 @@ export function PricingSection({ className }: { className?: string }) {
                     {isLoading ? (
                       <>
                         <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        <span className="uppercase">
+                        <span>
                           <CheckoutButtonStatusLabel status="processing" />
                         </span>
                       </>
                     ) : !session?.user ? (
                       <>
                         <LogIn className="mr-2 h-4 w-4" />
-                        <span className="uppercase">
+                        <span>
                           <CheckoutButtonStatusLabel status="login_required" />
                         </span>
                       </>

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const alertVariants = cva(
-  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
   {
     variants: {
       variant: {

--- a/src/components/ui/background-pattern.tsx
+++ b/src/components/ui/background-pattern.tsx
@@ -1,8 +1,0 @@
-export function BackgroundPattern() {
-  return (
-    <div className="absolute inset-0 -z-10">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(120,119,198,0.03),transparent_50%)]" />
-      <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--border))_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--border))_1px,transparent_1px)] bg-[size:4rem_4rem] opacity-20" />
-    </div>
-  );
-}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] [&>svg]:pointer-events-none [&>svg]:size-3",
+  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-colors focus-visible:ring-[3px] [&>svg]:pointer-events-none [&>svg]:size-3",
   {
     variants: {
       variant: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 inline-flex shrink-0 items-center justify-center gap-2 border border-transparent text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 text-white",
         outline:
-          "bg-background hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 border shadow-xs",
+          "border-border bg-background hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:
@@ -22,11 +22,11 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        xs: "h-6 gap-1 px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-8 gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 px-6 has-[>svg]:px-4",
         icon: "size-9",
-        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        "icon-xs": "size-6 [&_svg:not([class*='size-'])]:size-3",
         "icon-sm": "size-8",
         "icon-lg": "size-10",
       },

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 border py-6",
         className,
       )}
       {...props}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -14,7 +14,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary size-4 shrink-0 border outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -58,7 +58,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          "bg-background data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
           className,
         )}
         {...props}
@@ -67,7 +67,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">{t("common_close")}</span>

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -33,7 +33,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "bg-popover text-popover-foreground data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto border p-1 shadow-md",
           className,
         )}
         {...props}
@@ -65,7 +65,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive! relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive! relative flex cursor-default items-center gap-2 px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "border-input selection:bg-primary selection:text-primary-foreground file:text-foreground placeholder:text-muted-foreground dark:bg-input/30 h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input selection:bg-primary selection:text-primary-foreground file:text-foreground placeholder:text-muted-foreground dark:bg-input/30 h-9 w-full min-w-0 border bg-transparent px-3 py-1 text-base transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
         className,

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -14,7 +14,7 @@ function Progress({
     <ProgressPrimitive.Root
       data-slot="progress"
       className={cn(
-        "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
+        "bg-primary/20 relative h-2 w-full overflow-hidden",
         className,
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -31,7 +31,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='text-'])]:text-muted-foreground flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='text-'])]:text-muted-foreground flex w-fit items-center justify-between gap-2 border bg-transparent px-3 py-2 text-sm whitespace-nowrap transition-colors outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -56,7 +56,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-popover text-popover-foreground data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto border shadow-md",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,
@@ -90,7 +90,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-accent animate-pulse rounded-md", className)}
+      className={cn("bg-accent animate-pulse", className)}
       {...props}
     />
   );

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -57,7 +57,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-foreground h-10 px-2 text-left align-bottom font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}
@@ -70,7 +70,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "p-2 align-baseline whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -26,7 +26,7 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  "group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  "group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center border p-[3px] group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:border-0",
   {
     variants: {
       variant: {
@@ -64,7 +64,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "text-foreground/60 hover:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "text-foreground/60 hover:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-colors group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
         "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
         "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40 flex field-sizing-content min-h-16 w-full border bg-transparent px-3 py-2 text-base transition-colors outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className,
       )}
       {...props}

--- a/src/emails/magic-link-email.tsx
+++ b/src/emails/magic-link-email.tsx
@@ -52,7 +52,6 @@ const theme = {
   primaryDark: "#14285d",
   primaryForeground: "#f8f8f8",
   link: "#1b3478",
-  shadow: "0 12px 32px rgba(15, 23, 42, 0.08)",
 } as const;
 const styles = {
   body: {
@@ -76,7 +75,6 @@ const styles = {
     border: `1px solid ${theme.border}`,
     borderRadius: "0",
     overflow: "hidden",
-    boxShadow: theme.shadow,
   },
   header: {
     padding: "28px 32px 24px",
@@ -91,8 +89,6 @@ const styles = {
   },
   brand: {
     fontSize: "12px",
-    letterSpacing: "0.08em",
-    textTransform: "uppercase" as const,
     color: theme.primary,
     margin: "0 0 10px 0",
     fontFamily:
@@ -147,8 +143,6 @@ const styles = {
     fontWeight: "600",
     color: theme.foreground,
     margin: "0 0 10px 0",
-    textTransform: "uppercase" as const,
-    letterSpacing: "0.04em",
   },
   detailsLine: {
     fontSize: "14px",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,4 +1,5 @@
 {
+  "common_skip_to_content": "Skip to main content",
   "auth_oauth_login_description": "Choose a connected account to access your dashboard",
   "auth_oauth_signup_description": "Choose a connected account to create your account",
   "auth_sending_magic_link": "Sending magic link...",

--- a/src/messages/zh-Hans.json
+++ b/src/messages/zh-Hans.json
@@ -1,4 +1,5 @@
 {
+  "common_skip_to_content": "跳转到主要内容",
   "auth_oauth_login_description": "选择一个已关联的账号以访问控制台",
   "auth_oauth_signup_description": "选择一个已关联的账号以创建账户",
   "auth_sending_magic_link": "正在发送魔法链接...",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,6 +21,26 @@
     @apply bg-background text-foreground font-sans;
     font-family: var(--font-sans);
     letter-spacing: var(--tracking-normal);
+    text-rendering: optimizeLegibility;
+  }
+
+  ::selection {
+    @apply bg-primary text-primary-foreground;
+  }
+
+  :focus-visible {
+    scroll-margin: 1rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      scroll-behavior: auto !important;
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
   }
 
   .font-sans {

--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -49,17 +49,17 @@
 }
 
 .markdown-content blockquote {
-  @apply border-border text-muted-foreground bg-muted/30 mb-4 rounded-r border-l-4 py-2 pl-4 italic;
+  @apply border-primary text-muted-foreground bg-muted/30 mb-4 border-l-4 py-2 pl-4;
 }
 
 .markdown-content code {
-  @apply bg-muted rounded px-1.5 py-0.5 font-mono text-sm;
+  @apply bg-muted px-1.5 py-0.5 font-mono text-sm;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
 
 .markdown-content pre {
-  @apply bg-muted mb-4 overflow-x-auto rounded-lg p-6;
+  @apply bg-muted mb-4 overflow-x-auto border p-6;
 }
 
 .markdown-content pre code {
@@ -74,7 +74,7 @@
 }
 
 .markdown-content img {
-  @apply mb-4 h-auto max-w-full rounded-lg;
+  @apply mb-4 h-auto max-w-full border;
 }
 
 .markdown-content table {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,9 +1,5 @@
 :root {
-  /* 
-     Light Mode: "Modern Clean"
-     Crisp, professional, and airy.
-     Designed for readability and a premium SaaS feel.
-  */
+  /* Light: cool, high-contrast canvas with UllrAI indigo as the focal color. */
   --background: oklch(0.99 0.002 240);
   /* Almost pure white with a hint of cool gray for crispness */
   --foreground: oklch(0.15 0.02 240);
@@ -72,28 +68,19 @@
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
     "Courier New", monospace;
 
-  /* 
-     Radius: Modern, approachable, polished.
-     0.5rem (8px) is the industry standard for premium SaaS.
-  */
+  /* Square geometry is a defining part of the product language. */
   --radius: 0rem;
 
-  /* 
-     Shadows: Soft, diffused, multi-layered.
-     Creates depth without heaviness.
-  */
+  /* Flat by default. Elevated overlays use a small hard offset shadow. */
   --shadow-color: 240 5% 50%;
-  /* HSL-ish for shadow alpha composition */
-
-  --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-  --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --shadow-md:
-    0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-  --shadow-lg:
-    0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
-  --shadow-xl: 0 25px 50px -12px rgb(0 0 0 / 0.25);
-  --shadow-2xl: 0 25px 50px -12px rgb(0 0 0 / 0.25);
+  --shadow-2xs: none;
+  --shadow-xs: none;
+  --shadow-sm: none;
+  --shadow: 2px 2px 0 0 var(--border);
+  --shadow-md: 4px 4px 0 0 var(--border);
+  --shadow-lg: 6px 6px 0 0 var(--border);
+  --shadow-xl: 8px 8px 0 0 var(--border);
+  --shadow-2xl: 12px 12px 0 0 var(--border);
 
   --tracking-normal: 0em;
   /* Inter looks best with normal tracking */
@@ -101,11 +88,7 @@
 }
 
 .dark {
-  /* 
-     Dark Mode: "Midnight Pro"
-     Rich, deep indigo-slate background. 
-     Reduces eye strain while maintaining vibrancy.
-  */
+  /* Dark: deep indigo canvas with the same hierarchy as light mode. */
   --background: oklch(0.12 0.03 260);
   /* Deep Indigo/Slate */
   --foreground: oklch(0.98 0.01 240);
@@ -153,17 +136,15 @@
   --sidebar-border: oklch(0.2 0.04 260);
   --sidebar-ring: oklch(0.6 0.16 265);
 
-  /* Shadows adjustments for dark mode */
   --shadow-color: 0 0% 0%;
-  --shadow-xs: 0 1px 1px 0 rgb(0 0 0 / 0.5);
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.5);
-  --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.5), 0 2px 4px -2px rgb(0 0 0 / 0.5);
-  --shadow-md:
-    0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.5);
-  --shadow-lg:
-    0 20px 25px -5px rgb(0 0 0 / 0.5), 0 8px 10px -6px rgb(0 0 0 / 0.5);
-  --shadow-xl: 0 25px 50px -12px rgb(0 0 0 / 0.5);
-  --shadow-2xl: 0 25px 50px -12px rgb(0 0 0 / 0.5);
+  --shadow-2xs: none;
+  --shadow-xs: none;
+  --shadow-sm: none;
+  --shadow: 2px 2px 0 0 var(--border);
+  --shadow-md: 4px 4px 0 0 var(--border);
+  --shadow-lg: 6px 6px 0 0 var(--border);
+  --shadow-xl: 8px 8px 0 0 var(--border);
+  --shadow-2xl: 12px 12px 0 0 var(--border);
 }
 
 @theme inline {


### PR DESCRIPTION
## 概要

- 新增仓库级 `design.md`，参考 Vercel 的决策优先体系并适配 UllrAI 的实际产品、国际化与页面结构
- 保留现有靛蓝主色和直角硬朗风格，统一颜色、阴影、排版、容器、动效及可访问性规则
- 全面梳理营销页、认证、Dashboard、博客、定价与支付、上传、AI、邮件和基础 UI 组件
- 增加全局跳转主内容链接及中英文文案，移除装饰性背景、玻璃效果、柔和阴影和无意义动效

## 验证

- `pnpm prettier:check`
- `pnpm lint`
- `pnpm type-check`
- `pnpm test --runInBand`（158 suites / 1270 tests）
- `pnpm dead-code:check`
- `pnpm build`

## 限制

本地未配置符合安全约束的 `E2E_DATABASE_URL`，因此 `pnpm test:e2e` 在启动前停止，未连接或修改任何数据库。远端检查结果将作为合并门槛。